### PR TITLE
Configuration to allow alignments to be exported to GFF

### DIFF
--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1614,6 +1614,8 @@ my $feature_tables =
   {
    'Bio::EnsEMBL::AssemblyExceptionFeature' => 'assembly_exception',
    'Bio::EnsEMBL::DensityFeature' => 'density_feature',
+   'Bio::EnsEMBL::DnaDnaAlignFeature' => 'dna_align_feature',
+   'Bio::EnsEMBL::DnaPepAlignFeature' => 'protein_align_feature',
    'Bio::EnsEMBL::Exon' => 'exon',
    'Bio::EnsEMBL::ExonTranscript' => 'exon',
    'Bio::EnsEMBL::PredictionExon' => 'prediction_exon',

--- a/modules/Bio/EnsEMBL/Utils/SequenceOntologyMapper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SequenceOntologyMapper.pm
@@ -150,6 +150,8 @@ my %feature_so_mapping =
    'Bio::EnsEMBL::Variation::StructuralVariationFeature' => 'SO:0001537', # structural variant
    'Bio::EnsEMBL::Compara::ConstrainedElement' => 'SO:0001009', #DNA_constraint_sequence ????
    'Bio::EnsEMBL::Funcgen::RegulatoryFeature' => 'SO:0005836', # regulatory_region
+   'Bio::EnsEMBL::DnaDnaAlignFeature' => 'SO:0000347', # nucleotide_match
+   'Bio::EnsEMBL::DnaPepAlignFeature' => 'SO:0000349', # protein_match
   );
 
 


### PR DESCRIPTION
In order for GFFSerializer to export alignments, I found I needed two small changes: one to define the relevant SO terms; the other to get alignments on MT chromosomes to produce seq_region coords.