### PR TITLE
Added SQL functionality to handle duplicates for inserting

### DIFF
--- a/modules/t/dbEntries.t
+++ b/modules/t/dbEntries.t
@@ -151,15 +151,18 @@ my $tr = $gene->get_all_Transcripts()->[0];
 my $tl = $tr->translation();
 
 my $oxr_count = count_rows($db, 'object_xref');
+my $ixr_count = count_rows($db, 'identity_xref');
+
 $dbEntryAdaptor->store( $xref, $tr->dbID, "Transcript" );
 $oxr_count = count_rows($db, 'object_xref');
 $dbEntryAdaptor->store( $ident_xref, $tl->dbID, "Translation" );
 #intentional duplicates should be filtered out and not increase row count
+$ixr_count = count_rows($db, 'identity_xref');
 $dbEntryAdaptor->store( $ident_xref, $tl->dbID, "Translation" ); 
 $dbEntryAdaptor->store( $ident_xref, $tl->dbID, "Translation" );
 $dbEntryAdaptor->store( $ident_xref, $tl->dbID, "Translation" );
 $dbEntryAdaptor->store( $ident_xref, $tl->dbID, "Translation" );
-
+is($ixr_count, count_rows($db, 'identity_xref'), 'No increase in identity_xref rows');
 
 $oxr_count = count_rows($db, 'object_xref');
 $dbEntryAdaptor->store( $goref, $tl->dbID, "Translation" );


### PR DESCRIPTION
Added SQL functionality to handle duplicates for inserting into the object_xref table to return the duplicated object_xref_is rather than 0. This allows for extra annotation provided as associated_xrefs to get added to the current ensembl_id|ensembl_object_type|xref_id unique set.
