### PR TITLE
Enscoresw 1381

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
@@ -131,7 +131,9 @@ use constant NUM_HIGH_SCORERS => 20;
   Arg [2]     : (optional) string $type
   Example     : none
   Description : Retrives an ArchiveStableId that is the latest incarnation of
-                given stable_id.
+                given stable_id. If the lookup fails, attempts to check for a
+                version id delimited by a period (.) and lookup again using the
+                version id.
   Returntype  : Bio::EnsEMBL::ArchiveStableId or undef if not in database
   Exceptions  : none
   Caller      : general
@@ -141,6 +143,39 @@ use constant NUM_HIGH_SCORERS => 20;
 =cut
 
 sub fetch_by_stable_id {
+  my $self = shift;
+  my $stable_id = shift;
+
+  my $arch_id = $self->_fetch_by_stable_id($stable_id, @_);
+
+  # If we didn't get anything back, desperately try to see if there's
+  # a version number in the stable_id
+  if(!defined($arch_id) && (my $vindex = rindex($stable_id, '.'))) {
+      $arch_id = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
+						   substr($stable_id,$vindex+1),
+						   @_);
+  }
+
+  return $arch_id;
+}
+
+=head2 _fetch_by_stable_id
+
+  Arg [1]     : string $stable_id
+  Arg [2]     : (optional) string $type
+  Example     : none
+  Description : Retrives an ArchiveStableId that is the latest incarnation of
+                given stable_id. Helper function to fetch_by_stable_id, should
+                not be directly called.
+  Returntype  : Bio::EnsEMBL::ArchiveStableId or undef if not in database
+  Exceptions  : none
+  Caller      : general
+  Status      : At Risk
+              : under development
+
+=cut
+
+sub _fetch_by_stable_id {
   my $self = shift;
   my $stable_id = shift;
   
@@ -1598,13 +1633,13 @@ sub _resolve_type {
     }
 
   # standard Ensembl IDs
-  } elsif ($stable_id =~ /.*G\d+$/) {
+  } elsif ($stable_id =~ /.*G\d+(\.\d+)?$/) {
     $id_type = "Gene";
-  } elsif ($stable_id =~ /.*T\d+$/) { 
+  } elsif ($stable_id =~ /.*T\d+(\.\d+)?$/) { 
     $id_type = "Transcript";
-  } elsif ($stable_id =~ /.*P\d+$/) { 
+  } elsif ($stable_id =~ /.*P\d+(\.\d+)?$/) { 
     $id_type = "Translation";
-  } elsif ($stable_id =~ /.*E\d+$/) { 
+  } elsif ($stable_id =~ /.*E\d+(\.\d+)?$/) { 
     $id_type = "Exon";
 
   # if guessing fails, look in db

--- a/modules/Bio/EnsEMBL/DBSQL/ExonAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ExonAdaptor.pm
@@ -156,9 +156,50 @@ sub fetch_by_stable_id {
   $self->bind_param_generic_fetch($stable_id,SQL_VARCHAR);
   my ($exon) = @{ $self->generic_fetch($constraint) };
 
+  # If we didn't get anything back, desperately try to see if there's
+  # a version number in the stable_id
+  if(!defined($exon) && (my $vindex = rindex($stable_id, '.'))) {
+      $exon = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
+						substr($stable_id,$vindex+1));
+  }
+
   return $exon;
 }
 
+
+=head2 fetch_by_stable_id_version
+
+  Arg [1]    : String $id 
+               The stable ID of the exon to retrieve
+  Arg [2]    : Integer $version
+               The version of the stable_id to retrieve
+  Example    : $exon = $exon_adaptor->fetch_by_stable_id('ENSE0000988221', 3);
+  Description: Retrieves an exon object from the database via its stable id and version.
+               The exon will be retrieved in its native coordinate system (i.e.
+               in the coordinate system it is stored in the database). It may
+               be converted to a different coordinate system through a call to
+               transform() or transfer(). If the exon is not found
+               undef is returned instead.
+  Returntype : Bio::EnsEMBL::Exon or undef
+  Exceptions : if we cant get the exon in given coord system
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub fetch_by_stable_id_version {
+    my ($self, $stable_id, $version) = @_;
+
+    # Enforce that version be numeric
+    return unless($version =~ /^\d+$/);
+
+    my $constraint = "e.stable_id = ? AND e.version = ? AND e.is_current = 1";
+    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
+    $self->bind_param_generic_fetch($version, SQL_INTEGER);
+    my ($exon) = @{$self->generic_fetch($constraint)};
+
+    return $exon;
+}
 
 =head2 fetch_all_versions_by_stable_id 
 

