### PR TITLE
Master

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
@@ -210,6 +210,8 @@ sub print_feature {
                     my $trans_spliced = $feature->transcript->get_all_Attributes('trans_spliced');
                     if (scalar(@$trans_spliced)) {
                       $value = $so_term . ':' . join('_', $value, $feature->seq_region_name, $feature->seq_region_strand);
+                    } else {
+                      $value = $so_term . ':' . $value;
                     }
                   } else {
                     $value = $so_term . ':' . $value;


### PR DESCRIPTION
I hope somebody somewhere appreciates all this work to cater for trans-spliced transcripts... This change is required because CDS features within a trans-spliced transcript can have different strands (or different seq region names, although that's not the case with fruit fly). The CDS ID is ordinarily the translation stable ID, which implies that all the CDS rows are a single feature; which cannot therefore have multiple strands...