### PR TITLE
Experimental/merged alternative sequence store

### DIFF
--- a/misc-scripts/utilities/index_fasta.pl
+++ b/misc-scripts/utilities/index_fasta.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+# Copyright [1999-2014] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+use File::Basename;
+
+use Bio::EnsEMBL::Utils::IO::FileFaidx;
+
+my $current_time = time();
+
+my $file = $ARGV[0];
+my $faidx = Bio::EnsEMBL::Utils::IO::FileFaidx->new($file, 'write_index');
+
+my $index = $faidx->index_path($file);
+if(-f $index) {
+  print "Removing the existing index at $index\n";
+  unlink $index;
+}
+
+print "Generating the index\n";
+$faidx->lookup();
+my $finished_time = time();
+my $elapsed = $finished_time - $current_time;
+my $time = gmtime($finished_time);
+print "Finished @ $time. Took $elapsed second(s)\n";

--- a/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
@@ -505,8 +505,7 @@ sub fetch_and_dump_seq_via_toplevel{
     %{ $slice_adaptor->{'sr_id_cache'} }   = ();
 
     $ama->delete_cache();
-
-    %{ $seqa->{'seq_cache'} } = ();
+    $seqa->clear_cache();
   }
 
   close $dnah || die "unable to close dna file\n$!\n";
@@ -645,7 +644,7 @@ sub fetch_and_dump_seq_via_genes{
 
     $ama->delete_cache();
 
-    %{ $seqa->{'seq_cache'} } = ();
+    $seqa->clear_cache();
   }
   close $dnah || die "unable to close dna file\n$!\n";
   close $peph || die "unable to close peptide file\n$!\n"; 

