### PR TITLE
Delete from all alt-allele-related tables when deleting alt alleles.

### DIFF
--- a/misc-scripts/alt_alleles/alt_alleles.pl
+++ b/misc-scripts/alt_alleles/alt_alleles.pl
@@ -139,7 +139,8 @@ foreach my $group (@{$vega_groups}) {
 #
 print STDERR "\n\nDeleting all alt_alleles...\n\n";
 $core_dba->dbc->do("delete from alt_allele");
-
+$core_dba->dbc->do("delete from alt_allele_attrib");
+$core_dba->dbc->do("delete from alt_allele_group");
 
 #
 # Store alt_alleles.


### PR DESCRIPTION
The delete commands hadn't been updated after adding the new alt_allele tables "alt_allele_attrib" and "alt_allele_group".