### PR TITLE
Correct serializer behaviour, if an attribute for column 9 of the GFF…

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
@@ -238,9 +238,11 @@ sub print_feature {
         #$row =~ s/;?$// if $row =~ /;$/; # Remove trailing ';' if there is any
         while(my $attribute = shift @keys) {
             my $data_written = 0;
-            if (ref $summary{$attribute} eq "ARRAY" && scalar(@{$summary{$attribute}}) > 0) {
-                $row .= $attribute."=".join (',',map { uri_escape($_,'\t\n\r;=%&,') } grep { defined $_ } @{$summary{$attribute}});
-                $data_written = 1;
+            if (ref $summary{$attribute} eq "ARRAY") {
+		if (scalar(@{$summary{$attribute}}) > 0) {
+		    $row .= $attribute."=".join (',',map { uri_escape($_,'\t\n\r;=%&,') } grep { defined $_ } @{$summary{$attribute}});
+		    $data_written = 1;
+		}
             }
             else {
                 if (defined $summary{$attribute}) { 


### PR DESCRIPTION
… serializer (the misc, everything column) contains an empty array in the feature structure, skip printing the attribute rather than attribute=ARRAY(0xABCD)