### PR TITLE
Adding a fix for Chromosome 0, makeing code more robust

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/AssemblyMapperAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AssemblyMapperAdaptor.pm
@@ -474,8 +474,10 @@ sub _seq_region_name_to_id {
   my $sr_name = shift;
   my $cs_id   = shift;
 
-  ($sr_name && $cs_id) || throw('seq_region_name and coord_system_id args ' .
-				'are required');
+  if(!defined($sr_name) or
+     !defined($cs_id)){
+      throw('seq_region_name and coord_system_id args are required');
+  }
 
   my $arr = $self->{'sr_name_cache'}->{"$sr_name:$cs_id"};
   if( $arr ) {


### PR DESCRIPTION
Believe it or not we have chromosome 0, the 'bag of bits' chromosome that causes problems for short-cut code like this.

The fix is pretty basic and has been tested to work via the VEP dumper.