--- a/modules/Bio/EnsEMBL/DBSQL/BaseSequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseSequenceAdaptor.pm
@@ -1,0 +1,328 @@
+=head1 LICENSE
+
+Copyright [1999-2014] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <dev@ensembl.org>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <helpdesk@ensembl.org>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::DBSQL::BaseSequenceAdaptor
+
+=head1 DESCRIPTION
+
+The BaseSequenceAdaptor is responsible for the conversion of calls from 
+C<fetch_by_Slice_start_end_strand()> for Sequence data into requests for a 
+backing data store. In Ensembl these are the B<seqlevel> sequence region
+records held in the MySQL database. 
+
+The base adaptor also provides sequence caching based on normalisation 
+technique similar to the UCSC and BAM binning indexes. The code works 
+by right-shifting the requested start and end by a seq chunk power 
+(by default 18 approx. 250,000bp) and then left-shifting by the same 
+value. This means any value within a given window will always result in
+the same value. Please see the worked examples below:
+
+  # Equation
+  p=position
+  o=seq chunk power
+  offset=( (p-1)>>o ) << o
+  
+  # Using real values
+  p=1340001
+  o=18
+  right_shifted = (1340001-1) >> 18 == 5
+  offset = 5 << 18 == 1310720
+
+To control the size of the cache and sequences stored you can provide
+the seq chunk power and the number of sequences cached.
+
+=cut
+
+package Bio::EnsEMBL::DBSQL::BaseSequenceAdaptor;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Utils::Cache;
+use Bio::EnsEMBL::Utils::Exception qw(throw);
+
+our $SEQ_CHUNK_PWR   = 18; # 2^18 = approx. 250KB
+our $SEQ_CACHE_SIZE  = 5;
+
+=head2 fetch_by_Slice_start_end_strand
+
+  Arg  [1]   : Bio::EnsEMBL::Slice slice
+               The slice from which you want the sequence
+  Arg  [2]   : Integer; $strand (optional)
+               The start base pair relative to the start of the slice. Negative
+               values or values greater than the length of the slice are fine.
+               default = 1
+  Arg  [3]   : (optional) int endBasePair
+               The end base pair relative to the start of the slice. Negative
+               values or values greater than the length of the slice are fine,
+               but the end must be greater than or equal to the start
+               count from 1
+               default = the length of the slice
+  Arg  [4]   : Integer; $strand (optional)
+               Strand of DNA to fetch
+  Returntype : StringRef (DNA requested)
+  Description: Performs the fetching of DNA based upon a Slice. All fetches
+               should use this method and no-other.
+               
+               Implementing classes are responsible for converting the
+               given Slice and values into something which can be processed by 
+               the underlying storage engine. Implementing class are also
+               responsible for the reverse complementing of sequence.
+  Exceptions : Thrown if not redefined
+
+=cut
+
+sub fetch_by_Slice_start_end_strand {
+  my ( $self, $slice, $start, $end, $strand ) = @_;
+  throw "fetch_by_Slice_start_end_strand() must be implemented";
+}
+
+=head2 can_access_Slice
+
+  Description : Returns a boolean indiciating if the adaptor understands
+                the given Slice.
+  Returntype  : Boolean; if true you can get sequence for the given Slice
+  Exceptions  : Thrown if not redefined
+
+=cut
+
+sub can_access_Slice {
+  my ($self, $slice) = @_;
+  throw "can_access_Slice() must be implemented";
+}
+
+=head2 expand_Slice 
+
+  Arg  [1]    : Bio::EnsEMBL::Slice slice
+                The slice from which you want the sequence
+  Arg  [2]    : Integer; $strand (optional)
+                The start base pair relative to the start of the slice. Negative
+                values or values greater than the length of the slice are fine.
+                default = 1
+  Arg  [3]    : (optional) int endBasePair
+                The end base pair relative to the start of the slice. Negative
+                values or values greater than the length of the slice are fine,
+                but the end must be greater than or equal to the start
+                count from 1
+                default = the length of the slice
+  Arg  [4]    : Integer; $strand (optional)
+                Strand of DNA to fetch
+  Returntype  : Bio::EnsEMBL::Slice
+  Description : Creates a new Slice which represents the requested region. Provides
+                logic applicable to all SliceAdaptor instance
+  Exceptions  : Thrown if the Slice is circular (we currently do not support this as generic logic)
+
+=cut
+
+sub expand_Slice {
+  my ($self, $slice, $start, $end, $strand) = @_;
+  
+  $start = 1 if ! defined $start;
+  $end = ($slice->end() - $slice->start()) + 1 if ! defined $end;
+  $strand = 1 if ! defined $strand;
+
+  my $right_expand = $end - $slice->length();    #negative is fine
+  my $left_expand  = 1 - $start;                 #negative is fine
+
+  my $new_slice = $slice;
+  if ( $right_expand || $left_expand ) {
+    $new_slice =
+        $slice->strand > 0
+      ? $slice->expand( $left_expand,  $right_expand )
+      : $slice->expand( $right_expand, $left_expand );
+  }
+  
+  return $new_slice;
+}
+
+=head2 new
+
+  Arg [1]    : Int  $chunk_power; sets the size of each element of 
+                    the sequence cache. Defaults to 18 which gives 
+                    block sizes of ~250Kb (it is actually 2^18)
+  Arg [2]    : Int  $cache_size; size of the cache. Defaults to 5 meaning
+                    a cache of 1Mb if you use default values
+  Example    : my $sa = $db_adaptor->get_SequenceAdaptor();
+  Description: Constructor.  Calls superclass constructor and initialises
+               internal cache structure.
+  Returntype : Bio::EnsEMBL::DBSQL::SequenceAdaptor
+  Exceptions : none
+  Caller     : DBAdaptor::get_SequenceAdaptor
+  Status     : Stable
+
+=cut
+
+sub new {
+  my ($class, $chunk_power, $cache_size) = @_;
+  $class = ref($class) || $class;
+  my $self = bless({}, $class);
+  $self->_init_seq_instance($chunk_power, $cache_size);
+  return $self;
+}
+
+sub _init_seq_instance {
+  my ($self, $chunk_power, $cache_size) = @_;
+  $chunk_power ||= $SEQ_CHUNK_PWR;
+  $cache_size ||= $SEQ_CACHE_SIZE;
+  
+  # use a LRU cache to limit the size
+  my $cache = Bio::EnsEMBL::Utils::Cache->TIEHASH($cache_size);
+
+  $self->{cache_size} = $cache_size;
+  $self->{chunk_power} = $chunk_power;
+  $self->{seq_cache_max} = ((2 ** $chunk_power) * $cache_size);
+  $self->{seq_cache} = $cache;
+  return;
+}
+
+=head2 clear_cache
+
+  Example    	: $sa->clear_cache();
+  Description	: Removes all entries from the associcated sequence cache
+  Returntype 	: None
+  Exceptions 	: None
+
+=cut
+
+sub clear_cache {
+  my ($self) = @_;
+  $self->{seq_cache}->CLEAR();
+  return;
+}
+
+sub chunk_power {
+  my ($self) = @_;
+  return $self->{chunk_power};
+}
+
+sub cache_size {
+  my ($self) = @_;
+  return $self->{cache_size};
+}
+
+sub seq_cache_max {
+  my ($self) = @_;
+  return $self->{seq_cache_max};
+}
+
+=head2 _fetch_raw_seq
+
+  Arg [1]     : String $id
+                The identifier of the sequence to fetch.
+  Arg [2]     : Integer $start
+                Where to start fetching sequence from
+  Arg [2]     : Integer $length
+                Total length of seuqence to fetch
+  Description : Performs the fetch of DNA from the backing storage 
+                engine and provides it to the _fetch_seq() method
+                for optional caching.
+  Returntype  : ScalarRef of DNA fetched. All bases should be uppercased
+  Exceptions  : Thrown if the method is not reimplemented
+
+=cut
+sub _fetch_raw_seq {
+  my ($self, $id, $start, $length) = @_;
+  throw "Need to implement _fetch_raw_seq(). Code must return a ScalarRef";
+}
+
+=head2 _fetch_seq
+
+  Arg [1]     : String $id
+                The identifier of the sequence to fetch.
+  Arg [2]     : Integer $start
+                Where to start fetching sequence from
+  Arg [2]     : Integer $length
+                Total length of seuqence to fetch
+  Description	: If the requested region is smaller than our maximum length
+                cachable region we will see if the cache already contains
+                this chunk. If not we will request the region from C<_fetch_raw_seq()>
+                and cache it. If the region requested is larger than 
+                the maximum cacheable sequence length we pass the request
+                onto C<_fetch_raw_seq()> with no caching layer.
+                
+                This module is also responsible for the conversion of
+                requested regions into normalised region reuqests based
+                on C<chunk_power>.
+  Returntype 	: ScalarRef of DNA fetched. All bases should be uppercased
+  Exceptions 	: Thrown when C<_fetch_raw_seq()> is not re-implemented
+
+=cut
+
+sub _fetch_seq {
+  my ($self, $id, $start, $length) = @_;
+  my $cache = $self->{'seq_cache'};
+  my $cache_size = $self->cache_size();
+  my $seq_chunk_pwr = $self->chunk_power();
+  my $seq_cache_max = $self->seq_cache_max();
+
+  my $seq_ref;
+
+  # If the length of the region is less than the max size of the
+  # cache then we can use the cache. The region is converted into
+  # a min to max range of bins we have to query to get all the 
+  # required sequence. Of these bins the cache may have all of them,
+  # none of them or a combination of the two states
+  if($length < $seq_cache_max) {
+    my $chunk_min = ($start-1) >> $seq_chunk_pwr;
+    my $chunk_max = ($start + $length - 1) >> $seq_chunk_pwr;
+
+    # piece together sequence from cached component parts
+    my $entire_seq = q{};
+    for(my $i = $chunk_min; $i <= $chunk_max; $i++) {
+      my $key = "${id}:${i}";
+      #If it exists within the cache then add to the string. We will trim
+      #down to the requested region later on
+      my $cached_seq_ref = $cache->FETCH($key);
+      if($cached_seq_ref) {
+        $entire_seq .= ${$cached_seq_ref};
+      } 
+      #Otherwise it is uncached so fetch, concat and store in the cache
+      else {
+        my $min = ($i << $seq_chunk_pwr) + 1;
+        my $length = 1 << $seq_chunk_pwr;
+        my $tmp_seq_ref = $self->_fetch_raw_seq($id, $min, $length);
+        $entire_seq .= ${$tmp_seq_ref};
+        $cache->STORE($key, $tmp_seq_ref);
+      }
+    }
+
+    # now return only the requested portion of the entire sequence
+    my $min = ( $chunk_min << $seq_chunk_pwr ) + 1;
+    my $seq = substr( $entire_seq, $start - $min, $length );
+    $seq_ref = \$seq;
+  }
+  else {
+    # If it was too big then just ask it from the backing store. There's
+    # no use in caching this
+    $seq_ref = $self->_fetch_raw_seq($id, $start, $length);
+  }
+  
+  return $seq_ref;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/DBSQL/BaseSequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseSequenceAdaptor.pm
@@ -191,12 +191,12 @@ sub _init_seq_instance {
   $cache_size ||= $SEQ_CACHE_SIZE;
   
   # use a LRU cache to limit the size
-  my $cache = Bio::EnsEMBL::Utils::Cache->TIEHASH($cache_size);
+  tie my %cache, 'Bio::EnsEMBL::Utils::Cache', $cache_size, {};
 
   $self->{cache_size} = $cache_size;
   $self->{chunk_power} = $chunk_power;
   $self->{seq_cache_max} = ((2 ** $chunk_power) * $cache_size);
-  $self->{seq_cache} = $cache;
+  $self->{seq_cache} = \%cache;
   return;
 }
 
@@ -211,7 +211,7 @@ sub _init_seq_instance {
 
 sub clear_cache {
   my ($self) = @_;
-  $self->{seq_cache}->CLEAR();
+  %{$self->{seq_cache}} = ();
   return;
 }
 
@@ -297,7 +297,7 @@ sub _fetch_seq {
       my $key = "${id}:${i}";
       #If it exists within the cache then add to the string. We will trim
       #down to the requested region later on
-      my $cached_seq_ref = $cache->FETCH($key);
+      my $cached_seq_ref = $cache->{$key};
       if($cached_seq_ref) {
         $entire_seq .= ${$cached_seq_ref};
       } 
@@ -307,7 +307,7 @@ sub _fetch_seq {
         my $length = 1 << $seq_chunk_pwr;
         my $tmp_seq_ref = $self->_fetch_raw_seq($id, $min, $length);
         $entire_seq .= ${$tmp_seq_ref};
-        $cache->STORE($key, $tmp_seq_ref);
+        $cache->{$key} = $tmp_seq_ref;
       }
     }
 

--- a/modules/Bio/EnsEMBL/DBSQL/FastaSequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/FastaSequenceAdaptor.pm
@@ -1,0 +1,155 @@
+=head1 LICENSE
+
+Copyright [1999-2014] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <dev@ensembl.org>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <helpdesk@ensembl.org>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor
+
+=head1 DESCRIPTION
+
+This sequence adaptor extends the BaseSequenceAdaptor code to provide an 
+implementation of the .fai index lookup as defined by samtools. The code uses
+this indexing system to access portions of sequence and translates Slice requests
+into sensible locations for our FASTA query layer.
+
+The adaptor must be initalised with access to a Faidx compatible object and the FASTA
+file backing must use the same seq_region_name as the querying slices otherwise
+we cannot return the required data.
+
+=cut
+
+package Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor;
+
+use strict;
+use warnings;
+
+use base qw/Bio::EnsEMBL::DBSQL::BaseSequenceAdaptor/;
+
+use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Bio::EnsEMBL::Utils::Scalar qw/assert_ref/;
+use Bio::EnsEMBL::Utils::Sequence qw/reverse_comp/;
+use English qw/-no_match_vars/;
+require bytes;
+
+=head2 new
+  
+  Arg [1]     : FileFaidx; $faindex. A FileFaidx object or a compatible version
+  Arg [2]     : Integer; $chunk_power. Size of the region to cache
+  Arg [3]     : Integer; $cache_size. Number of regions to cache
+  Description : Builds an instance of the FastaSequenceAdaptor
+
+=cut
+
+sub new {
+  my ($class, $faindex, $chunk_power, $cache_size) = @_;
+  my $self = $class->SUPER::new($chunk_power, $cache_size);
+  $self->faindex($faindex);
+  return $self;
+}
+
+=head2 fetch_by_Slice_start_end_strand
+  
+  Arg [1]     : Bio::EnsEMBL::Slice; $slice. Slice to fetch sequence for
+  Arg [2]     : Integer; $start. Start of region to retrieve relative to the Slice (defaults to 1)
+  Arg [3]     : Integer; $end. End of region to retreive relative to the Slice (defaults to length)
+  Arg [4]     : Integer; $strand. Strand to fetch (defaults to 1)
+  Description : Fetches sequence for the given slice. Unlike the normal SequenceAdaptor we assume
+                Sequence is held in a FASTA file under the Slice's seq_region_name.
+  Exception   : Thrown if we are given a circular slice
+=cut
+
+sub fetch_by_Slice_start_end_strand {
+  my ( $self, $slice, $start, $end, $strand ) = @_;
+  
+  # Input checks
+  assert_ref($slice, 'Bio::EnsEMBL::Slice', 'slice');
+  if(defined $end && $start > $end && $slice->is_circular()) {
+    throw "Currently we do not support circular requests";
+  }
+  
+  #Get a new slice that spans the exact region to retrieve dna from.
+  #Then constrain to seq region if it's gone negative or over the end  
+  $slice = $self->expand_Slice($slice, $start, $end, $strand);
+  $slice = $slice->constrain_to_seq_region();
+  
+  # This call is likely to barf if we try to query using a chr name
+  # we do not understand. Use can_access_Slice() to make sure
+  my $seq_ref = $self->_fetch_seq($slice->seq_region_name(), $slice->start(), $slice->length());
+  reverse_comp($seq_ref) if $strand == -1;
+  return $seq_ref;
+}
+
+=head2 faindex
+
+  Description : Holds a reference to the Faindex object to use for sequence access
+
+=cut
+
+sub faindex {
+  my ($self, $faindex) = @_;
+  if(defined $faindex) {
+    assert_ref($faindex, 'Bio::EnsEMBL::Utils::IO::FileFaidx', 'faidx');
+    $self->{faindex} = $faindex;
+  }
+  return $self->{faindex};
+}
+
+=head2 can_access_Slice
+
+  Description : Checks the lookup to see if we have access to the Slice given (using 
+                seq region name as the ID). We reject any Circular Slice
+
+=cut
+
+sub can_access_Slice {
+  my ($self, $slice) = @_;
+  return 0 if $slice->is_circular();
+  return $self->faindex()->can_access_id($slice->seq_region_name());
+}
+
+=head2 store
+  
+  Description : Unsupported operation. Please use a FASTA serialiser
+
+=cut
+
+sub store {
+  throw "Unsupported operation. Cannot store sequence in a fasta file";
+}
+
+=head _fetch_raw_seq
+
+  Description : Provides access to the underlying faindex object and returns a sequence scalar ref
+
+=cut
+
+sub _fetch_raw_seq {
+  my ($self, $id, $start, $length) = @_;
+  my $seq_ref = $self->faindex()->fetch_seq($id, $start, $length);
+  return $seq_ref;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Utils/IO/FileFaidx.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/FileFaidx.pm
@@ -1,0 +1,469 @@
+=head1 LICENSE
+
+Copyright [1999-2014] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <dev@ensembl.org>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <helpdesk@ensembl.org>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Utils::IO::FileFaidx
+
+=head1 DESCRIPTION
+
+This object provides an implementation of the .fai index lookup as defined by samtools. 
+This format assumes that all lines in a FASTA file are the same length (bytes and bases) 
+and this information is held in a file called .fai (held in the same directory
+as the FASTA file). The format is tab delimited like so:
+
+    RecordID    RecordLength(bp)   File offset (bytes)       bp per line      bytes per line
+
+For example:
+
+    MT    16571   6       50      51
+    1    247249719       16915   50      51
+
+The columns are sequence ID, sequence length, offset in file, bases per line 
+and bytes per line. This module will read this format (if the file is available)
+or will generate it from a FASTA file. It is recommnded that you pre-generate this
+by using this module with the C<write_index_to_disk()> flag on or by using the
+samtools faidx binary.
+
+Please note that we do not handle RAZF compressed indexes or FASTA files.
+
+We recommend you use this adaptor with the fully assembled chromsome files available from 
+our FTP site (primary assembly).
+
+=cut
+
+package Bio::EnsEMBL::Utils::IO::FileFaidx;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Utils::Exception qw/throw warning/;
+use Bio::EnsEMBL::Utils::IO qw/iterate_lines work_with_file slurp/;
+use English qw/-no_match_vars/;
+require bytes;
+
+=head2 new
+  
+  Arg [1]     : String; $file. Path to the FASTA file
+  Arg [2]     : Boolean; $write_index_to_disk. Write the index to disk
+  Arg [3]     : Boolean; $persist_fh. Persist the file handle between requests for sequence
+  Arg [4]     : Boolean; $no_generation. Stop index generation and force the reading of an index from disk
+  Arg [5]     : Boolean; $uppercase_sequence. Uppercase sequence returned from the code. Defaults to true
+  Description : Builds an instance of the FaidxFasta object
+
+=cut
+
+sub new {
+  my ($class, $fasta_file, $write_index_to_disk, $persist_fh, $no_generation, $uppercase_sequence) = @_;
+  throw 'No file given; cannot continue without one' unless $fasta_file;
+  $uppercase_sequence //= 1;
+  my $self = bless({}, ref($class)||$class);
+  $self->file($fasta_file);
+  $self->write_index_to_disk($write_index_to_disk);
+  $self->persist_fh($persist_fh);
+  $self->no_generation($no_generation);
+  $self->uppercase_sequence($uppercase_sequence);
+  return $self;
+}
+
+=head2 can_access_id
+
+  Description : Checks the lookup to see if we have access to the id
+
+=cut
+
+sub can_access_id {
+  my ($self, $id) = @_;
+  return exists $self->lookup()->{$id} ? 1 : 0;
+}
+
+=head2 file
+  
+  Arg [1]     : String; $file. Path to the FASTA file
+  Description : Location of the FASTA file
+  Exception   : Thrown if the file cannot be found
+
+=cut
+
+sub file {
+  my ($self, $file) = @_;
+  if(defined $file) {
+    throw "No file found at '${file}'" unless -f $file;
+    $self->{'file'} = $file;
+  }
+  return $self->{'file'};
+}
+
+=head2 store
+  
+  Arg [1]     : Boolean; $write_index_to_disk. Controls if we write the index back to disk
+  Description : Controls if we can write back to disk. Only run to generate the indexes
+
+=cut
+
+sub write_index_to_disk {
+  my ($self, $write_index_to_disk) = @_;
+  $self->{'write_index_to_disk'} = $write_index_to_disk if defined $write_index_to_disk;
+  return $self->{'write_index_to_disk'};
+}
+
+=head2 persist_fh
+  
+  Arg [1]     : Boolean; $persist_fh
+  Description : Controls if we leave a file handle open between sequence reads
+
+=cut
+
+sub persist_fh {
+  my ($self, $persist_fh) = @_;
+  $self->{'persist_fh'} = $persist_fh if defined $persist_fh;
+  return $self->{'persist_fh'};
+}
+
+=head2 no_generation
+  
+  Arg [1]     : Boolean; $no_generation
+  Description : Controls if we will attempt an index generation if a .fai file is missing
+
+=cut
+
+sub no_generation {
+  my ($self, $no_generation) = @_;
+  $self->{'no_generation'} = $no_generation if defined $no_generation;
+  return $self->{'no_generation'};
+}
+
+=head2 uppercase_sequence
+  
+  Arg [1]     : Boolean; $uppercase_sequence
+  Description : Controls if always uppercase sequence or not. Defaults to true
+
+=cut
+
+sub uppercase_sequence {
+  my ($self, $uppercase_sequence) = @_;
+  $self->{'uppercase_sequence'} = $uppercase_sequence if defined $uppercase_sequence;
+  return $self->{'uppercase_sequence'};
+}
+
+
+
+=head2 index_suffix
+
+  Description : Returns the index suffix normally used (fai)
+  Returntype  : String of the index suffix
+
+=cut
+
+sub index_suffix {
+  my ($class) = @_;
+  return 'fai';
+}
+
+=head2 index_path
+
+  Arg [1]     : String; $path. Path of the current index
+  Description : Returns the index path (normally the given path plus an .fai extension)
+  Returntype  : Path to the index file
+
+=cut
+
+sub index_path {
+  my ($class, $path) = @_;
+  my $suffix = $class->index_suffix();
+  return "${path}.${suffix}";
+}
+
+=head2 lookup
+  
+  Description : Attempts to load the index from disk or create 
+                it from the FASTA file in question. Once loaded it is 
+                cached locally. The lookup will be written to disk
+                if the write_index_to_disk attribute is true.
+  Returntype  : HashRef of FASTA ID to ArrayRef of attributes
+                [size, file start position, bases per line, bytes per line]
+  Exception   : Thrown if we could not generate a lookup from the FASTA file or
+                .fai index
+=cut
+
+sub lookup {
+  my ($self) = @_;
+  return $self->{lookup} if exists $self->{lookup};
+  my $faindex_lookup = $self->load_from_faindex();
+  if(! %{$faindex_lookup}) {
+    if(!$self->no_generation()) {
+      $faindex_lookup = $self->load_faindex_from_fasta();
+    }
+    if(! %{$faindex_lookup}) {
+      throw "Cannot generate a lookup from a .fai file or from the fasta file ".$self->file();
+    }
+    $self->{lookup} = $faindex_lookup;
+    if($self->write_index_to_disk()) {
+      $self->write_faindex();
+    }
+  }
+  else {
+    $self->{lookup} = $faindex_lookup;
+  }
+  return $self->{lookup};
+}
+
+=head2 load_from_faindex
+
+  Description : Loads the lookup index from a .fai file. This must be in the same location
+                as the fasta file with a .fai extension. Please see samtools for more format
+                information or the module description.
+
+=cut
+
+sub load_from_faindex {
+  my ($self) = @_;
+  my $index = $self->index_path($self->file());
+  return {} if ! -f $index;
+  my $contents = slurp($index);
+  open my $fh, '<', \$contents or throw "Cannot open contents as an in-memory file: $!";
+  my $lookup = $self->_load_faindex_from_fh($fh);
+  close $fh;
+  return $lookup;
+}
+
+=head2 _load_faindex_from_fh
+
+  Description : Loads the .fai index from a given file handle
+
+=cut
+
+sub _load_faindex_from_fh {
+  my ($self, $fh) = @_;
+  throw "No file handle given" unless $fh;
+  my %lookup;
+  iterate_lines($fh, sub {
+    my ($line) = @_;
+    chomp $line;
+    my ($id,$size,$location,$bases_per_line,$bytes_per_line) = $line =~ /^(.+) \s+ (\d+) \s+ (\d+) \s+ (\d+) \s+ (\d+) $/xms;
+    # force numerification. Remember these values are from a text file
+    $lookup{$id} = [$size+0, $location+0, $bases_per_line+0, $bytes_per_line+0, $id];
+  });
+  return \%lookup;
+}
+
+=head2 load_faindex_from_fasta
+
+  Description : Iterates the given FASTA file looking for occurances of
+                fasta record headers. We then record the start of DNA
+                as a file offset, the size of the sequence, the number of
+                bases per line and the number of bytes per line. This is
+                identical to samtool's faidx command. Please note that
+                samtools will do this a lot faster than this implementation
+                as that's C and this is not.
+
+=cut
+
+sub load_faindex_from_fasta {
+  my ($self) = @_;
+  my %lookup;
+  my $fasta_file = $self->file();
+  my $current_values;
+  work_with_file($fasta_file, 'r', sub {
+    my ($fh) = @_;
+    my ($line_number, $offset, $blank_line, $mismatched_lengths) = (0,0,0,0);
+    while(my $line = <$fh>) {
+      $line_number++;
+      my $length = bytes::length($line);
+
+      # Check for a header
+      if($line =~ /^>(.+?)\s+/) {
+        my $id = $1;
+        # Reset the blank line and mismatched booleans since we're starting a new record
+        ($blank_line, $mismatched_lengths) = (0,0);
+        # Create a new current values array & add it to the hash
+        # values are [sequence length, offset, bases per line, bytes per line, fasta id]
+        $current_values = [0,-1,-1,-1,$id];
+        $lookup{$id} = $current_values;
+      }
+      #Check for a blank line
+      elsif(! $current_values && $line =~ /^\s+$/) {
+        # Blank!
+        warning "Found whitespace at line $line_number. Consider trimming";
+      }
+      #If not either we must be in sequence
+      else {
+        
+        # If current record offset is set to -1 then we must set it to the current offset
+        if ($current_values->[1] == -1) {
+          $current_values->[1] = $offset;
+        }
+        
+        # Minus whitespace gives us bp length
+        my $bp_length = ($length-1);
+        $current_values->[0] += $bp_length;
+        
+        # Already seen a line in the record
+        if($current_values->[2] > -1) {
+          # Check if we've seen a problem. Only way out of this is to continue
+          # seeing blank lines until we hit another record. If not instant fail
+          if($blank_line || $mismatched_lengths) {
+            if($bp_length == 0) {
+              # set the line number of blank line for later error reporting
+              $blank_line = $line_number;
+            }
+            else {
+              my $id = $current_values->[4];
+              if($blank_line) {
+                throw "FASTA record $id is misformatted. Line $blank_line is blank and embedded within a record. Please fix before rerunning this command";
+              }
+              my $recorded_length = $current_values->[2];
+              throw "FASTA record $id is misformatted. Line $mismatched_lengths is different to the detected record length $recorded_length. Please fix before rerunning";
+            }
+          }
+          
+          # Mismatched length detection
+          if($current_values->[2] != $bp_length) {
+            $mismatched_lengths = $line_number;
+            if($bp_length == 0) {
+              $blank_line = $line_number;
+            }
+          }
+        }
+        # First line in the FASTA record
+        else {
+          $current_values->[2] = $bp_length; #bases per line
+          $current_values->[3] = $length; #bytes per line
+        }
+      }
+      $offset += $length;
+    }
+  });
+  return \%lookup;
+}
+
+=head2 write_faindex
+
+  Description : Writes the .fai index out to disk. Each line is a tab separated record recording 
+                the id, size, location (file offset), bases per line and bytes per line of each
+                FASTA record. This is compatible with samtools faidx. Values are stored according
+                to their position in the file.
+
+=cut
+
+sub write_faindex {
+  my ($self) = @_;
+  my $lookup = $self->lookup();
+  my $fasta_file = $self->file();
+  my $index = $fasta_file.'.'.$self->index_suffix();
+  work_with_file($index, 'w', sub {
+    my ($fh) = @_;
+    my @entries = sort { $a->[1] <=> $b->[1] } values %{$lookup};
+    foreach my $entry (@entries) {
+      my ($size, $location, $bases_per_line, $bytes_per_line, $id) = @{$entry};
+      print $fh sprintf("%s\t%d\t%d\t%d\t%d\n", $id, $size, $location, $bases_per_line, $bytes_per_line);
+    }
+    return;
+  });
+  return;
+}
+
+=head2 fetch_seq
+
+  Arg [1]     : String; $id. Identifier of the sequence in the FASTA file
+  Arg [2]     : Integer; $q_start. The start of the region to find
+  Arg [3]     : Integer; $q_length. The length of the region to fetch
+  Description : The guts. We convert the requested start and length for an ID into
+                a file position start and end. We seek to the start and read the
+                requested sequence as a single operation. Line terminators are then
+                substituted out and a Scalar reference handed back (de-reference to
+                get to the DNA).
+                
+                All sequence is uppercased before returning.
+
+=cut
+
+sub fetch_seq {
+  my ($self, $id, $q_start, $q_length) = @_;
+
+  my $lookup = $self->lookup();
+  my $info = $lookup->{$id};
+  if(! $info) {
+    throw "Cannot convert the $id into a valid lookup. Abort!";
+  }
+  my ($size, $location, $bases_per_line, $bytes_per_line) = @{$info};
+
+  my $q_end = ($q_start + $q_length) - 1;
+  # We can never request a region larger than the sequence length
+  if($q_end > $size) {
+    $q_end = $size;
+  }
+  
+  my $file = $self->file();
+
+  my $line_start = int(($q_start - 1) / $bases_per_line);
+  my $line_start_position = ($q_start-1) % $bases_per_line;
+
+  my $line_end = int(($q_end - 1) / $bases_per_line);
+  my $line_end_position = ($q_end-1) % $bases_per_line;
+  
+  my $offset = $location + ($line_start * $bytes_per_line) + $line_start_position;
+  my $end = $location + ($line_end * $bytes_per_line) + $line_end_position;
+  my $length = ($end - $offset)+1;
+
+  #Get sequence. ATMO this is a FH but why not a HTTP server in the future?
+  my $seq_ref = $self->_read_from_source($file, $offset, $length);
+  #Cleanup
+  chomp ${$seq_ref};
+  ${$seq_ref} =~ s/$INPUT_RECORD_SEPARATOR//g;
+  ${$seq_ref} = uc(${$seq_ref}) if $self->uppercase_sequence();
+  return $seq_ref;
+}
+
+# Open file, seek, read length and close filehandle.
+# Override to read from alternative sources of FASTA formatted data
+# indexed using FAIDX from sources like HTTP
+sub _read_from_source {
+  my ($self, $location, $offset, $length) = @_;
+  my $persist_fh = $self->persist_fh();
+  my $fh;
+  if($persist_fh && exists $self->{fh}) {
+    $fh = $self->{fh};
+  }
+  else {
+    open $fh, '<', $location or throw "Cannot open $location for reading: $!";
+    $self->{fh} = $fh if $persist_fh;
+  }
+  
+  my $seq;
+  seek($fh, $offset, 0);
+  read($fh, $seq, $length);
+  close $fh if ! $persist_fh;
+  
+  return \$seq;
+}
+
+sub DESTROY {
+  my ($self) = @_;
+  close $self->{fh} if $self->{fh};
+}
+
+1;

--- a/modules/t/fastaSequenceAdaptor.t
+++ b/modules/t/fastaSequenceAdaptor.t
@@ -72,9 +72,9 @@ my $SA = $dba->get_SliceAdaptor();
     dies_ok { $dba->get_SequenceAdaptor()->store() } 'Call should die due to FASTASequenceAdaptor being in place';
 
     # Drill into the object and look at the cache
-    my $cache_key = $sa->{seq_cache}->FIRSTKEY();
+    my ($cache_key) = keys %{$sa->{seq_cache}};
     my $expected_length = 1 << $power;
-    is(length(${$sa->{seq_cache}->FETCH($cache_key)}), $expected_length, 'Checking length of cached sequence');
+    is(length(${$sa->{seq_cache}->{$cache_key}}), $expected_length, 'Checking length of cached sequence');
   });
 }
 

