### PR TITLE
added guard clause to ensure we get some sequence back for our feature

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SequenceAdaptor.pm
@@ -267,7 +267,7 @@ sub fetch_by_Slice_start_end_strand {
                                     $seq_slice->start, $seq_slice->length())};
 
      if(!defined $tmp_seq) {
-         throw('No sequence found for seq_region '.$seq_region_id.':'.$min);
+         throw('No sequence found for seq_region '.$seq_region_id.':'.$seq_slice->start);
      }
 
      #reverse compliment on negatively oriented slices


### PR DESCRIPTION
Change to catch features which don't actually lie within the seq_region, which are usually coming from erroneous database loads/projections
