### PR TITLE
New attrib table for dna_align_features

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/AttributeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AttributeAdaptor.pm
@@ -179,6 +179,14 @@ sub store_batch_on_Translation {
   return;
 }
 
+sub store_batch_on_DnaDnaAlignFeature {
+  my ($self, $attributes, $batch_size) = @_;
+
+  $self->store_batch_on_Object('dna_align_feature', $attributes, $batch_size);
+
+  return;
+}
+
 
 ## Single store
 
@@ -299,6 +307,22 @@ sub store_on_Translation {
   return;
 }
 
+sub store_on_DnaDnaAlignFeature {
+  my ($self, $object, $attributes) = @_;
+
+  my $object_id;
+  if (!ref($object)){
+    $object_id = $object;
+  }
+  else {
+    $object_id = $object->dbID;
+  }
+
+  $self->store_on_Object($object_id, $attributes, 'dna_align_feature');
+
+  return;
+}
+
 
 ## Remove methods
 
@@ -400,6 +424,18 @@ sub remove_from_Translation {
 
   my $object_id = $object->dbID();
   $self->remove_from_Object($object_id, 'translation', $code);
+  
+  return;
+
+}
+
+sub remove_from_DnaDnaAlignFeature {
+  my ($self, $object, $code) = @_;
+
+  assert_ref($object, 'Bio::EnsEMBL::DnaDnaAlignFeature');
+
+  my $object_id = $object->dbID();
+  $self->remove_from_Object($object_id, 'dna_align_feature', $code);
   
   return;
 
@@ -539,6 +575,23 @@ sub fetch_all_by_Translation {
   return $results;
 
 }
+
+sub fetch_all_by_DnaDnaAlignFeature {
+  my ($self, $object, $code) = @_;
+
+  my $object_id;
+
+  if (defined($object)) {
+    assert_ref($object, 'Bio::EnsEMBL::DnaDnaAlignFeature');
+    $object_id = $object->dbID();
+  }
+
+  my $results = $self->fetch_all_by_Object($object_id, 'dna_align_feature', $code);
+  
+  return $results;
+
+}
+
 
 
 

--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue May 10 12:28:29 2016
+-- Created on Fri Jun 24 15:49:02 2016
 -- 
 
 BEGIN TRANSACTION;
@@ -257,6 +257,17 @@ CREATE TABLE dna_align_feature (
   hcoverage double precision,
   external_data text
 );
+
+--
+-- Table: dna_align_feature_attrib
+--
+CREATE TABLE dna_align_feature_attrib (
+  dna_align_feature_id integer NOT NULL,
+  attrib_type_id smallint NOT NULL,
+  value text NOT NULL
+);
+
+CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
 
 --
 -- Table: exon

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -98,3 +98,4 @@
 98	\N	patch	patch_84_85_a.sql|schema_version
 99	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 100	\N	patch	patch_85_86_a.sql|schema_version
+101	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=101 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=102 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue May 10 12:28:58 2016
+-- Created on Fri Jun 24 15:49:07 2016
 -- 
 
 BEGIN TRANSACTION;
@@ -257,6 +257,17 @@ CREATE TABLE dna_align_feature (
   hcoverage double precision,
   external_data text
 );
+
+--
+-- Table: dna_align_feature_attrib
+--
+CREATE TABLE dna_align_feature_attrib (
+  dna_align_feature_id integer NOT NULL,
+  attrib_type_id smallint NOT NULL,
+  value text NOT NULL
+);
+
+CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
 
 --
 -- Table: exon

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -77,3 +77,4 @@
 137	\N	patch	patch_84_85_a.sql|schema_version
 138	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 146	\N	patch	patch_85_86_a.sql|schema_version
+147	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=29797194 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=147 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=148 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue May 10 12:29:23 2016
+-- Created on Fri Jun 24 15:49:12 2016
 -- 
 
 BEGIN TRANSACTION;
@@ -257,6 +257,17 @@ CREATE TABLE dna_align_feature (
   hcoverage double precision,
   external_data text
 );
+
+--
+-- Table: dna_align_feature_attrib
+--
+CREATE TABLE dna_align_feature_attrib (
+  dna_align_feature_id integer NOT NULL,
+  attrib_type_id smallint NOT NULL,
+  value text NOT NULL
+);
+
+CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
 
 --
 -- Table: exon

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -77,3 +77,4 @@
 126	\N	patch	patch_84_85_a.sql|schema_version
 127	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 128	\N	patch	patch_85_86_a.sql|schema_version
+129	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=129 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=130 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -259,6 +259,17 @@ CREATE TABLE dna_align_feature (
 );
 
 --
+-- Table: dna_align_feature_attrib
+--
+CREATE TABLE dna_align_feature_attrib (
+  dna_align_feature_id integer NOT NULL,
+  attrib_type_id smallint NOT NULL,
+  value text NOT NULL
+);
+
+CREATE UNIQUE INDEX dna_align_feature_attribx ON dna_align_feature_attrib (dna_align_feature_id, attrib_type_id, value);
+
+--
 -- Table: exon
 --
 CREATE TABLE exon (

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -82,3 +82,4 @@
 2089	\N	patch	patch_84_85_a.sql|schema_version
 2090	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 2091	\N	patch	patch_85_86_a.sql|schema_version
+2092	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=29387404 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2092 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2093 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -38,3 +38,4 @@
 131	\N	patch	patch_84_85_a.sql|schema_version
 132	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 133	\N	patch	patch_85_86_a.sql|schema_version
+134	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=134 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=135 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -155,3 +155,4 @@
 1667	\N	patch	patch_84_85_a.sql|schema_version
 1668	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 1669	\N	patch	patch_85_86_a.sql|schema_version
+1670	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1670 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1671 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -131,3 +131,4 @@
 211	\N	patch	patch_84_85_a.sql|schema_version
 212	\N	patch	patch_84_85_b.sql|remove_duplicated_key
 213	\N	patch	patch_85_86_a.sql|schema_version
+214	\N	patch	patch_85_86_b.sql|add dna_align_feature_attrib table

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -225,6 +225,16 @@ CREATE TABLE `dna_align_feature` (
   KEY `external_db_idx` (`external_db_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
+CREATE TABLE `dna_align_feature_attrib` (
+  `dna_align_feature_id` int(10) unsigned NOT NULL,
+  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `value` text NOT NULL,
+  UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
+  KEY `dna_align_feature_idx` (`dna_align_feature_id`),
+  KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
+  KEY `val_only_idx` (`value`(40))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `seq_region_id` int(10) unsigned NOT NULL,
@@ -467,7 +477,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=214 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=215 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/sql/patch_85_86_b.sql
+++ b/sql/patch_85_86_b.sql
@@ -1,0 +1,38 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_85_86_b.sql
+#
+# Title: New dna_align_feature_attrib table
+#
+# Description:
+#   Add a new table, for attributes associated with DNA alignment features
+
+CREATE TABLE dna_align_feature_attrib (
+
+  dna_align_feature_id        INT(10) UNSIGNED NOT NULL,
+  attrib_type_id              SMALLINT(5) UNSIGNED NOT NULL,
+  value                       TEXT NOT NULL,
+
+  UNIQUE KEY dna_align_feature_attribx (dna_align_feature_id, attrib_type_id, value(500)),
+  KEY dna_align_feature_idx (dna_align_feature_id),
+  KEY type_val_idx (attrib_type_id, value(40)),
+  KEY val_only_idx (value(40))
+
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_85_86_b.sql|add dna_align_feature_attrib table');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -680,6 +680,31 @@ CREATE TABLE dna_align_feature_attrib (
 
 
 /**
+@table dna_align_feature_attrib
+@desc Enables storage of attributes that relate to DNA sequence alignments.
+
+@column dna_align_feature_id        Foreign key references to the @link dna_align_feature table.
+@column attrib_type_id              Foreign key references to the @link attrib_type table.
+@column value                       Attribute value.
+
+@see dna_align_feature
+*/
+
+CREATE TABLE dna_align_feature_attrib (
+
+  dna_align_feature_id        INT(10) UNSIGNED NOT NULL,
+  attrib_type_id              SMALLINT(5) UNSIGNED NOT NULL,
+  value                       TEXT NOT NULL,
+
+  UNIQUE KEY dna_align_feature_attribx (dna_align_feature_id, attrib_type_id, value(500)),
+  KEY dna_align_feature_idx (dna_align_feature_id),
+  KEY type_val_idx (attrib_type_id, value(40)),
+  KEY val_only_idx (value(40))
+
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+
+/**
 @table exon
 @desc Stores data about exons. Associated with transcripts via exon_transcript. Allows access to contigs seq_regions.
 Note seq_region_start is always less that seq_region_end, i.e. when the exon is on the other strand the seq_region_start is specifying the 3prime end of the exon.

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -655,6 +655,31 @@ CREATE TABLE dna_align_feature (
 
 
 /**
+@table dna_align_feature_attrib
+@desc Enables storage of attributes that relate to DNA sequence alignments.
+
+@column dna_align_feature_id        Foreign key references to the @link dna_align_feature table.
+@column attrib_type_id              Foreign key references to the @link attrib_type table.
+@column value                       Attribute value.
+
+@see dna_align_feature
+*/
+
+CREATE TABLE dna_align_feature_attrib (
+
+  dna_align_feature_id        INT(10) UNSIGNED NOT NULL,
+  attrib_type_id              SMALLINT(5) UNSIGNED NOT NULL,
+  value                       TEXT NOT NULL,
+
+  UNIQUE KEY dna_align_feature_attribx (dna_align_feature_id, attrib_type_id, value(500)),
+  KEY dna_align_feature_idx (dna_align_feature_id),
+  KEY type_val_idx (attrib_type_id, value(40)),
+  KEY val_only_idx (value(40))
+
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+
+/**
 @table exon
 @desc Stores data about exons. Associated with transcripts via exon_transcript. Allows access to contigs seq_regions.
 Note seq_region_start is always less that seq_region_end, i.e. when the exon is on the other strand the seq_region_start is specifying the 3prime end of the exon.

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -683,31 +683,6 @@ CREATE TABLE dna_align_feature_attrib (
 
 
 /**
-@table dna_align_feature_attrib
-@desc Enables storage of attributes that relate to DNA sequence alignments.
-
-@column dna_align_feature_id        Foreign key references to the @link dna_align_feature table.
-@column attrib_type_id              Foreign key references to the @link attrib_type table.
-@column value                       Attribute value.
-
-@see dna_align_feature
-*/
-
-CREATE TABLE dna_align_feature_attrib (
-
-  dna_align_feature_id        INT(10) UNSIGNED NOT NULL,
-  attrib_type_id              SMALLINT(5) UNSIGNED NOT NULL,
-  value                       TEXT NOT NULL,
-
-  UNIQUE KEY dna_align_feature_attribx (dna_align_feature_id, attrib_type_id, value(500)),
-  KEY dna_align_feature_idx (dna_align_feature_id),
-  KEY type_val_idx (attrib_type_id, value(40)),
-  KEY val_only_idx (value(40))
-
-) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
-
-
-/**
 @table exon
 @desc Stores data about exons. Associated with transcripts via exon_transcript. Allows access to contigs seq_regions.
 Note seq_region_start is always less that seq_region_end, i.e. when the exon is on the other strand the seq_region_start is specifying the 3prime end of the exon.

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -310,6 +310,9 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_85_86_a.sql|schema_version');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_85_86_b.sql|add dna_align_feature_attrib table');
+
 
 /**
 @table meta_coord


### PR DESCRIPTION
The new dna_align_feature_attrib table is to replace functionality that would be lost when the 'external_data' column is removed from the dna_align_feature table.

Tests and test databases updated accordingly.

