### PR TITLE
Update schema_patcher.pl

### DIFF
--- a/misc-scripts/schema_patcher.pl
+++ b/misc-scripts/schema_patcher.pl
@@ -281,7 +281,7 @@ my %patches;
 
 foreach my $thing ( [ 'ensembl',               'core',        'table.sql'   ],
                     [ 'ensembl-compara',       'compara',     'table.sql'   ], 
-                    [ 'ensembl-funcgen',       'funcgen',     'efg.sql'     ],
+                    [ 'ensembl-funcgen',       'funcgen',     'table.sql'   ],
                     [ 'ensembl-variation',     'variation',   'table.sql'   ],
                     [ 'ensembl-production',    'production',  'tables.sql'  ],
                     [ 'ensembl',               'ontology',    'tables.sql'  ] )


### PR DESCRIPTION
Funcgen has renamed its sql file from 'efg.sql' to 'table.sql', therefore schema_patcher.pl has to be modified to reflect this change.