### PR TITLE
bugfix: get_all_DBAdaptors() should return an empty list if the species name (alias) does not exist

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -669,7 +669,10 @@ sub get_all_DBAdaptors {
 
   my ( $species, $group ) = rearrange( [qw(SPECIES GROUP)], @args );
 
-  if ( defined($species) ) { $species = $class->get_alias($species) }
+  if ( defined($species) ) {
+    $species = $class->get_alias($species);
+    return [] unless $species;
+  }
 
   my @ret;
   foreach my $dba ( @{ $registry_register{'_DBA'} } ) {

--- a/modules/t/registry.t
+++ b/modules/t/registry.t
@@ -123,9 +123,16 @@ TMPL
 
 # Test get_all_species
 
-my @species = $reg->get_all_species();
+my @species = @{ $reg->get_all_species() };
 ok(scalar(@species) == 1, "get_all_species");
 ok(scalar(@{ $reg->get_all_species('cahoona') }) == 0, "get_all_species with bogus data.");
+
+ok(scalar(@{$reg->get_all_DBAdaptors(-SPECIES => $species[0])}), "get_all_DBAdaptors() on a valid species");
+warns_like(
+    sub { is(scalar(@{$reg->get_all_DBAdaptors(-SPECIES => 'cahoona')}), 0, "get_all_DBAdaptors() on a non-existing species"); },
+    qr/cahoona is not a valid species name/,
+    q{Warns that the species doesn't exist},
+);
 
 dies_ok { $reg->load_all('i really hope there is no file named this way', undef, undef, undef, 1) } 'Pointing to a non-existing file should throw an error (if the option is switched on)';
 is($reg->load_all('i really hope there is no file named this way'), 0, 'Pointing to a non-existing file does not throw an error if the option is switched off');


### PR DESCRIPTION
Otherwise it returns the list of all DBAdaptors ... (when -GROUP is not set)