### PR TITLE
More flexible attribute output for GFF dumping

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
@@ -150,7 +150,7 @@ sub run_coordinatemapping {
   my $analysis_sql = qq(
     SELECT  analysis_id
     FROM    analysis
-    WHERE   logic_name = 'XrefCoordinateMapping'
+    WHERE   logic_name = 'xrefcoodinatemapping'
     AND     parameters = ?
   );
 
@@ -163,7 +163,7 @@ sub run_coordinatemapping {
   if ( !defined($analysis_id) ) {
     $analysis_id =
       $core_dbh->selectall_arrayref( "SELECT analysis_id FROM analysis "
-               . "WHERE logic_name = 'XrefCoordinateMapping'" )->[0][0];
+               . "WHERE logic_name = 'xrefcoodinatemapping'" )->[0][0];
 
     if ( defined($analysis_id) && $do_upload ) {
       log_progress(   "Will update 'analysis' table "
@@ -183,7 +183,7 @@ sub run_coordinatemapping {
 
     } else {
       log_progress("Can not find analysis ID for this analysis:\n");
-      log_progress("  logic_name = 'XrefCoordinateMapping'\n");
+      log_progress("  logic_name = 'xrefcoodinatemapping'\n");
       log_progress( "  parameters = '%s'\n", $analysis_params );
 
       if ($do_upload) {
@@ -205,7 +205,7 @@ sub run_coordinatemapping {
         my $sth = $core_dbh->prepare($sql);
 
         $sth->bind_param( 1, ++$analysis_id,          SQL_INTEGER );
-        $sth->bind_param( 2, 'XrefCoordinateMapping', SQL_VARCHAR );
+        $sth->bind_param( 2, 'xrefcoodinatemapping', SQL_VARCHAR );
         $sth->bind_param( 3, 'xref_mapper.pl',        SQL_VARCHAR );
         $sth->bind_param( 4, $analysis_params,        SQL_VARCHAR );
         $sth->bind_param( 5, 'CoordinateMapper.pm',   SQL_VARCHAR );

--- a/misc-scripts/xref_mapping/XrefMapper/VBCoordinateMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/VBCoordinateMapper.pm
@@ -113,7 +113,7 @@ sub run_coordinatemapping {
   my $analysis_sql = qq(
     SELECT  analysis_id
     FROM    analysis
-    WHERE   logic_name = 'XrefCoordinateMapping'
+    WHERE   logic_name = 'xrefcoodinatemapping'
     AND     parameters = ?
   );
 
@@ -124,7 +124,7 @@ sub run_coordinatemapping {
   if ( !defined($analysis_id) ) {
     $analysis_id =
       $core_dbh->selectall_arrayref( "SELECT analysis_id FROM analysis "
-               . "WHERE logic_name = 'XrefCoordinateMapping'" )->[0][0];
+               . "WHERE logic_name = 'xrefcoodinatemapping'" )->[0][0];
 
     if ( defined($analysis_id) && $do_upload ) {
       log_progress(   "Will update 'analysis' table "
@@ -144,7 +144,7 @@ sub run_coordinatemapping {
 
     } else {
       log_progress("Can not find analysis ID for this analysis:\n");
-      log_progress("  logic_name = 'XrefCoordinateMapping'\n");
+      log_progress("  logic_name = 'xrefcoodinatemapping'\n");
       log_progress( "  parameters = '%s'\n", $analysis_params );
 
       if ($do_upload) {
@@ -162,7 +162,7 @@ sub run_coordinatemapping {
           . 'VALUES(?, now(), ?, \N, \N, \N, ?, \N, \N, ?, ?, \N, \N, \N)';
         my $sth = $core_dbh->prepare($sql);
 
-        $sth->execute( ++$analysis_id,   'XrefCoordinateMapping',
+        $sth->execute( ++$analysis_id,   'xrefcoodinatemapping',
                        'xref_mapper.pl', $analysis_params,
                        'CoordinateMapper.pm' );
       }

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -395,10 +395,12 @@ sub create_xrefs {
         if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
         my $gene_name = undef;
 
-        if ($gn =~ / Name=([A-Za-z0-9_\-\.]+)/s) { #/s for multi-line entries ; is the delimiter
+        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s]+)/s) { #/s for multi-line entries ; is the delimiter
 # Example line 
 # GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
-          $depe{LABEL} = $1; # leave name as is, upper/lower case is relevant in gene names
+          my $name = $1;
+          $name =~ s/\s+$//g; # Remove white spaces that are left over at the end if there was an evidence code
+          $depe{LABEL} = $name; # leave name as is, upper/lower case is relevant in gene names
           $depe{ACCESSION} = $self->get_name($xref->{ACCESSION},$depe{LABEL});
           $gene_name = $depe{ACCESSION};
 

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -796,7 +796,7 @@ priority        = 1
 prio_descr      =
 parser          = CCDSParser
 release_uri     =
-data_uri        = script:host=>ens-livemirror,dbname=>ccds_mouse_77,tran_name=>ENSMUST,
+data_uri        = script:host=>ens-livemirror,dbname=>ccds_mouse_80,tran_name=>ENSMUST,
 
 [source Celera_Pep::anopheles_gambiae]
 # Used by anopheles_gambiae
@@ -1004,7 +1004,7 @@ prio_descr      = main
 parser          = GOSlimParser
 dependent_on    = GO
 release_uri     =
-data_uri        = script:host=>ens-staging1,dbname=>ensembl_ontology_79,
+data_uri        = script:host=>ens-staging1,dbname=>ensembl_ontology_80,
 
 [source goslim_goa::EG]
 # Used by Ensembl Genomes
@@ -2283,7 +2283,7 @@ priority        = 2
 prio_descr      = ccds
 parser          = RefSeq_CCDSParser
 release_uri     =
-data_uri        = script:host=>ens-livemirror,dbname=>ccds_mouse_77,
+data_uri        = script:host=>ens-livemirror,dbname=>ccds_mouse_80,
 
 
 [source RefSeq_dna::pan_troglodytes]

--- a/misc-scripts/xref_mapping/xref_parser.pl
+++ b/misc-scripts/xref_mapping/xref_parser.pl
@@ -79,6 +79,16 @@ if ( !$user || !$host || !$dbname ) {
     exit(1);
 }
 
+if ( $host =~ /staging/ || $host =~ /livemirror/ ){
+  print STDERR "$host was specified as host name. This is a production server and should not be used to create the xref database\n";
+  exit(1);
+}
+
+if ($dbname =~ /_core_/) {
+  print STDERR "$dbname was specified for the database name. This should be the name of the xref database, not the core database\n";
+  exit(1);
+}
+
 
 print "host os $host\n";
 

--- a/modules/Bio/EnsEMBL/DBSQL/GenomeContainer.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GenomeContainer.pm
@@ -709,7 +709,7 @@ sub is_empty {
   my $self = shift;
   my $db = $self->db;
   my $species_id = $self->db->species_id();
-  my $is_empty = 0;
+  my $is_empty = 1;
   my $count_sql = q{
     SELECT count(*) FROM genome_statistics
   };
@@ -717,7 +717,7 @@ sub is_empty {
   my $sth = $self->prepare($count_sql);
   $sth->execute();
   if ($sth->fetchrow()) {
-    $is_empty = 1;
+    $is_empty = 0;
   }
   $sth->finish();
   return $is_empty;

--- a/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
@@ -227,7 +227,11 @@ sub print_feature {
                   }
                 }
                 $key = uc($key) if $key eq 'id';
-                $row .= $key."=".uri_escape($value,'\t\n\r;=%&,');
+                if (ref $value eq "ARRAY" && scalar(@{$value}) > 0) {
+                  $row .= $key."=".join (',',map { uri_escape($_,'\t\n\r;=%&,') } grep { defined $_ } @{$value});
+                } else {
+                  $row .= $key."=".uri_escape($value,'\t\n\r;=%&,');
+                }
                 $row .= ';' if scalar(@ordered_keys) > 0 || scalar(keys %summary) > 0;
             }
         }

--- a/modules/t/genomeContainer.t
+++ b/modules/t/genomeContainer.t
@@ -187,8 +187,8 @@ is(0, $empty_genome->is_high_coverage, "Empty db is not high coverage");
 # Test if there is data
 #
 
-is(1, $genome->is_empty, "Human core database has genome data");
-is(0, $empty_genome->is_empty, "Empty database has no genome data");
+is(0, $genome->is_empty, "Human core database has genome data");
+is(1, $empty_genome->is_empty, "Empty database has no genome data");
 
 #
 # Test polyploid genome support

--- a/modules/t/gffSerialiser.t
+++ b/modules/t/gffSerialiser.t
@@ -134,6 +134,29 @@ OUT
   assert_gff3($gene->canonical_transcript(), $expected, 'Transcript with custom source serialises to GFF3 as expected. Source is wibble');
 }
 
+{
+  my $gene = $ga->fetch_by_stable_id($id);
+  
+  my $summary = $gene->summary_as_hash;
+  $$summary{'Dbxref'} = ['bibble', 'fibble'];
+  $$summary{'Ontology_term'} = 'GO:0001612';
+  local undef &{Bio::EnsEMBL::Gene::summary_as_hash};
+  local *{Bio::EnsEMBL::Gene::summary_as_hash} = sub {return $summary};
+  
+  my $expected = <<'OUT';
+##gff-version 3
+##sequence-region   20 30274334 30300924
+OUT
+  #Have to do this outside of the HERETO thanks to tabs
+  $expected .= join("\t", 
+    qw/20  ensembl region 30274334  30300924  . + ./,
+    'ID=gene:ENSG00000131044;Dbxref=bibble,fibble;Ontology_term=GO:0001612;assembly_name=NCBI33;biotype=protein_coding;description=DJ310O13.1.2 (NOVEL PROTEIN SIMILAR DROSOPHILA PROTEIN CG7474%2C ISOFORM 2 ) (FRAGMENT). [Source:SPTREMBL%3BAcc:Q9BR18];external_name=C20orf125;logic_name=ensembl;version=1' 
+  );
+  $expected .= "\n";
+
+  assert_gff3($gene, $expected, 'Gene with array- and string-valued attributes as expected.');
+}
+
 sub assert_gff3 {
   my ($feature, $expected, $msg) = @_;
   my $ota = Test::SO->new();

--- a/modules/t/iterator.t
+++ b/modules/t/iterator.t
@@ -160,7 +160,7 @@ my $ga        = $db->get_GeneAdaptor;
 
 
 #Do this via direct SQL as unlikely to change
-my $sql = 'SELECT sr.name, g.seq_region_start from gene g, seq_region sr where g.seq_region_id = sr.seq_region_id order by g.seq_region_start limit 1';
+my $sql = 'SELECT sr.name, g.seq_region_start from gene g, seq_region sr where g.seq_region_id = sr.seq_region_id and sr.name = "MT_NC_001807"';
 my ($sr_name, $sr_start) = @{$db->dbc->db_handle->selectrow_arrayref($sql)};
 my $slice     = $sa->fetch_by_region('chromosome', $sr_name, 1, ($sr_start + 1000000));
 my @genes     = @{$ga->fetch_all_by_Slice($slice)};

--- a/modules/t/schemaPatches.t
+++ b/modules/t/schemaPatches.t
@@ -166,10 +166,15 @@ sub compare_after_patches {
   # get target-specific patches in source
   $dbc->do("use $source_schema");
   my $source_patches = $sql_helper->execute_simple(-SQL => "select meta_value from meta where meta_key='patch' and meta_value like 'patch_${last_release}_${current_release}_%'");
-  
+
   my %source_patches;
+  my %target_patches;
   map { $source_patches{$_}++ } @{$source_patches};
+  map { $target_patches{$_}++ } @{$target_patches};
   map { ok(exists $source_patches{$_}, "$_ in patched database") } @{$target_patches};
+  map { ok(exists $target_patches{$_}, "$_ in original database") } @{$source_patches};
+
+
 
 }
 


### PR DESCRIPTION
Allow 'special' attributes (e.g. Dbxref, Ontology_term) to be specified as a list and written as a single comma-separated value. (This was already possible for generic attributes with uncapitalized first letters.)