### PR TITLE
Transcript->add_supporting_features(): fix cut-n-pasted throw() message.

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -454,8 +454,8 @@ sub add_supporting_features {
     
     if ((defined $self->slice() && defined $feature->slice())&&
       ( $self->slice()->name() ne $feature->slice()->name())){
-      throw("Supporting feat not in same coord system as exon\n" .
-            "exon is attached to [".$self->slice()->name()."]\n" .
+      throw("Supporting feat not in same coord system as transcript\n" .
+            "transcript is attached to [".$self->slice()->name()."]\n" .
             "feat is attached to [".$feature->slice()->name()."]");
     }
 


### PR DESCRIPTION
Just a wee fix to a throw message in Transcript's add_supporting_features method.
