### PR TITLE
Fix sqlite timestamps

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/Driver/SQLite.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/SQLite.pm
@@ -57,7 +57,7 @@ sub from_date_to_seconds {
 
 sub from_seconds_to_date {
     my ($self, $seconds) = @_;
-    return "DATETIME($seconds)";
+    return "DATETIME($seconds, 'unixepoch')";
 }
 
 sub insert_ignore_clause {

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -280,6 +280,9 @@ my $stable_id = 'ENSG00000171456';
 $gene->description($desc);
 $gene->stable_id($stable_id);
 
+$gene->created_date( time());
+$gene->modified_date(time());
+
 $multi->hide("core", "meta_coord", "gene", "transcript", "exon", "exon_transcript", "translation", "supporting_feature", "dna_align_feature", 'xref', 'object_xref', 'identity_xref');
 
 my $gene_ad = $db->get_GeneAdaptor();
@@ -299,6 +302,12 @@ ok($gene_out->stable_id eq $stable_id);
 
 #make sure the description was stored
 ok($gene_out->description eq $desc);
+
+debug("gene_out created_date   = ", $gene_out->created_date);
+debug("gene_out modified_date  = ", $gene_out->modified_date);
+
+is($gene_out->created_date,  $gene->created_date,  'created_date roundtrips');
+is($gene_out->modified_date, $gene->modified_date, 'modified_date roundtrips');
 
 ok(scalar(@{$gene_out->get_all_Exons()}) == 3);
 


### PR DESCRIPTION
Unix timestamps were being erroneously converted in the SQLite driver.

(The assumed default for integers passed to SQLite's DATETIME() function turns out to be Julian day number, who knew???)

If this looks okay, I'll backport to 78 and 77 (which we're still using).

Many thanks!