--- a/modules/t/fastaSequenceAdaptor.t
+++ b/modules/t/fastaSequenceAdaptor.t
@@ -1,0 +1,81 @@
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use Bio::EnsEMBL::Test::TestUtils;
+use Bio::EnsEMBL::Test::MultiTestDB;
+
+use File::Spec;
+use File::Temp qw/:seekable tempdir/;
+use Bio::EnsEMBL::Utils::IO::FASTASerializer;
+use Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor;
+use Bio::EnsEMBL::Utils::IO::FileFaidx;
+use Bio::EnsEMBL::Utils::IO qw/work_with_file/;
+
+# "Globals"
+my $multi_db = Bio::EnsEMBL::Test::MultiTestDB->new;
+my $dba = $multi_db->get_DBAdaptor('core');
+
+my $CHR           = '20';
+my $START         = 30_220_000;
+my $END           = 31_200_000;
+my $STRAND        = 1;
+
+my $DIR = tempdir( CLEANUP => 1 );
+my $FASTA_FILE = File::Spec->catfile($DIR, 'chromosome.fa');
+my $SA = $dba->get_SliceAdaptor();
+
+# Write sequence to a file and index
+{
+  work_with_file($FASTA_FILE, 'w', sub {
+    my ($fh) = @_;
+    my $fasta = Bio::EnsEMBL::Utils::IO::FASTASerializer->new($fh, sub {
+      my ($slice) = @_;
+      return $slice->seq_region_name();
+    });
+    my $slice = $SA->fetch_by_region('chromosome', $CHR);
+    $fasta->print_Seq($slice);
+  });
+}
+
+# Now index and compare
+{
+  my $fidx = Bio::EnsEMBL::Utils::IO::FileFaidx->new($FASTA_FILE);
+  my $slice = $SA->fetch_by_region('chromosome', $CHR, $START, $END, $STRAND);
+  my $db_seq = $slice->seq();
+
+  # Setup switchable adaptor and test
+  my $power = 20;
+  my $fsa = Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor->new($fidx, $power); #request 1MB cache chunks
+  $dba->switch_adaptor('sequence', $fsa, sub {
+    my $fasta_seq = $slice->seq();
+    is($db_seq, $fasta_seq, 'Checking both adaptors return the same sequence');
+    
+    my $sa = $dba->get_SequenceAdaptor();
+    ok($sa->isa('Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor'), 'Checking replacement worked as expected');
+    dies_ok { $dba->get_SequenceAdaptor()->store() } 'Call should die due to FASTASequenceAdaptor being in place';
+
+    # Drill into the object and look at the cache
+    my $cache_key = $sa->{seq_cache}->FIRSTKEY();
+    my $expected_length = 1 << $power;
+    is(length(${$sa->{seq_cache}->FETCH($cache_key)}), $expected_length, 'Checking length of cached sequence');
+  });
+}
+
+done_testing();

