### PR TITLE
When an executable can't be found in the default location, the script at...

### DIFF
--- a/misc-scripts/CopyDBoverServer.pl
+++ b/misc-scripts/CopyDBoverServer.pl
@@ -311,7 +311,7 @@ foreach my $key ( keys(%executables) ) {
   my $rc     = $? >> 8;
 
   if ( $rc != 0 ) {
-    my $possible_location = `locate -l 1 $key 2>&1`;  # Ugly but simple.
+    my $possible_location = `find -name $key 2>&1`; 
     my $loc_rc            = $? >> 8;
 
     if ( $loc_rc == 0 ) {


### PR DESCRIPTION
...tempt to find it using the UNIX locate command which return a wrong path location. I've updated the locate command to the UNIX find command. This now return the expected executable location (if specified in the PATH variable)