### PR TITLE
Restore read coverage support

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/StrainSliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/StrainSliceAdaptor.pm
@@ -196,8 +196,8 @@ sub fetch_by_name {
   # get all allele features for this slice and individual
   #my @afs = sort {$a->start() <=> $b->start()} @{$af_adaptor->fetch_all_by_Slice($slice, $ind)};
   
-  # get allele features
-  my $afs = $strain_slice->get_all_AlleleFeatures_Slice();
+  # get allele features with coverage info
+  my $afs = $strain_slice->get_all_AlleleFeatures_Slice(1);
   
   # check we got some data
   #warning("No strain genotype data available for slice ".$slice->name." and strain ".$ind->name) if ! defined $afs[0];


### PR DESCRIPTION
Restore read_coverage data support removed in 75. Also support the has_coverage field and the downstream effects on rendered sequence of secondary strains - strains with no explicit read coverage data are represented in lowercase where there is no genotype call available.
