### PR TITLE
New attrib table for dna_align_features

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/AttributeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AttributeAdaptor.pm
@@ -179,6 +179,14 @@ sub store_batch_on_Translation {
   return;
 }
 
+sub store_batch_on_DnaDnaAlignFeature {
+  my ($self, $attributes, $batch_size) = @_;
+
+  $self->store_batch_on_Object('dna_align_feature', $attributes, $batch_size);
+
+  return;
+}
+
 
 ## Single store
 
@@ -299,6 +307,22 @@ sub store_on_Translation {
   return;
 }
 
+sub store_on_DnaDnaAlignFeature {
+  my ($self, $object, $attributes) = @_;
+
+  my $object_id;
+  if (!ref($object)){
+    $object_id = $object;
+  }
+  else {
+    $object_id = $object->dbID;
+  }
+
+  $self->store_on_Object($object_id, $attributes, 'dna_align_feature');
+
+  return;
+}
+
 
 ## Remove methods
 
@@ -400,6 +424,18 @@ sub remove_from_Translation {
 
   my $object_id = $object->dbID();
   $self->remove_from_Object($object_id, 'translation', $code);
+  
+  return;
+
+}
+
+sub remove_from_DnaDnaAlignFeature {
+  my ($self, $object, $code) = @_;
+
+  assert_ref($object, 'Bio::EnsEMBL::DnaDnaAlignFeature');
+
+  my $object_id = $object->dbID();
+  $self->remove_from_Object($object_id, 'dna_align_feature', $code);
   
   return;
 
@@ -539,6 +575,23 @@ sub fetch_all_by_Translation {
   return $results;
 
 }
+
+sub fetch_all_by_DnaDnaAlignFeature {
+  my ($self, $object, $code) = @_;
+
+  my $object_id;
+
+  if (defined($object)) {
+    assert_ref($object, 'Bio::EnsEMBL::DnaDnaAlignFeature');
+    $object_id = $object->dbID();
+  }
+
+  my $results = $self->fetch_all_by_Object($object_id, 'dna_align_feature', $code);
+  
+  return $results;
+
+}
+
 
 
 

--- a/sql/patch_85_86_b.sql
+++ b/sql/patch_85_86_b.sql
@@ -1,0 +1,38 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_85_86_b.sql
+#
+# Title: New dna_align_feature_attrib table
+#
+# Description:
+#   Add a new table, for attributes associated with DNA alignment features
+
+CREATE TABLE dna_align_feature_attrib (
+
+  dna_align_feature_id        INT(10) UNSIGNED NOT NULL,
+  attrib_type_id              SMALLINT(5) UNSIGNED NOT NULL,
+  value                       TEXT NOT NULL,
+
+  UNIQUE KEY dna_align_feature_attribx (dna_align_feature_id, attrib_type_id, value(500)),
+  KEY dna_align_feature_idx (dna_align_feature_id),
+  KEY type_val_idx (attrib_type_id, value(40)),
+  KEY val_only_idx (value(40))
+
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_85_86_b.sql|add dna_align_feature_attrib table');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -657,6 +657,31 @@ CREATE TABLE dna_align_feature (
 
 
 /**
+@table dna_align_feature_attrib
+@desc Enables storage of attributes that relate to DNA sequence alignments.
+
+@column dna_align_feature_id        Foreign key references to the @link dna_align_feature table.
+@column attrib_type_id              Foreign key references to the @link attrib_type table.
+@column value                       Attribute value.
+
+@see dna_align_feature
+*/
+
+CREATE TABLE dna_align_feature_attrib (
+
+  dna_align_feature_id        INT(10) UNSIGNED NOT NULL,
+  attrib_type_id              SMALLINT(5) UNSIGNED NOT NULL,
+  value                       TEXT NOT NULL,
+
+  UNIQUE KEY dna_align_feature_attribx (dna_align_feature_id, attrib_type_id, value(500)),
+  KEY dna_align_feature_idx (dna_align_feature_id),
+  KEY type_val_idx (attrib_type_id, value(40)),
+  KEY val_only_idx (value(40))
+
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+
+/**
 @table exon
 @desc Stores data about exons. Associated with transcripts via exon_transcript. Allows access to contigs seq_regions.
 Note seq_region_start is always less that seq_region_end, i.e. when the exon is on the other strand the seq_region_start is specifying the 3prime end of the exon.


### PR DESCRIPTION
The new dna_align_feature_attrib table is to replace functionality that would be lost when the 'external_data' column is removed from the dna_align_feature table.

I've added tests for the new functionality, and they run fine when I use a preloaded test db with the schema modification. I didn't feel confident in updating the test-genome-DBs directory, however, so the Travis tests will fail until the table is added into the table defs there (the tests do not assume that there will be any rows in the dna_align_feature_attrib table).