--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -248,7 +248,48 @@ sub fetch_by_stable_id {
   $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
   my ($gene) = @{$self->generic_fetch($constraint)};
 
+  # If we didn't get anything back, desperately try to see if there's
+  # a version number in the stable_id
+  if(!defined($gene) && (my $vindex = rindex($stable_id, '.'))) {
+      $gene = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
+						substr($stable_id,$vindex+1));
+  }
+
   return $gene;
+}
+
+=head2 fetch_by_stable_id_version
+
+  Arg [1]    : String $id 
+               The stable ID of the gene to retrieve
+  Arg [2]    : Integer $version
+               The version of the stable_id to retrieve
+  Example    : $gene = $gene_adaptor->fetch_by_stable_id('ENSG00000148944', 14);
+  Description: Retrieves a gene object from the database via its stable id and version.
+               The gene will be retrieved in its native coordinate system (i.e.
+               in the coordinate system it is stored in the database). It may
+               be converted to a different coordinate system through a call to
+               transform() or transfer(). If the gene or exon is not found
+               undef is returned instead.
+  Returntype : Bio::EnsEMBL::Gene or undef
+  Exceptions : if we cant get the gene in given coord system
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub fetch_by_stable_id_version {
+    my ($self, $stable_id, $version) = @_;
+
+    # Enforce that version be numeric
+    return unless($version =~ /^\d+$/);
+
+    my $constraint = "g.stable_id = ? AND g.version = ? AND g.is_current = 1";
+    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
+    $self->bind_param_generic_fetch($version, SQL_INTEGER);
+    my ($gene) = @{$self->generic_fetch($constraint)};
+
+    return $gene;
 }
 
 =head2 fetch_all_by_source

--- a/modules/Bio/EnsEMBL/DBSQL/OperonTranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/OperonTranscriptAdaptor.pm
@@ -150,12 +150,12 @@ sub list_seq_region_ids {
 
   Arg [1]    : String $id 
                The stable ID of the operon_transcript to retrieve
-  Example    : $operon_transcript = $operon_transcript_adaptor->fetch_by_stable_id('ENSG00000148944');
+  Example    : $operon_transcript = $operon_transcript_adaptor->fetch_by_stable_id('T16152-16153-4840');
   Description: Retrieves a operon_transcript object from the database via its stable id.
                The operon_transcript will be retrieved in its native coordinate system (i.e.
                in the coordinate system it is stored in the database). It may
                be converted to a different coordinate system through a call to
-               transform() or transfer(). If the operon_transcript or exon is not found
+               transform() or transfer(). If the operon_transcript is not found
                undef is returned instead.
   Returntype : Bio::EnsEMBL::OperonTranscript or undef
   Exceptions : if we cant get the operon_transcript in given coord system
@@ -171,7 +171,48 @@ sub fetch_by_stable_id {
 	$self->bind_param_generic_fetch( $stable_id, SQL_VARCHAR );
 	my ($operon_transcript) = @{ $self->generic_fetch($constraint) };
 
+	# If we didn't get anything back, desperately try to see if there's
+	# a version number in the stable_id
+	if(!defined($operon_transcript) && (my $vindex = rindex($stable_id, '.'))) {
+	    $operon_transcript = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
+								   substr($stable_id,$vindex+1));
+	}
+
 	return $operon_transcript;
+}
+
+=head2 fetch_by_stable_id_version
+
+  Arg [1]    : String $id 
+               The stable ID of the operon_transcript to retrieve
+  Arg [2]    : Integer $version
+               The version of the stable_id to retrieve
+  Example    : $operon_transcript = $operon_transcript_adaptor->fetch_by_stable_id('T16152-16153-4840', 2);
+  Description: Retrieves an operon_transcript object from the database via its stable id and version.
+               The operon_transcript will be retrieved in its native coordinate system (i.e.
+               in the coordinate system it is stored in the database). It may
+               be converted to a different coordinate system through a call to
+               transform() or transfer(). If the operon_transcript is not found
+               undef is returned instead.
+  Returntype : Bio::EnsEMBL::OperonTranscript or undef
+  Exceptions : if we cant get the operon_transcript in given coord system
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub fetch_by_stable_id_version {
+    my ($self, $stable_id, $version) = @_;
+
+    # Enforce that version be numeric
+    return unless($version =~ /^\d+$/);
+
+    my $constraint = "o.stable_id = ? AND o.version = ?";
+    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
+    $self->bind_param_generic_fetch($version, SQL_INTEGER);
+    my ($operon_transcript) = @{$self->generic_fetch($constraint)};
+
+    return $operon_transcript;
 }
 
 =head2 fetch_by_name

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
@@ -169,9 +169,51 @@ sub fetch_by_stable_id {
 
   my ($transcript) = @{ $self->generic_fetch($constraint) };
 
+  # If we didn't get anything back, desperately try to see if there's
+  # a version number in the stable_id
+  if(!defined($transcript) && (my $vindex = rindex($stable_id, '.'))) {
+      $transcript = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
+						substr($stable_id,$vindex+1));
+  }
+
   return $transcript;
 }
 
