### PR TITLE
Switchable adaptor support

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
@@ -70,10 +70,12 @@ use Bio::EnsEMBL::DBSQL::BaseFeatureAdaptor;
 use Bio::EnsEMBL::Utils::SeqRegionCache;
 use Bio::EnsEMBL::Utils::Exception qw(throw warning deprecate);
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
-use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Utils::Scalar qw(check_ref scope_guard);
 use Bio::EnsEMBL::Utils::ConfigRegistry;
 
-my $registry = "Bio::EnsEMBL::Registry";
+
+my $REGISTRY = "Bio::EnsEMBL::Registry";
+require Bio::EnsEMBL::Registry;
 
 =head2 new
 
@@ -162,7 +164,6 @@ sub new {
   if ( defined($species) ) { $self->species($species); } 
   if ( defined($group) )   { $self->group($group) }
 
- 
   $self = Bio::EnsEMBL::Utils::ConfigRegistry::gen_load($self);
 
   if (defined $species_id) {
@@ -197,7 +198,7 @@ sub new {
 
 sub clear_caches {
   my ($self) = @_;
-  my $adaptors = Bio::EnsEMBL::Registry->get_all_adaptors(
+  my $adaptors = $REGISTRY->get_all_adaptors(
     $self->species(), $self->group());
   foreach my $adaptor (@{$adaptors}) {
     if($adaptor->can('clear_cache')) {
@@ -287,8 +288,6 @@ sub dbc{
   return $self->{_dbc};
 }
 
-
-
 =head2 add_db_adaptor
 
   Arg [1]    : string $name
@@ -313,7 +312,7 @@ sub add_db_adaptor {
     throw('adaptor and name arguments are required');
   }
 
-  Bio::EnsEMBL::Registry->add_db($self, $name, $adaptor);
+  $REGISTRY->add_db($self, $name, $adaptor);
 
 }
 
@@ -335,8 +334,7 @@ sub add_db_adaptor {
 
 sub remove_db_adaptor {
   my ($self, $name) = @_;
-
-  return Bio::EnsEMBL::Registry->remove_db($self, $name);
+  return $REGISTRY->remove_db($self, $name);
 }
 
 
@@ -358,7 +356,7 @@ sub remove_db_adaptor {
 
 sub get_all_db_adaptors {
   my ($self) = @_;
-  return Bio::EnsEMBL::Registry->get_all_db_adaptors($self);
+  return $REGISTRY->get_all_db_adaptors($self);
 }
 
 
@@ -382,7 +380,7 @@ sub get_all_db_adaptors {
 sub get_db_adaptor {
   my ($self, $name) = @_;
 
-  return Bio::EnsEMBL::Registry->get_db($self, $name);
+  return $REGISTRY->get_db($self, $name);
 }
 
 =head2 get_available_adaptors
@@ -397,7 +395,6 @@ sub get_db_adaptor {
 =cut 
 
 sub get_available_adaptors {
-
   my $adaptors = {
     # Firstly those that just have an adaptor named after there object
     # in the main DBSQL directory.
@@ -648,8 +645,7 @@ sub add_ExternalFeatureFactory{
 
 sub get_adaptor {
   my ($self, $canonical_name, @other_args) = @_;
-
-  return $registry->get_adaptor($self->species(),$self->group(),$canonical_name);
+  return $REGISTRY->get_adaptor($self->species(),$self->group(),$canonical_name);
 }
 
 
@@ -673,9 +669,7 @@ sub get_adaptor {
 
 sub set_adaptor {
   my ($self, $canonical_name, $module) = @_;
-
-  $registry->add_adaptor($self->species(),$self->group(),$canonical_name,$module);
-
+  $REGISTRY->add_adaptor($self->species(),$self->group(),$canonical_name,$module);
   return $module;
 }
 
@@ -788,30 +782,10 @@ sub species {
 
 sub all_species {
   my ($self) = @_;
-
   if ( !$self->is_multispecies() ) { return [ $self->species() ] }
-
-  if ( exists( $self->{'_all_species'} ) ) {
-    return $self->{'_all_species'};
-  }
-
-  my $statement =
-      "SELECT meta_value "
-    . "FROM meta "
-    . "WHERE meta_key = 'species.db_name'";
-
-  my $sth = $self->dbc()->db_handle()->prepare($statement);
-
-  $sth->execute();
-
-  my $species;
-  $sth->bind_columns( \$species );
-
-  my @all_species;
-  while ( $sth->fetch() ) { push( @all_species, $species ) }
-
-  $self->{'_all_species'} = \@all_species;
-
+  return $self->{'_all_species'} if exists $self->{_all_species};
+  my $sql = "SELECT meta_value FROM meta WHERE meta_key = 'species.db_name'";
+  $self->{_all_species} = $self->dbc->sql_helper()->execute_simple(-SQL => $sql);
   return $self->{'_all_species'};
 } ## end sub all_species
 
@@ -989,11 +963,11 @@ sub dnadb {
 
   if(@_) {
     my $arg = shift;
-    $registry->add_DNAAdaptor($self->species(),$self->group(),$arg->species(),$arg->group());
+    $REGISTRY->add_DNAAdaptor($self->species(),$self->group(),$arg->species(),$arg->group());
   }
 
 #  return $self->{'dnadb'} || $self;
-  return $registry->get_DNAAdaptor($self->species(),$self->group()) || $self;
+  return $REGISTRY->get_DNAAdaptor($self->species(),$self->group()) || $self;
 }
 
 
@@ -1011,8 +985,7 @@ sub AUTOLOAD {
     throw( sprintf( "Could not work out type for %s\n", $AUTOLOAD ) );
   }
   
-  my $ret = $registry->get_adaptor( $self->species(), $self->group(), $type );
-
+  my $ret = $REGISTRY->get_adaptor( $self->species(), $self->group(), $type );
   return $ret if $ret;
   
   warning( sprintf(
@@ -1051,6 +1024,88 @@ sub to_hash {
   return $hash;
 }
 
+#########################
+# Switchable adaptor methods
+#########################
+
+=head2 switch_adaptor
+
+  Arg [1]     : String name of the adaptor type to switch out
+  Arg [2]     : Reference The switchable adaptor implementation
+  Arg [3]     : (optional) CodeRef Callback which provides automatic switchable adaptor cleanup 
+                once the method has finished
+  Arg [4]     : (optional) Boolean override any existing switchable adaptor
+  Example     : $dba->switch_adaptor("seqeunce", $my_replacement_sequence_adaptor);
+                $dba->switch_adaptor("seqeunce", $my_other_replacement_sequence_adaptor, 1);
+                $dba->switch_adaptor("seqeunce", $my_replacement_sequence_adaptor, sub {
+                  #Make calls as normal without having to do manual cleanup
+                });
+  Returntype  : None
+  Description : Provides a wrapper around the Registry add_switchable_adaptor() method
+                defaulting both species and group to the current DBAdaptor. Callbacks are
+                also available providing automatic resource cleanup.
+
+                The method also remembers the last switch you did. It will not remember
+                multiple switches though.
+  Exceptions  : Thrown if no switchable adaptor instance was given
+
+=cut
+
+sub switch_adaptor {
+  my ($self, $adaptor_name, $instance, $callback, $force) = @_;
+  my ($species, $group) = ($self->species(), $self->group());
+  $REGISTRY->add_switchable_adaptor($species, $group, $adaptor_name, $instance, $force);
+  $self->{_last_switchable_adaptor} = $adaptor_name;
+  if(check_ref($callback, 'CODE')) {
+    #Scope guard will reset the adaptor once it falls out of scope. They
+    #are implemented as callback DESTROYS so are neigh on impossible
+    #to stop executing
+    my $guard = scope_guard(sub { $REGISTRY->remove_switchable_adaptor($species, $group, $adaptor_name); } );
+    $callback->();
+  }
+  return;
+}
+
+=head2 has_switched_adaptor
+
+  Arg [1]     : String name of the adaptor type to switch back in
+  Example     : $dba->has_switchable_adaptor("seqeunce"); #explicit switching back
+  Returntype  : Boolean indicating if the given adaptor is being activly switched
+  Description : Provides a wrapper around the Registry has_switchable_adaptor() method
+                defaulting both species and group to the current DBAdaptor. This will
+                inform if the specified adaptor is being switched out
+  Exceptions  : None
+
+=cut
+
+sub has_switched_adaptor {
+  my ($self, $adaptor_name) = @_;
+  return $REGISTRY->has_switchable_adaptor($self->species, $self->group, $adaptor_name);
+}
+
+=head2 revert_adaptor
+
+  Arg [1]     : (optional) String name of the adaptor type to switch back in
+  Example     : $dba->revert_adaptor(); #implicit switching back whatever was the last switch_adaptor() call
+                $dba->revert_adaptor("seqeunce"); #explicit switching back
+  Returntype  : The removed adaptor
+  Description : Provides a wrapper around the Registry remove_switchable_adaptor() method
+                defaulting both species and group to the current DBAdaptor. This will remove
+                a switchable adaptor. You can also remove the last adaptor you switched
+                in without having to specify any parameter.
+  Exceptions  : Thrown if no switchable adaptor name was given or could be found in the internal
+                last adaptor variable
+
+=cut
+
+sub revert_adaptor {
+  my ($self, $adaptor_name) = @_;
+  $adaptor_name ||= $self->{_last_switchable_adaptor};
+  throw "Not given an adaptor name to remove and cannot find the name of the last switched adaptor" if ! $adaptor_name;
+  my $deleted_adaptor = $REGISTRY->remove_switchable_adaptor($self->species, $self->group, $adaptor_name);
+  delete $self->{last_switch};
+  return $deleted_adaptor;
+}
 
 #########################
 # sub DEPRECATED METHODS

--- a/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
@@ -1035,9 +1035,9 @@ sub to_hash {
   Arg [3]     : (optional) CodeRef Callback which provides automatic switchable adaptor cleanup 
                 once the method has finished
   Arg [4]     : (optional) Boolean override any existing switchable adaptor
-  Example     : $dba->switch_adaptor("seqeunce", $my_replacement_sequence_adaptor);
-                $dba->switch_adaptor("seqeunce", $my_other_replacement_sequence_adaptor, 1);
-                $dba->switch_adaptor("seqeunce", $my_replacement_sequence_adaptor, sub {
+  Example     : $dba->switch_adaptor("sequence", $my_replacement_sequence_adaptor);
+                $dba->switch_adaptor("sequence", $my_other_replacement_sequence_adaptor, 1);
+                $dba->switch_adaptor("sequence", $my_replacement_sequence_adaptor, sub {
                   #Make calls as normal without having to do manual cleanup
                 });
   Returntype  : None
@@ -1069,7 +1069,7 @@ sub switch_adaptor {
 =head2 has_switched_adaptor
 
   Arg [1]     : String name of the adaptor type to switch back in
-  Example     : $dba->has_switchable_adaptor("seqeunce"); #explicit switching back
+  Example     : $dba->has_switchable_adaptor("sequence"); #explicit switching back
   Returntype  : Boolean indicating if the given adaptor is being activly switched
   Description : Provides a wrapper around the Registry has_switchable_adaptor() method
                 defaulting both species and group to the current DBAdaptor. This will
@@ -1087,7 +1087,7 @@ sub has_switched_adaptor {
 
   Arg [1]     : (optional) String name of the adaptor type to switch back in
   Example     : $dba->revert_adaptor(); #implicit switching back whatever was the last switch_adaptor() call
-                $dba->revert_adaptor("seqeunce"); #explicit switching back
+                $dba->revert_adaptor("sequence"); #explicit switching back
   Returntype  : The removed adaptor
   Description : Provides a wrapper around the Registry remove_switchable_adaptor() method
                 defaulting both species and group to the current DBAdaptor. This will remove

--- a/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
@@ -1032,8 +1032,9 @@ sub to_hash {
 
   Arg [1]     : String name of the adaptor type to switch out
   Arg [2]     : Reference The switchable adaptor implementation
-  Arg [3]     : (optional) CodeRef Callback which provides automatic switchable adaptor cleanup 
-                once the method has finished
+  Arg [3]     : (optional) CodeRef Provide a subroutine reference as a callback. The
+                adaptor will be switched before your codeblock is executed and 
+                the adaptor switched back to the original once your code has finished running
   Arg [4]     : (optional) Boolean override any existing switchable adaptor
   Example     : $dba->switch_adaptor("sequence", $my_replacement_sequence_adaptor);
                 $dba->switch_adaptor("sequence", $my_other_replacement_sequence_adaptor, 1);

--- a/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
@@ -223,7 +223,7 @@ sub clear_caches {
 
 sub find_and_add_aliases {
   my ($self) = @_;
-  $registry->find_and_add_aliases(-ADAPTOR => $self);
+  $REGISTRY->find_and_add_aliases(-ADAPTOR => $self);
   return;
 }
 

--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -143,6 +143,8 @@ use Bio::EnsEMBL::Utils::URI qw/parse_uri/;
 
 use DBI qw(:sql_types);
 
+use Scalar::Util qw/blessed/;
+
 use vars qw(%registry_register);
 
 # This is a map from group names to Ensembl DB adaptors.  Used by
@@ -918,6 +920,8 @@ sub add_adaptor {
   my ( $class, $species, $group, $type, $adap, $reset ) = @_;
 
   $species = $class->get_alias($species);
+  my $lc_group = lc($group);
+  my $lc_type = lc($type);
 
   # Since the adaptors are not stored initially, only their class paths
   # when the adaptors are obtained, we need to store these instead.  It
@@ -927,52 +931,151 @@ sub add_adaptor {
 
   if ( defined($reset) )
   {    # JUST RESET THE HASH VALUE NO MORE PROCESSING NEEDED
-    $registry_register{_SPECIES}{$species}{ lc($group) }{ lc($type) } =
-      $adap;
+    $registry_register{_SPECIES}{$species}{ $lc_group }{ $lc_type } = $adap;
     return;
   }
 
   if (
     defined(
-      $registry_register{_SPECIES}{$species}{ lc($group) }{ lc($type) }
+      $registry_register{_SPECIES}{$species}{ $lc_group }{ $lc_type }
     ) )
   {
   # print STDERR (
   #      "Overwriting Adaptor in Registry for $species $group $type\n");
-    $registry_register{_SPECIES}{$species}{ lc($group) }{ lc($type) } =
-      $adap;
+    $registry_register{_SPECIES}{$species}{ $lc_group }{ $lc_type } = $adap;
     return;
   }
-  $registry_register{_SPECIES}{$species}{ lc($group) }{ lc($type) } =
-    $adap;
+  $registry_register{_SPECIES}{$species}{ $lc_group }{ $lc_type } = $adap;
 
   if ( !defined( $registry_register{_SPECIES}{$species}{'list'} ) ) {
     $registry_register{_SPECIES}{$species}{'list'} = [$type];
-  } else {
+  } 
+  else {
     push( @{ $registry_register{_SPECIES}{$species}{'list'} }, $type );
   }
 
-  if ( !defined( $registry_register{_TYPE}{ lc($type) }{$species} ) ) {
-    $registry_register{_TYPE}{ lc($type) }{$species} = [$adap];
-  } else {
-    push( @{ $registry_register{_TYPE}{ lc($type) }{$species} },
-      $adap );
+  if ( !defined( $registry_register{_TYPE}{ $lc_type }{$species} ) ) {
+    $registry_register{_TYPE}{ $lc_type }{$species} = [$adap];
+  } 
+  else {
+    push( @{ $registry_register{_TYPE}{ $lc_type }{$species} }, $adap );
   }
   return;
 } ## end sub add_adaptor
 
 
-=head2 get_adaptor
+=head2 add_switchable_adaptor
 
-  Arg [1]    : name of the species to add the adaptor to in the registry.
-  Arg [2]    : name of the group to add the adaptor to in the registry.
-  Arg [3]    : name of the type to add the adaptor to in the registry.
-  Example    : $adap = Bio::EnsEMBL::Registry->get_adaptor("Human", "core", "Gene");
-  Returntype : adaptor
+  Arg [1]    : String name of the species to add its switchable adaptor into the registry
+  Arg [2]    : String name of the group to add its switchable adaptor into the registry
+  Arg [3]    : String name of the type to add its switchable adaptor into the registry
+  Arg [4]    : Reference switchable adaptor to insert
+  Arg [5]    : Boolean override any existing switchable adaptor
+  Example    : Bio::EnsEMBL::Registry->add_switchable_adaptor("Human", "core", "Gene", $my_other_source);
+  Returntype : None
+  Exceptions : Thrown if a valid internal name cannot be found for the given 
+               name. If thrown check your API and DB version. Also thrown if
+               no type, group or switchable adaptor instance was given
+
+=cut
+
+sub add_switchable_adaptor {
+  my ($class, $species, $group, $adaptor_type, $instance, $override) = @_;
+  
+  my $ispecies = $class->get_alias($species);
+  throw "Cannot decode given species ${species} to an internal registry name" if ! $species;
+  throw "No group given" if ! $group;
+  throw "No adaptor type given" if ! $adaptor_type;
+  throw "No switchable adaptor given" if ! $instance;
+  throw "Switchable adaptor was not a blessed reference" if ! blessed($instance);
+
+  $group = lc($group);
+  $adaptor_type = lc($adaptor_type);
+  if($override) {
+    $registry_register{_SWITCHABLE}{$species}{$group}{$adaptor_type} = $instance;
+    return;
+  }
+
+  if(exists $registry_register{_SWITCHABLE}{$species}{$group}{$adaptor_type}) {
+    my $existing_ref = ref($registry_register{_SWITCHABLE}{$species}{$group}{$adaptor_type});
+    throw "Cannot switch adaptors for ${species}, ${group} and ${adaptor_type} because one is already set ($existing_ref). Use the override flag or revert_switchable_adaptor";
+  }
+
+  $registry_register{_SWITCHABLE}{$species}{$group}{$adaptor_type} = $instance;
+  return;
+}
+
+=head2 has_switchable_adaptor
+
+  Arg [1]    : String name of the species to add its switchable adaptor into the registry
+  Arg [2]    : String name of the group to add its switchable adaptor into the registry
+  Arg [3]    : String name of the type to add its switchable adaptor into the registry
+  Example    : Bio::EnsEMBL::Registry->has_switchable_adaptor("Human", "core", "Gene");
+  Returntype : Boolean indicating if a switchable adaptor is available for your submitted combination
+  Exceptions : Thrown if a valid internal name cannot be found for the given 
+               name. If thrown check your API and DB version. Also thrown if
+               no type, group or switchable adaptor instance was given
+
+=cut
+
+sub has_switchable_adaptor {
+  my ($class, $species, $group, $adaptor_type) = @_;
+  
+  my $ispecies = $class->get_alias($species);
+  throw "Cannot decode given species ${species} to an internal registry name" if ! $species;
+  throw "No group given" if ! $group;
+  throw "No adaptor type given" if ! $adaptor_type;
+
+  $group = lc($group);
+  $adaptor_type = lc($adaptor_type);
+  return (defined $registry_register{_SWITCHABLE}{$species}{$group}{$adaptor_type}) ? 1 : 0;
+}
+
+=head2 remove_switchable_adaptor
+
+  Arg [1]    : name of the species to remove its switchable adaptor from the registry
+  Arg [2]    : name of the group to remove its switchable adaptor from the registry
+  Arg [3]    : name of the type to remove its switchable adaptor from the registry
+  Example    : $adap = Bio::EnsEMBL::Registry->remove_switchable_adaptor("Human", "core", "Gene");
+  Returntype : The removed adaptor if one was removed. Otherwise undef
   Exceptions : Thrown if a valid internal name cannot be found for the given 
                name. If thrown check your API and DB version. Also thrown if
                no type or group was given
-  Status     : Stable
+
+=cut
+
+sub remove_switchable_adaptor {
+  my ($class, $species, $group, $adaptor_type) = @_;
+  my $ispecies = $class->get_alias($species);
+  throw "Cannot decode given species ${species} to an internal registry name" if ! $species;
+  throw "No group given" if ! $group;
+  throw "No adaptor type given" if ! $adaptor_type;
+
+  $group = lc($group);
+  $adaptor_type = lc($adaptor_type);
+  if(defined $registry_register{_SWITCHABLE}{$ispecies}{$group}{$adaptor_type}) {
+    my $adaptor = $registry_register{_SWITCHABLE}{$ispecies}{$group}{$adaptor_type};
+    delete $registry_register{_SWITCHABLE}{$ispecies}{$group}{$adaptor_type};
+    return $adaptor;
+  }
+  return;
+}
+
+=head2 get_adaptor
+
+  Arg [1]     : name of the species to add the adaptor to in the registry.
+  Arg [2]     : name of the group to add the adaptor to in the registry.
+  Arg [3]     : name of the type to add the adaptor to in the registry.
+  Example     : $adap = Bio::EnsEMBL::Registry->get_adaptor("Human", "core", "Gene");
+  Description : Finds and returns the specified adaptor. This method will also check
+                if the species, group and adaptor combination satisfy a DNADB condition
+                (and will return that DNADB's implementation). Also we check for 
+                any available switchable adaptors and will return that if available.
+  Returntype  : adaptor
+  Exceptions  : Thrown if a valid internal name cannot be found for the given 
+                name. If thrown check your API and DB version. Also thrown if
+                no type or group was given
+  Status      : Stable
 
 =cut
 
@@ -988,6 +1091,9 @@ sub get_adaptor {
   
   throw 'No adaptor group given' if ! defined $group;
   throw 'No adaptor type given' if ! defined $type;
+
+  $group = lc($group);
+  my $lc_type = lc($type);
   
   
   if($type =~ /Adaptor$/i) {
@@ -995,43 +1101,50 @@ sub get_adaptor {
     $type =~ s/Adaptor$//i;
   }
 
+  # For historical reasons, allow use of group 'regulation' to refer to
+  # group 'funcgen'.
+  if ( $group eq 'regulation' ) { $group = 'funcgen' }
+
   my %dnadb_adaptors = (
     'sequence'                 => 1,
     'assemblymapper'           => 1,
     'karyotypeband'            => 1,
     'repeatfeature'            => 1,
-    'coordsystem'              => ((lc($group) ne 'funcgen') ? 1 : undef),
+    'coordsystem'              => (($group ne 'funcgen') ? 1 : undef),
     'assemblyexceptionfeature' => 1
   );
 
-  # warn "$species, $group, $type";
-
-  $type = lc($type);
-
-  # For historical reasons, allow use of group 'regulation' to refer to
-  # group 'funcgen'.
-  if ( lc($group) eq 'regulation' ) { $group = 'funcgen' }
-
-  my $dnadb_group =
-    $registry_register{_SPECIES}{$species}{ lc($group) }{'_DNA'};
-
-  if ( defined($dnadb_group)
-    && defined( $dnadb_adaptors{ lc($type) } ) )
-  {
-    $species =
-      $registry_register{_SPECIES}{$species}{ lc($group) }{'_DNA2'};
-    $group = $dnadb_group;
+  #Before looking for DNA adaptors we need to see if we have a switchable adaptor since they take preference
+  if(defined $registry_register{_SWITCHABLE}{$species}{$group}{$lc_type}) {
+    return $registry_register{_SWITCHABLE}{$species}{$group}{$lc_type};
   }
 
-  my $ret =
-    $registry_register{_SPECIES}{$species}{ lc($group) }{ lc($type) };
+  # Look for a possible DNADB group alongside the species hash
+  my $dnadb_group = $registry_register{_SPECIES}{$species}{ $group }{'_DNA'};
+
+  # If we found one & this is an adaptor we should be replaced by a DNADB then
+  # look up the species to use and replace the current group with the DNADB group
+  # (groups are held in _DNA, species are in _DNA2)
+  if ( defined($dnadb_group) && defined( $dnadb_adaptors{ $lc_type } ) ) {
+    $species = $registry_register{_SPECIES}{$species}{ $group }{'_DNA2'};
+    $group = $dnadb_group;
+
+    # Once we have switched to the possibility of a DNADB call now check again for
+    # a switchable adaptor
+    if(defined $registry_register{_SWITCHABLE}{$species}{$group}{$lc_type}) {
+      return $registry_register{_SWITCHABLE}{$species}{$group}{$lc_type};
+    }  
+  }
+
+  # No switchable adaptor? Ok then continue with the normal logic
+  my $ret = $registry_register{_SPECIES}{$species}{ $group }{ $lc_type };
 
   if ( !defined($ret) ) { return }
   if ( ref($ret) )      { return $ret }
 
   # Not instantiated yet
 
-  my $dba = $registry_register{_SPECIES}{$species}{ lc($group) }{'_DB'};
+  my $dba = $registry_register{_SPECIES}{$species}{ $group }{'_DB'};
   my $module = $ret;
 
   my $test_eval = eval "require $module"; ## no critic
@@ -1042,10 +1155,10 @@ sub get_adaptor {
 
   if (
     !defined(
-      $registry_register{_SPECIES}{$species}{ lc($group) }{'CHECKED'} )
+      $registry_register{_SPECIES}{$species}{ $group }{'CHECKED'} )
     )
   {
-    $registry_register{_SPECIES}{$species}{ lc($group) }{'CHECKED'} = 1;
+    $registry_register{_SPECIES}{$species}{ $group }{'CHECKED'} = 1;
     $class->version_check($dba);
   }
 

--- a/modules/t/switchableAdaptors.t
+++ b/modules/t/switchableAdaptors.t
@@ -1,0 +1,156 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::MockObject;
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Test::MultiTestDB;
+use Bio::EnsEMBL::Test::TestUtils qw/mock_object/;
+
+# "Globals"
+my $CHR           = '20';
+my $START         = 30_270_000;
+my $END           = 30_270_200;
+my $STRAND        = 1;
+my $LENGTH				= 201;	
+my $REGISTRY			= 'Bio::EnsEMBL::Registry';
+
+# Get a human core DB so we have something in the registy to mess about with
+my $multi = Bio::EnsEMBL::Test::MultiTestDB->new();
+my $dba = $multi->get_DBAdaptor('core');
+my $empty_dba = $multi->get_DBAdaptor('empty');
+
+sub mock_adaptor {
+	my ($residue) = @_;
+	my $mock_sequence_adaptor = Test::MockObject->new();
+	$mock_sequence_adaptor->mock('fetch_by_Slice_start_end_strand', sub {
+		my ( $self, $slice, $start, $end, $strand ) = @_;
+		my $seq = $residue x $slice->length(); # return a bogus piece of sequence
+		return \$seq;
+	});
+}
+
+# Create the mock sequence adaptor which responds to one method
+my $m_mock_adaptor = mock_adaptor('M');
+my $x_mock_adaptor = mock_adaptor('X');
+
+#Get the slice & setup assertion methods
+my $slice = $dba->get_SliceAdaptor()->fetch_by_region('toplevel', $CHR, $START, $END);
+sub normal_slice {
+	my ($local_slice) = @_;
+	note 'Asserting normal slice content';
+	$local_slice ||= $slice;
+	my $seq = $local_slice->seq();
+	is(length($seq), $LENGTH, 'Expected retrieved sequence length');
+	like($seq, qr/^[ACTG]+$/, 'Checking we just have ACTG');
+}
+
+sub m_switchable_slice {
+	my ($local_slice) = @_;
+	note 'Asserting mocked slice content of just M';
+	$local_slice ||= $slice;
+	my $seq = $local_slice->seq();
+	is(length($seq), $LENGTH, 'Expected retrieved sequence length');
+	like($seq, qr/^M+$/, 'Checking that we use the mock adaptor and it only reports the residue M');
+}
+
+sub x_switchable_slice {
+	my ($local_slice) = @_;
+	note 'Asserting mocked slice content of just X';
+	$local_slice ||= $slice;
+	my $seq = $local_slice->seq();
+	is(length($seq), $LENGTH, 'Expected retrieved sequence length');
+	like($seq, qr/^X+$/, 'Checking that we use the mock adaptor and it only reports the residue X');
+}
+
+#Test normality
+normal_slice();
+
+#Replace the adaptor & see what occurs
+$REGISTRY->add_switchable_adaptor($dba->species(), $dba->group(), 'sequence', $m_mock_adaptor);
+ok($REGISTRY->has_switchable_adaptor($dba->species(), $dba->group(), 'sequence'), 'Has a sequence switchable adaptor should respond with true');
+ok(!$REGISTRY->has_switchable_adaptor($dba->species(), $dba->group(), 'someotheradaptor'), 'Has switchable adaptor should respond with false for a bogus adaptor');
+m_switchable_slice();
+
+#Attempt again and catch exceptions
+dies_ok { $REGISTRY->add_switchable_adaptor($dba->species, $dba->group, 'sequence', $x_mock_adaptor) } 'Dies if we try to set it without resetting';
+dies_ok { $REGISTRY->add_switchable_adaptor($dba->species, $dba->group, 'sequence', $m_mock_adaptor) } 'Dies if we try to set it to the same adaptor without resetting';
+
+#Now switch with a force and assert
+$REGISTRY->add_switchable_adaptor($dba->species, $dba->group, 'sequence', $x_mock_adaptor, 1);
+x_switchable_slice();
+
+#Remove and ensure it goes back to normal
+$REGISTRY->remove_switchable_adaptor($dba->species, $dba->group, 'sequence');
+normal_slice();
+ok(!$REGISTRY->has_switchable_adaptor($dba->species(), $dba->group(), 'sequence'), 'Has switchable adaptor should respond with true now we have removed the adaptor');
+
+###############################################################
+##### Now test the expected functionality of the delegating 
+##### DNADB interface
+###############################################################
+is($empty_dba->group(), 'empty', 'Make sure empty DB group is empty');
+is($empty_dba->dnadb(), $empty_dba, 'Empty DNADB is itself since it is an unknown group to ConfigRegistry');
+
+# If we call normal_slice on the empty DBA then we should get the original sequence back since it's a duplication
+my $empty_dba_slice = $empty_dba->get_SliceAdaptor()->fetch_by_region('toplevel', $CHR, $START, $END);
+normal_slice($empty_dba_slice);
+
+# Set the dnadb to core
+$empty_dba->dnadb($dba);
+
+#Set the switchable adaptor on both empty dba and dba. empty dba should win
+$REGISTRY->add_switchable_adaptor($dba->species, $dba->group, 'sequence', $m_mock_adaptor);
+$REGISTRY->add_switchable_adaptor($empty_dba->species, $empty_dba->group, 'sequence', $x_mock_adaptor);
+# my $empty_dba_slice = $empty_dba->get_SliceAdaptor()->fetch_by_region('toplevel', $CHR, $START, $END);
+x_switchable_slice($empty_dba_slice);
+# M should now win
+$REGISTRY->remove_switchable_adaptor($empty_dba->species, $empty_dba->group, 'sequence');
+m_switchable_slice($empty_dba_slice);
+$REGISTRY->remove_switchable_adaptor($dba->species, $dba->group, 'sequence');
+
+###############################################################
+##### Test the methods on DBAdaptor for switching including 
+##### automatic re-switching and remembering last switched
+##### adaptors
+###############################################################
+note 'Running DBAdaptor level tests';
+normal_slice();
+ok(!$dba->has_switched_adaptor('sequence'), 'Verifying the instance is not being switched out');
+$dba->switch_adaptor('sequence', $m_mock_adaptor);
+ok($dba->has_switched_adaptor('sequence'), 'Verifying the instance is being switched out');
+note 'Try switching to X. Will fail';
+m_switchable_slice();
+dies_ok { $dba->switch_adaptor('sequence', $x_mock_adaptor); } 'Forcing a switch to an already switched adaptor causes an error';
+note 'Still set to M';
+m_switchable_slice();
+$dba->revert_adaptor();
+normal_slice();
+
+note 'Running callback methods';
+$dba->switch_adaptor('sequence', $m_mock_adaptor, sub {
+	m_switchable_slice();
+});
+normal_slice();
+
+note 'Forcing a switch using callbacks';
+$dba->switch_adaptor('sequence', $m_mock_adaptor);
+$dba->switch_adaptor('sequence', $x_mock_adaptor, sub {
+	x_switchable_slice();
+}, 1);
+normal_slice();
+
+note 'Trying a switch callback and die. The revert method should still fire';
+
+dies_ok {$dba->switch_adaptor('sequence', $m_mock_adaptor, sub {
+	die "Raising an exception";
+});
+} 'Dies are propagated through correctly';
+ok(! $dba->has_switched_adaptor('sequence'), 'We have reverted the switch');
+normal_slice();
+
+
+
+done_testing();


### PR DESCRIPTION
This branch brings in changes to the Registry to support a very basic implementation of dependency injection/inversion of control container. You can switch an adaptor for an alternative implementation using the Registry directly where you are responsible for switching the implementation back after finishing with the code.

Alternatively you can use a method on the DBAdaptor instance which takes in a callback subroutine and will deal with the nitty gritty of switching implementations back and forth.

Main use case is to switch where DNA sequence comes from.