### PR TITLE
Making the load of a profile.lsf file optional

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBasic.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBasic.pm
@@ -132,7 +132,10 @@ sub resubmit_exonerate {
   my $exe_file = $root_dir."/resub_".$job_id."_".$array_number;
   open(my $rh, ">", $exe_file) || die "Could not open file $exe_file";
   
-  print $rh ". /usr/local/lsf/conf/profile.lsf\n";
+  my $lsf_profile = '/usr/local/lsf/conf/profile.lsf';
+  if (-e $lsf_profile) {
+    print $rh ". $lsf_profile\n";
+  }
   print $rh $command."\n";
 
   close $rh;


### PR DESCRIPTION
In Ensembl Genomes we don't have a profile.lsf file, so only add it if the file exists.
