### PR TITLE
fix for _get_by_slice on feature-less slices

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
@@ -899,6 +899,7 @@ COORD_SYSTEM: foreach my $coord_system (@feature_coord_systems) {
      }
      $mapper = undef;
     } # End foreach
+    $self->{_bind_param_generic_fetch} = undef;
     return \@pan_coord_features;
 }
 #


### PR DESCRIPTION
This was revealed as a problem when running densityfeature code (from GenomeLoader, not from the hive) on genomes with slices without features - it looks as if bind parameters were left hanging around in the adaptor instance as they weren't ever used (and hence cleared). This is probably the simplest fix.