--- a/modules/t/fileFaidx.t
+++ b/modules/t/fileFaidx.t
@@ -1,0 +1,123 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Differences;
+use Test::Exception;
+
+use Bio::EnsEMBL::Utils::IO qw/slurp/;
+use Bio::EnsEMBL::Test::TestUtils;
+use File::Temp qw/:seekable tempdir/;
+
+use Bio::EnsEMBL::Utils::IO::FileFaidx;
+
+my $dir = tempdir( CLEANUP => 1 );
+
+# Test a working FASTA file with an known index
+{
+  my $fasta = <<'FASTA';
+>TEST1
+ACTGG
+ACTGt
+A
+
+>TEST2
+AAAA
+AAAA
+AAAA
+>TEST3
+TTTTTTTTTTTTTTTTTTTT
+FASTA
+
+  my ($tmp_fh, $fsa) = to_fsa($fasta);
+  $fsa->write_index_to_disk(1);
+  my $expected_lookup = {TEST1 => [11,7,5,6,'TEST1'], TEST2=> [12,29,4,5,'TEST2'], TEST3 => [20,51,20,21,'TEST3']};
+  eq_or_diff($fsa->lookup(), $expected_lookup, 'Lookup generated correctly');
+  
+  #Check that the index was written correct
+  my $expected_index = <<INDEX;
+TEST1\t11\t7\t5\t6
+TEST2\t12\t29\t4\t5
+TEST3\t20\t51\t20\t21
+INDEX
+  my $actual_index = slurp("${tmp_fh}.fai");
+  eq_or_diff($actual_index, $expected_index, 'Serialised index conforms to the expected format');
+  
+  # Check a non-generating system reading the above index back in
+  
+  my $non_generating_fsa = Bio::EnsEMBL::Utils::IO::FileFaidx->new("$tmp_fh");
+  $non_generating_fsa->no_generation(1);
+  {
+    #make sure we properly mess up the code which loads the data from FASTA and the test will still work
+    no warnings qw/redefine/;
+    local *Bio::EnsEMBL::Utils::IO::FileFaidx::load_faindex_from_fasta = sub {
+      die "This cannot happen";
+    };
+    eq_or_diff($non_generating_fsa->lookup(), $expected_lookup, 'Lookup was read from the file system');
+  }
+
+  my $actual_seq = $non_generating_fsa->fetch_seq('TEST1', 6, 6);
+  eq_or_diff(${$actual_seq}, 'ACTGTA', 'Fetched sequence as expected');
+  
+  # Checking that fetches end at the limits of the sequence and we ignore lowercasing
+  eq_or_diff(${$non_generating_fsa->fetch_seq('TEST1', 10, 20)}, 'TA', 'Reads off the end do not crash and we ignore case from the file');
+
+  # Check that we can still get lower-cased characters if we need to
+  $non_generating_fsa->uppercase_sequence(0);
+  eq_or_diff(${$non_generating_fsa->fetch_seq('TEST1', 10, 11)}, 'tA', 'uppercase_sequence() is off so we can get lower-cased values back');
+}
+
+# 1st broken index. In-record whitespace
+{
+  my $fasta = <<'FASTA';
+>TEST
+ACTG
+
+ACTG
+A
+FASTA
+  my ($fh, $fsa) = to_fsa($fasta);
+  throws_ok { $fsa->lookup() } qr/Line 3 is blank/, 'Inline whitespace detected';
+}
+
+# 2nd broken index. Mismatched length records
+{
+  my $fasta = <<'FASTA';
+>Test
+ACTGTTCG
+ATTG
+ATCGTCCC
+ATTG
+FASTA
+  my ($fh, $fsa) = to_fsa($fasta);
+  throws_ok { $fsa->lookup() } qr/Line 3 is different to the detected record length 8/, 'Mismatched record length detected';
+}
+
+# 3rd broken index. Leading whitespace
+{
+  my $fasta = <<'FASTA';
+
+
+>Test
+ACTGTTCG
+FASTA
+  my ($fh, $fsa) = to_fsa($fasta);
+  #we warn twice; once for line 1 and once for line 2
+  warns_like { $fsa->lookup() } qr/Found whitespace at line 1.+Consider trimming.+line 2/s, 'Leading FASTA whitespace detcted';
+}
+
+# 4th broken index. Not there
+{
+  throws_ok { my $fsa = Bio::EnsEMBL::Utils::IO::FileFaidx->new("/a/random/location/yeah") } qr/No file found at/, 'No file means exception';
+}
+
+sub to_fsa {
+  my ($string) = @_;
+  my $tmp = File::Temp->new(UNLINK => 1, SUFFIX => '.fa', DIR => $dir);
+  print $tmp $string;
+  $tmp->seek(0, SEEK_SET); #rewind to start
+  my $fsa = Bio::EnsEMBL::Utils::IO::FileFaidx->new("$tmp");
+  return ($tmp, $fsa);
+}
+
+done_testing();

