### PR TITLE
Retain the backslash on escaped single quotes when generating a hash from a flattened string.

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -1109,7 +1109,7 @@ sub get_dumped_data {
     my $self = shift;
     my $data = shift;
 
-    $data =~ s/\n|\r|\f|\\//g;
+    $data =~ s/\n|\r|\f|(\\\\)//g;
     return eval ($data); ## no critic
 }
 


### PR DESCRIPTION
Data::Dumper is used to flatten hashes into strings, for insertion into the 'external_data' columns of some tables. By default, it uses single quotes, and automatically does any necessary escaping. The code to subsequently extract the values from the 'external_data' column removed all backslashes, resulting in an invalid hash; e.g. `'Desc' => '3\'UTR',` becomes `'Desc' => '3'UTR',`.
Because Data::Dumper escapes backslashes, we can remove all superfluous backslashes by removing all double-backslash instances, which leaves the single-backslash-escaped quotes intact.