### PR TITLE
Fix for sub_Slice when slice->start is <1

### DIFF
--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -1270,12 +1270,14 @@ sub constrain_to_seq_region {
 sub sub_Slice {
   my ( $self, $start, $end, $strand ) = @_;
 
-  if( $start < 1 || $start > $self->{'end'} ) {
+  my $length = $self->length();
+
+  if( $start < 1 || $start > $length ) {
     # throw( "start argument not valid" );
     return undef;
   }
 
-  if( $end < $start || $end > $self->{'end'} ) {
+  if( $end < $start || $end > $length ) {
     # throw( "end argument not valid" )
     return undef;
   }

--- a/modules/t/strainSlice.t
+++ b/modules/t/strainSlice.t
@@ -78,7 +78,7 @@ ok(scalar @$afs == 46, 'get_all_AllelelFeatures_Slice with_coverage');
 $afs = $A_J->get_all_differences_StrainSlice($FVB_NJ);
 ok(scalar @$afs == 53, 'get_all_differences_StrainSlice');
 
-my $sub_Slice = $A_J->sub_Slice(20380187, 20380197, 1);
+my $sub_Slice = $A_J->sub_Slice(2, 12, 1);
 ok(length($sub_Slice->seq) == 11, 'sub_Slice length');
 
 my $ref_subseq = $A_J->ref_subseq(20380187, 20380197, 1);


### PR DESCRIPTION
If a slice has start<1, then it is valid to request an end that is
&gt; slice->end as long as it is <=slice->length, since sub_Slice args
are relative to the original slice.

Please do correct me if I'm wrong here! I am thoroughly confused by the concept of slices with start<1 to begin with :-)