### PR TITLE
Updated column definition of genome_statistics.value from INT to BIGINT

### DIFF
--- a/sql/patch_79_80_d.sql
+++ b/sql/patch_79_80_d.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_79_80_d.sql
+#
+# Title: Update column definition for genome_statistics.value from INT to BIGINT, 
+#
+# Description:
+#   Column type from INT(10) to BIGINT(11) for genome_statistics.value
+#   So value range can be extended to large plants genomes
+
+ALTER TABLE genome_statistics MODIFY COLUMN value BIGINT(11) unsigned NOT NULL DEFAULT '0'; 
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_79_80_d.sql|genome_statistics_value_longer');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -221,7 +221,7 @@ CREATE TABLE genome_statistics(
 
   genome_statistics_id     INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   statistic                VARCHAR(128) NOT NULL,
-  value                    INT(10) UNSIGNED DEFAULT '0' NOT NULL,
+  value                    BIGINT(11) UNSIGNED DEFAULT '0' NOT NULL,
   species_id               INT UNSIGNED DEFAULT 1,
   attrib_type_id           INT(10) UNSIGNED DEFAULT NULL,
   timestamp                DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',


### PR DESCRIPTION
So we can cope with the size of some plants genomes, beyond max int value (ie 4294967295).