### PR TITLE
changed attributes to use correct casing as per GFF spec

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
@@ -226,7 +226,8 @@ sub print_feature {
                     $value = 'transcript:' . $value;
                   }
                 }
-                $row .= uc($key)."=".uri_escape($value,'\t\n\r;=%&,');
+                $key = uc($key) if $key eq 'id';
+                $row .= $key."=".uri_escape($value,'\t\n\r;=%&,');
                 $row .= ';' if scalar(@ordered_keys) > 0 || scalar(keys %summary) > 0;
             }
         }

--- a/modules/t/gffSerialiser.t
+++ b/modules/t/gffSerialiser.t
@@ -121,8 +121,17 @@ OUT
     'ID=gene:ENSG00000131044;assembly_name=NCBI33;biotype=protein_coding;description=DJ310O13.1.2 (NOVEL PROTEIN SIMILAR DROSOPHILA PROTEIN CG7474%2C ISOFORM 2 ) (FRAGMENT). [Source:SPTREMBL%3BAcc:Q9BR18];external_name=C20orf125;logic_name=ensembl;version=1' 
   );
   $expected .= "\n";
-
   assert_gff3($gene, $expected, 'Gene with custom source serialises to GFF3 as expected. Source is wibble');
+  $expected = <<'OUT';
+##gff-version 3
+##sequence-region   20 30274334 30298904
+OUT
+  $expected .= join("\t", 
+  qw/20      ensembl region  30274334        30298904        .       +       ./,
+  'ID=transcript:ENST00000310998;Parent=gene:ENSG00000131044;assembly_name=NCBI33;biotype=protein_coding;external_name=C20orf125;logic_name=ensembl;version=1'
+  );
+  $expected .= "\n";
+  assert_gff3($gene->canonical_transcript(), $expected, 'Transcript with custom source serialises to GFF3 as expected. Source is wibble');
 }
 
 sub assert_gff3 {


### PR DESCRIPTION
A user reported that the casing of the attributes (ID, PARENT etc.) is not GFF3 compliant as per http://gmod.org/wiki/GFF3. Not sure what the intent was in the original code, but this is a fix that sorts it, with an extended test for Parent using a transcript (does not test all attributes though)
