### PR TITLE
Update xref_config.ini

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -7147,8 +7147,8 @@ source          = misc_EG::EG
 source 		= ArrayExpress::EG
 
 [species plasmodium_chabaudi]
-taxonomy_id     = 5825
-aliases         = plasmodium_chabaudi,
+taxonomy_id     = 31271
+aliases         = plasmodium_chabaudi
 source          = EntrezGene::MULTI
 source          = GO::MULTI
 source          = goslim_goa::EG


### PR DESCRIPTION
Corrected Plasmodium chabaudi tax_id to match the one used by UniProt for annotating the P. chabaudi genome.