### PR TITLE
fastmap expects seq region name not id

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
@@ -1135,7 +1135,7 @@ sub _remap {
       #slice of feature in different coord system, mapping required
       # $seq_region comes out as an integer not a string
       ($seq_region_id, $start, $end, $strand) =
-        $mapper->fastmap($fseq_region_id,$f->start(),$f->end(),$f->strand(),$fcs);
+        $mapper->fastmap($fslice->seq_region_name(),$f->start(),$f->end(),$f->strand(),$fcs);
 
       # undefined start means gap
       next if(!defined $start);


### PR DESCRIPTION
This is broken in earlier versions also (I checked 80 and 81) - is it possible to have the fix applied to least to 81 as well as master?