+
+=head2 fetch_by_stable_id_version
+
+  Arg [1]    : String $id 
+               The stable ID of the transcript to retrieve
+  Arg [2]    : Integer $version
+               The version of the stable_id to retrieve
+  Example    : $tr = $tr_adaptor->fetch_by_stable_id('ENST00000309301', 3);
+  Description: Retrieves a transcript object from the database via its 
+               stable id and version.
+               The transcript will be retrieved in its native coordinate system (i.e.
+               in the coordinate system it is stored in the database). It may
+               be converted to a different coordinate system through a call to
+               transform() or transfer(). If the transcript is not found
+               undef is returned instead.
+  Returntype : Bio::EnsEMBL::Transcript or undef
+  Exceptions : if we cant get the transcript in given coord system
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub fetch_by_stable_id_version {
+    my ($self, $stable_id, $version) = @_;
+
+    # Enforce that version be numeric
+    return unless($version =~ /^\d+$/);
+
+    my $constraint = "t.stable_id = ? AND t.version = ? AND t.is_current = 1";
+    $self->bind_param_generic_fetch($stable_id, SQL_VARCHAR);
+    $self->bind_param_generic_fetch($version, SQL_INTEGER);
+    my ($transcript) = @{$self->generic_fetch($constraint)};
+
+    return $transcript;
+}
 
 sub fetch_all {
   my ($self) = @_;
@@ -216,7 +258,7 @@ sub fetch_all_versions_by_stable_id {
                   ('ENSP00000311007');
   Description: Retrieves a Transcript object using the stable identifier of
                its translation.
-  Returntype : Bio::EnsEMBL::Transcript
+  Returntype : Bio::EnsEMBL::Transcript or undef
   Exceptions : none
   Caller     : general
   Status     : Stable
@@ -242,11 +284,60 @@ sub fetch_by_translation_stable_id {
   $sth->finish;
   if ($id){
     return $self->fetch_by_dbID($id);
+  } elsif(my $vindex = rindex($transl_stable_id, '.')) {
+    return $self->fetch_by_translation_stable_id_version(substr($transl_stable_id,0,$vindex),
+							 substr($transl_stable_id,$vindex+1));
+  } else {
+      return undef;
+  }
+}
+
+=head2 fetch_by_translation_stable_id_version
+
+  Arg [1]    : String $transl_stable_id
+               The stable identifier of the translation of the transcript to 
+               retrieve
+  Arg [2]    : Integer $version
+               The version of the translation of the transcript to retrieve
+  Example    : my $tr = $tr_adaptor->fetch_by_translation_stable_id_version
+                  ('ENSP00000311007', 2);
+  Description: Retrieves a Transcript object using the stable identifier and
+               version of its translation.
+  Returntype : Bio::EnsEMBL::Transcript or undef
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub fetch_by_translation_stable_id_version {
+  my ($self, $transl_stable_id, $transl_version ) = @_;
+
+  # Enforce that version be numeric
+  return unless($transl_version =~ /^\d+$/);
+
+  my $sth = $self->prepare(qq(
+      SELECT t.transcript_id
+      FROM   translation tl,
+             transcript t
+      WHERE  tl.stable_id = ?
+      AND    tl.version = ?
+      AND    tl.transcript_id = t.transcript_id
+      AND    t.is_current = 1
+  ));
+
+  $sth->bind_param(1, $transl_stable_id, SQL_VARCHAR);
+  $sth->bind_param(2, $transl_version, SQL_INTEGER);
+  $sth->execute();
+
+  my ($id) = $sth->fetchrow_array;
+  $sth->finish;
+  if ($id){
+    return $self->fetch_by_dbID($id);
   } else {
     return undef;
   }
 }
-
 
 =head2 fetch_by_translation_id
 

--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -775,6 +775,44 @@ sub fetch_by_stable_id {
    return $self->fetch_by_Transcript($transcript);
 }
 
+=head2 fetch_by_stable_id_version
+
+  Arg [1]    : String $id 
+               The stable ID of the gene to retrieve
+  Arg [2]    : Integer $version
+               The version of the stable_id to retrieve
+  Example    : $gene = $gene_adaptor->fetch_by_stable_id('ENSG00000148944', 14);
+  Description: Retrieves a gene object from the database via its stable id and version.
+               The gene will be retrieved in its native coordinate system (i.e.
+               in the coordinate system it is stored in the database). It may
+               be converted to a different coordinate system through a call to
+               transform() or transfer(). If the gene or exon is not found
+               undef is returned instead.
+  Returntype : Bio::EnsEMBL::Gene or undef
+  Exceptions : if we cant get the gene in given coord system
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub fetch_by_stable_id_version {
+   my ($self,$stable_id, $version) = @_;
+
+   if(!$stable_id) {
+     throw("stable id argument is required");
+   }
+
+   # Enforce that version be numeric
+   return unless($version =~ /^\d+$/);
+
+   my $transcript_adaptor = $self->db()->get_TranscriptAdaptor();
+   my $transcript = 
+       $transcript_adaptor->fetch_by_translation_stable_id_version($stable_id, $version);
+
+   return if(!$transcript);
+
+   return $self->fetch_by_Transcript($transcript);
+}
 
 =head2 fetch_all_by_Transcript_list
 

--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -3171,7 +3171,8 @@ sub _core_get_species_and_object_type {
   if(@results) {
       return @results;
   } elsif(my $vindex = rindex($stable_id, '.')) {
-      return $self->_core_get_species_and_object_type_worker(substr($stable_id,0,$vindex), $known_type, $dba);
+      return $self->_core_get_species_and_object_type_worker(substr($stable_id,0,$vindex), $known_type, $dba)
+	  if(substr($stable_id,$vindex+1) =~ /^\d+$/);
   }
 
   return;
@@ -3213,7 +3214,8 @@ sub _compara_get_species_and_object_type {
   if(@results) {
       return @results;
   } elsif(my $vindex = rindex($stable_id, '.')) {
-      return $self->_compara_get_species_and_object_type_worker(substr($stable_id,0,$vindex), $known_type, $dba);
+      return $self->_compara_get_species_and_object_type_worker(substr($stable_id,0,$vindex), $known_type, $dba)
+	  if(substr($stable_id,$vindex+1) =~ /^\d+$/);
   }
 
   return;

--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -3159,9 +3159,27 @@ sub archive_id_lookup {
 }
 
 
+# A level of abstraction because we need to test the stable_id as-is and then
+# try to chop off a version id if nothing is return, and try again
 
-# Loop over a known set of object types for a core DB until we find a hit 
 sub _core_get_species_and_object_type {
+  my ($self, $stable_id, $known_type, $dba) = @_;
+
+  # Try looking up the species with the stable_is, as-is
+  my @results = $self->_core_get_species_and_object_type_worker($stable_id, $known_type, $dba);
+
+  if(@results) {
+      return @results;
+  } elsif(my $vindex = rindex($stable_id, '.')) {
+      return $self->_core_get_species_and_object_type_worker(substr($stable_id,0,$vindex), $known_type, $dba);
+  }
+
+  return;
+
+}
+
+# Loop over a known set of object types for a core DB until we find a hit
+sub _core_get_species_and_object_type_worker {
   my ($self, $stable_id, $known_type, $dba) = @_;
   my @types = defined $known_type ? ($known_type) : ('Gene', 'Transcript', 'Translation', 'Exon', 'Operon', 'OperonTranscript');
   my ($species, $final_type, $final_db_type);
@@ -3183,8 +3201,27 @@ sub _core_get_species_and_object_type {
   return;
 }
 
-# Loop over a known set of object types for a compara DB until we find a hit
+# A level of abstraction because we need to test the stable_id as-is and then
+# try to chop off a version id if nothing is return, and try again
+
 sub _compara_get_species_and_object_type {
+  my ($self, $stable_id, $known_type, $dba) = @_;
+
+  # Try looking up the species with the stable_is, as-is
+  my @results = $self->_compara_get_species_and_object_type_worker($stable_id, $known_type, $dba);
+
+  if(@results) {
+      return @results;
+  } elsif(my $vindex = rindex($stable_id, '.')) {
+      return $self->_compara_get_species_and_object_type_worker(substr($stable_id,0,$vindex), $known_type, $dba);
+  }
+
+  return;
+
+}
+
+# Loop over a known set of object types for a compara DB until we find a hit
+sub _compara_get_species_and_object_type_worker {
   my ($self, $stable_id, $known_type, $dba) = @_;
   my @types = defined $known_type ? ($known_type) : ('GeneTree');
   my ($species, $final_type, $final_db_type);

--- a/modules/t/archiveStableId.t
+++ b/modules/t/archiveStableId.t
@@ -215,6 +215,16 @@ ok( scalar(@assoc) == 2 and
 $asi = $asia->fetch_by_stable_id_version("P2", 1);
 ok( $asi->get_peptide eq 'PTWOVERSIONONE*' );
 
+#
+# Test looking up active ids
+#
+my $archive_obj = $asia->fetch_by_stable_id('ENSG00000171456');
+is($archive_obj->stable_id, 'ENSG00000171456', 'fetch_by_stable_id with active stable_id');
+ok($archive_obj->is_current, 'Is the current stable_id');
+
+$archive_obj = $asia->fetch_by_stable_id('ENSG00000171456.1');
+is($archive_obj->stable_id, 'ENSG00000171456', 'fetch_by_stable_id with active stable_id with version');
+ok($archive_obj->is_latest, 'Is the latest stable_id');
 
 #
 # debug helper

--- a/modules/t/exon.t
+++ b/modules/t/exon.t
@@ -242,6 +242,18 @@ $exon = $exonad->fetch_by_stable_id('ENSE00001109603');
 debug("fetch_by_stable_id");
 ok( $exon->dbID == 162033 );
 
+$exon = $exonad->fetch_by_stable_id('ENSE00001109603.1');
+ok($exon->dbID == 162033, 'fetch_by_stable_id with version');
+
+$exon = $exonad->fetch_by_stable_id('ENSE00001109603.1a');
+ok(!defined($exon), 'fetch_by_stable_id with bad version');
+
+$exon = $exonad->fetch_by_stable_id_version('ENSE00001109603', 1);
+ok($exon->dbID == 162033, 'fetch_by_stable_id_version with version');
+
+$exon = $exonad->fetch_by_stable_id_version('ENSE00001109603', '1a');
+ok(!defined($exon), 'fetch_by_stable_id_version with bad version');
+
 my @exons = @{ $exonad->fetch_all_versions_by_stable_id('ENSE00001109603') };
 debug("fetch_all_versions_by_stable_id");
 ok( scalar(@exons) == 1 );

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -939,7 +939,16 @@ SKIP: {
   #test the get_species_and_object_type method from the Registry
   my $registry = 'Bio::EnsEMBL::Registry';
   my ( $species, $object_type, $db_type ) = $registry->get_species_and_object_type('ENSG00000355555');
-  ok( $species eq 'homo_sapiens' && $object_type eq 'Gene');
+  is( $species, 'homo_sapiens', 'Test the get_species_and_object_type method from the Registry, species');
+  is( $object_type, 'Gene', 'Test the get_species_and_object_type method from the Registry, object_type');
+
+  ( $species, $object_type, $db_type ) = $registry->get_species_and_object_type('ENSG00000355555.1');
+  is( $species, 'homo_sapiens', 'Test the get_species_and_object_type method from the Registry with version, species');
+  is( $object_type, 'Gene', 'Test the get_species_and_object_type method from the Registry with version, object_type');
+
+  ( $species, $object_type, $db_type ) = $registry->get_species_and_object_type('ENSG00000355555.2');
+  ok( !defined($species), 'Test the get_species_and_object_type method from the Registry with wrong version, species');
+
 }
 
 # Testing compara dba retrieval

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -946,7 +946,7 @@ SKIP: {
   is( $species, 'homo_sapiens', 'Test the get_species_and_object_type method from the Registry with version, species');
   is( $object_type, 'Gene', 'Test the get_species_and_object_type method from the Registry with version, object_type');
 
-  ( $species, $object_type, $db_type ) = $registry->get_species_and_object_type('ENSG00000355555.2');
+  ( $species, $object_type, $db_type ) = $registry->get_species_and_object_type('ENSG00000355555.2a');
   ok( !defined($species), 'Test the get_species_and_object_type method from the Registry with wrong version, species');
 
 }

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -840,6 +840,18 @@ $gene = $ga->fetch_by_stable_id('ENSG00000355555');
 debug("fetch_by_stable_id");
 ok($gene->dbID == 18275);
 
+$gene = $ga->fetch_by_stable_id("ENSG00000171456.1");
+ok($gene->stable_id eq 'ENSG00000171456', "Fetch by stable_id with version");
+
+$gene = $ga->fetch_by_stable_id_version("ENSG00000171456", 1);
+ok($gene->stable_id eq 'ENSG00000171456', "fetch_by_stable_id_version");
+
+$gene = $ga->fetch_by_stable_id("ENSG00000171456.1a");
+ok(! defined($gene), "Fetch by stable_id with bad version");
+
+$gene = $ga->fetch_by_stable_id_version("ENSG00000171456", '1a');
+ok(! defined($gene), "fetch_by_stable_id_version, with bad version");
+
 @genes = @{$ga->fetch_all_versions_by_stable_id('ENSG00000355555')};
 debug("fetch_all_versions_by_stable_id");
 ok(scalar(@genes) == 1);

--- a/modules/t/operon.t
+++ b/modules/t/operon.t
@@ -99,6 +99,18 @@ $operon = $operon_adaptor->fetch_by_stable_id('16152-16153-4840');
 debug( "Operon->fetch_by_stable_id()" );
 ok( $operon );
 
+$operon = $operon_adaptor->fetch_by_stable_id('16152-16153-4840.1');
+ok($operon->stable_id eq '16152-16153-4840', 'fetch_by_stable_id with version');
+
+$operon = $operon_adaptor->fetch_by_stable_id('16152-16153-4840.1a');
+ok(! defined($operon), 'fetch_by_stable_id with bad version');
+
+$operon = $operon_adaptor->fetch_by_stable_id_version('16152-16153-4840', 1);
+ok($operon->stable_id eq '16152-16153-4840', 'fetch_by_stable_id_version with version');
+
+$operon = $operon_adaptor->fetch_by_stable_id_version('16152-16153-4840', '1a');
+ok(! defined($operon), 'fetch_by_stable_id_version with bad version');
+
 #19
 my @operons = @{ $operon_adaptor->fetch_all_versions_by_stable_id('16152-16153-4840') };
 debug("fetch_all_versions_by_stable_id");

--- a/modules/t/operon_transcript.t
+++ b/modules/t/operon_transcript.t
@@ -237,6 +237,18 @@ $operon_transcript = $ota->fetch_by_stable_id('T16152-16153-4840');
 debug( "OperonTranscript->fetch_by_stable_id()" );
 ok( $operon_transcript );
 
+$operon_transcript = $ota->fetch_by_stable_id('T16152-16153-4840.1');
+ok($operon_transcript->stable_id eq 'T16152-16153-4840', 'fetch_by_stable_id with version');
+
+$operon_transcript = $ota->fetch_by_stable_id('T16152-16153-4840.1a');
+ok(! defined($operon_transcript), 'fetch_by_stable_id with bad version');
+
+$operon_transcript = $ota->fetch_by_stable_id_version('T16152-16153-4840', 1);
+ok($operon_transcript->stable_id eq 'T16152-16153-4840', 'fetch_by_stable_id_version with version');
+
+$operon_transcript = $ota->fetch_by_stable_id_version('T16152-16153-4840', '1a');
+ok(! defined($operon_transcript), 'fetch_by_stable_id with bad version');
+
 #49
 @operon_transcripts = @{ $ota->fetch_all_versions_by_stable_id('T16152-16153-4840') };
 debug("fetch_all_versions_by_stable_id");

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -609,6 +609,18 @@ is( scalar(@transcripts), 1, 'Fetched all transcripts by stable_id' );
 $tr = $ta->fetch_by_translation_stable_id('ENSP00000355555');
 is( $tr->dbID, 21740, 'Fetched transcript by translation stable id' );
 
+$tr = $ta->fetch_by_translation_stable_id('ENSP00000355555.1');
+is( $tr->dbID, 21740, 'Fetched transcript by translation stable id with version' );
+
+$tr = $ta->fetch_by_translation_stable_id('ENSP00000355555.1a');
+ok( ! defined($tr), 'Fetched transcript by translation stable id with bad version' );
+
+$tr = $ta->fetch_by_translation_stable_id_version('ENSP00000355555', 1);
+is( $tr->dbID, 21740, 'Fetched transcript by translation stable id (version) with version' );
+
+$tr = $ta->fetch_by_translation_stable_id_version('ENSP00000355555', '1a');
+ok( ! defined($tr), 'Fetched transcript by translation stable id (version) with bad version' );
+
 @transcripts = @{ $ta->fetch_all_by_exon_stable_id('ENSE00001109603') };
 is( scalar(@transcripts), 1);
 is( $transcripts[0]->dbID, 21740, 'Fetched transcript by exon stable id' );
@@ -668,6 +680,18 @@ $tr = $ta->fetch_by_stable_id('ENST00000355555');
 is($tr->is_current, 1, 'Transcript is now current');   # 151
 
 $multi->restore;
+
+$tr = $ta->fetch_by_stable_id('ENST00000310998.1');
+ok($tr->stable_id eq 'ENST00000310998', 'Fetch by stable_id with version');
+
+$tr = $ta->fetch_by_stable_id('ENST00000310998.1a');
+ok(! defined($tr), 'Fetch by stable_id with bad version');
+
+$tr = $ta->fetch_by_stable_id_version('ENST00000310998', 1);
+ok($tr->stable_id eq 'ENST00000310998', 'fetch_by_stable_id_version');
+
+$tr = $ta->fetch_by_stable_id_version('ENST00000310998', '1a');
+ok(! defined($tr), 'fetch_by_stable_id_version with bad version');
 
 # UTR Tests
 {

--- a/modules/t/translation.t
+++ b/modules/t/translation.t
@@ -113,6 +113,12 @@ ok($translation && $translation->dbID() == 21734, 'fetch_by_stable_id with versi
 $translation = $ta->fetch_by_stable_id('ENSP00000201961.1a');
 ok(!defined($translation), 'fetch_by_stable_id with bad version');
 
+$translation = $ta->fetch_by_stable_id_version('ENSP00000201961', 1);
+ok($translation && $translation->dbID() == 21734, 'fetch_by_stable_id_version');
+
+$translation = $ta->fetch_by_stable_id_version('ENSP00000201961', '1a');
+ok(!defined($translation), 'fetch_by_stable_id_version with bad version');
+
 #
 # test fetch_by_external_name
 #

--- a/modules/t/translation.t
+++ b/modules/t/translation.t
@@ -107,6 +107,12 @@ ok($translation && $translation->stable_id() eq 'ENSP00000201961');
 $translation = $ta->fetch_by_stable_id('ENSP00000201961');
 ok($translation && $translation->dbID() == 21734);
 
+$translation = $ta->fetch_by_stable_id('ENSP00000201961.1');
+ok($translation && $translation->dbID() == 21734, 'fetch_by_stable_id with version');
+
+$translation = $ta->fetch_by_stable_id('ENSP00000201961.1a');
+ok(!defined($translation), 'fetch_by_stable_id with bad version');
+
 #
 # test fetch_by_external_name
 #


### PR DESCRIPTION
- Added support in the Registry for version ids (\.\d+) support in stable_id when determining idenfitier type
- Added support to the ArchiveStableIdAdaptor for versions in stable_ids on object creation
- Test cases for identifiers with and without versions when doing lookups
- handlers in Exon, Gene, Operon, OperonTranscript and Transcript Adaptors for a versions fetch_by_stable_id call and new handler for fetch_by_stable_id_version
- Translation is handled implicitly through calls to Transcript
- Test cases for the new handlers and functionality