### PR TITLE
Switching to a tied hash instance versus blessed hash.

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
@@ -505,8 +505,7 @@ sub fetch_and_dump_seq_via_toplevel{
     %{ $slice_adaptor->{'sr_id_cache'} }   = ();
 
     $ama->delete_cache();
-
-    %{ $seqa->{'seq_cache'} } = ();
+    $seqa->clear_cache();
   }
 
   close $dnah || die "unable to close dna file\n$!\n";
@@ -645,7 +644,7 @@ sub fetch_and_dump_seq_via_genes{
 
     $ama->delete_cache();
 
-    %{ $seqa->{'seq_cache'} } = ();
+    $seqa->clear_cache();
   }
   close $dnah || die "unable to close dna file\n$!\n";
   close $peph || die "unable to close peptide file\n$!\n"; 

--- a/modules/t/fastaSequenceAdaptor.t
+++ b/modules/t/fastaSequenceAdaptor.t
@@ -72,9 +72,9 @@ my $SA = $dba->get_SliceAdaptor();
     dies_ok { $dba->get_SequenceAdaptor()->store() } 'Call should die due to FASTASequenceAdaptor being in place';
 
     # Drill into the object and look at the cache
-    my $cache_key = $sa->{seq_cache}->FIRSTKEY();
+    my ($cache_key) = keys %{$sa->{seq_cache}};
     my $expected_length = 1 << $power;
-    is(length(${$sa->{seq_cache}->FETCH($cache_key)}), $expected_length, 'Checking length of cached sequence');
+    is(length(${$sa->{seq_cache}->{$cache_key}}), $expected_length, 'Checking length of cached sequence');
   });
 }
 


### PR DESCRIPTION
Seems that calling external code could assume the sequence cache is, in
fact, a hash. If the cache is replaced with the wrong data structure
(say a normal hash) then a memory leak will appear as seen in the xref
pipeline whilst dumping sequences.