### PR TITLE
[ENSCORESW-1997]. Enable local load data feature at the specific driv…

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/Driver/mysql.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/mysql.pm
@@ -34,6 +34,20 @@ use strict;
 
 use base 'Bio::EnsEMBL::DBSQL::Driver';
 
+#
+# override parent's method to enable MySQL local load data in case DBD::mysql 
+# has been compiled against a C client library which has been built with
+# no support for this feature
+#
+sub connect_params {
+  my ($self, $conn) = @_;
+
+  my $params = $self->SUPER::connect_params($conn);
+  $params->{attributes}{mysql_local_infile} = 1;
+
+  return $params;
+}
+
 sub from_date_to_seconds {
     my ($self, $column) = @_;
     return "UNIX_TIMESTAMP($column)";


### PR DESCRIPTION
…er level.

Unfortunately, creating an appropriate test case turns out to be extremely inconvenient
as one must make sure the underlying DBD::mysql has been compiled against a C library
where this feature is turned off.

This approach has been tested at the base class level and it seems to be working, so this
is more for:
- the team to quickly have a look and make appropriate suggestions;
- @andrewyatz to set up a proper test environment, run a test and confirm, as we've discussed.