### PR TITLE
A warning more verbose, allow no alias, formatting

### DIFF
--- a/misc-scripts/xref_mapping/xref_config2sql.pl
+++ b/misc-scripts/xref_mapping/xref_config2sql.pl
@@ -36,9 +36,10 @@ use strict;
 use warnings;
 
 use Config::IniFiles;
-my $file = ( defined $ARGV[0] && -f $ARGV[0]) ? $ARGV[0] : 'xref_config.ini';
-warn $file;
-my $config =Config::IniFiles->new(-file =>$file);
+my $file = (defined $ARGV[0] && -f $ARGV[0]) ? $ARGV[0] : 'xref_config.ini';
+warn "using ", $file;
+
+my $config = Config::IniFiles->new(-file => $file);
 if(! defined $config) {
   foreach my $e (@Config::IniFiles::errors) {
     warn "errors found";
@@ -51,7 +52,7 @@ my %source_ids;
 
 # Do the species.
 
-print( '#' x 80, "\n" );
+print('#' x 80, "\n");
 print("# SPECIES\n");
 print("\n");
 
@@ -71,7 +72,7 @@ foreach my $section ( $config->GroupMembers('species') ) {
 
     printf( "VALUES (%d, %d, '%s', '%s');\n",
             $species_id, $taxonomy_id, $species_name,
-            $config->val( $section, 'aliases' ) );
+            $config->val( $section, 'aliases' ) || $species_name );
   }
 
   print("\n");


### PR DESCRIPTION
Other than some very minor formatting changes, the two changes here:
a) make a warning more verbose (I missed the meaning of the output)
b) allow the config file to have no alias value without causing an error.