--- a/modules/t/slice.t
+++ b/modules/t/slice.t
@@ -23,6 +23,7 @@ use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::ProjectionSegment;
 use Test::Exception;
+use Test::Differences;
 
 our $verbose = 0;
 
@@ -246,7 +247,7 @@ is(length($seq), $slice->length, "Sequence is correct length");
 $seq = reverse $seq;  #reverse complement seq
 $seq =~ tr/ACTG/TGAC/; 
 
-is($seq, $invert_seq, "revcom same as seq on inverted slice");
+eq_or_diff($seq, $invert_seq, "revcom same as seq on inverted slice");
 
 #
 # Test Slice::subseq
@@ -260,7 +261,7 @@ ok(length $sub_seq == (2*$SPAN) + 1 );
 $sub_seq = reverse $sub_seq;
 $sub_seq =~ tr/ACTG/TGAC/;
 
-ok($sub_seq eq $invert_sub_seq);
+eq_or_diff($sub_seq, $invert_sub_seq);
 
 #
 # Test Slice::get_all_PredictionTranscripts


### PR DESCRIPTION
the alternative_sequence_store branch has been successfully tested with the fasta dumping pipeline and the xref pipeline, the updated clear_cache method seems to behave
I now need a sanity check that reverting the revert commit does the right thing and we have not lost anything