### PR TITLE
Support g. in a location string and some comments

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -607,11 +607,12 @@ sub parse_location_to_values {
   
   #cleanup any nomenclature like 1 000 or 1,000
   my $number_seps_regex = qr/\s+|,/;
-  my $separator_regex = qr/(?:-|[.]{2}|\:|_)?/;
+  my $separator_regex = qr/(?:-|[.]{2}|\:|_)?/; # support -, .., : and _ as separators
+  my $hgvs_nomenclature_regex = qr/(?:g\.)?/; # check for HGVS looking locations e.g. X:g.1-100
   my $number_regex = qr/[0-9, E]+/xms;
   my $strand_regex = qr/[+-1]|-1/xms;
   
-  my $regex = qr/^((?:\w|\.|_|-)+) \s* :? \s* ($number_regex)? $separator_regex ($number_regex)? $separator_regex ($strand_regex)? $/xms;
+  my $regex = qr/^((?:\w|\.|_|-)+) \s* :? \s* $hgvs_nomenclature_regex ($number_regex)? $separator_regex ($number_regex)? $separator_regex ($strand_regex)? $/xms;
   my ($seq_region_name, $start, $end, $strand);
   if(($seq_region_name, $start, $end, $strand) = $location =~ $regex) {
     

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -617,6 +617,9 @@ test_toplevel_location('1: 100', 'chromosome', '1', 100, 246874334);
 test_toplevel_location('1:100..2000000000', 'chromosome', '1', 100, 246874334);
 test_toplevel_location('1:100..2E9', 'chromosome', '1', 100, 246874334);
 
+# Try with optional g. addition
+test_toplevel_location('1:g.1_1000', 'chromosome', '1', 1, 1000);
+
 # Try chr
 my $ucsc = 1;
 test_toplevel_location('chr1: 1-1,000', 'chromosome', '1', 1, 1000, 1, $ucsc);


### PR DESCRIPTION
Extending support so locations like X:g.1-10 are parsed as a genomic
coordinate. Also added some comments as the regular expressions are
slightly cryptic.