### PR TITLE
Added an option in BaseAdaptor to define the column of the dbID

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -666,8 +666,9 @@ sub _uncached_fetch_by_dbID{
   #construct a constraint like 't1.table1_id = 123'
   my @tabs = $self->_tables;
   my ($name, $syn) = @{$tabs[0]};
+  my $col = $self->_dbID_column;
   $self->bind_param_generic_fetch($id,SQL_INTEGER);
-  my $constraint = "${syn}.${name}_id = ?";
+  my $constraint = "${syn}.${col} = ?";
 
   #Should only be one
   my ($feat) = @{$self->generic_fetch($constraint)};
@@ -781,7 +782,7 @@ sub _uncached_fetch_all_by_id_list {
   # is the field/column name
   my $field_name;
   if($id_type eq 'dbID') {
-    $field_name = $name.'_id';
+    $field_name = $self->_dbID_column();
     # If numeric was not set default it to 1 since this is an int
     $numeric = 1 if ! defined $numeric;
   }
@@ -1008,6 +1009,26 @@ sub _tables {
 sub _columns {
   throw(   "abstract method _columns not defined "
          . "by implementing subclass of BaseAdaptor" );
+}
+
+
+# _dbID_column
+#
+#  Arg [1]    : none
+#  Example    : none
+#  Description: May be overridden to provide the name of the column
+#               that represents the dbID of this object. Defaults
+#               to _tablename() . '_id'
+#  Returntype : string
+#  Exceptions : none
+#  Caller     : generic_fetch and alike
+#
+
+sub _dbID_column {
+  my $self = shift;
+  my @tabs = $self->_tables;
+  my ($table) = @{$tabs[0]};
+  return $table.'_id';
 }
 
 

--- a/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
@@ -1195,8 +1195,8 @@ sub store{
   Example    : $feature_adaptor->remove($feature);
   Description: This removes a feature from the database.  The table the
                feature is removed from is defined by the abstract method
-               _tablename, and the primary key of the table is assumed
-               to be _tablename() . '_id'.  The feature argument must 
+               _tablename, and the primary key of the table is defined
+               by the method _dbID_column().  The feature argument must
                be an object implementing the dbID method, and for the
                feature to be removed from the database a dbID value must
                be returned.
@@ -1222,8 +1222,9 @@ sub remove {
 
   my @tabs = $self->_tables;
   my ($table) = @{$tabs[0]};
+  my $col = $self->_dbID_column;
 
-  my $sth = $self->prepare("DELETE FROM $table WHERE ${table}_id = ?");
+  my $sth = $self->prepare("DELETE FROM $table WHERE ${col} = ?");
   $sth->bind_param(1,$feature->dbID,SQL_INTEGER);
   $sth->execute();
 
@@ -1354,8 +1355,9 @@ sub remove_by_feature_id {
 
   my @tabs = $self->_tables;
   my ($tablename) = @{$tabs[0]};
+  my $col = $self->_dbID_column;
 
-  my $sql = sprintf "DELETE FROM $tablename WHERE ${tablename}_id IN (%s)", join ', ', @feats;
+  my $sql = sprintf "DELETE FROM $tablename WHERE $col IN (%s)", join ', ', @feats;
 #  warn "SQL : $sql";
       
   my $sth = $self->prepare($sql);


### PR DESCRIPTION
It defaults to ${table_name}_id but allows individual adaptors to rename it. This feature would be useful for the Compara API.

I haven't changed DnaAlignFeatureAdaptor and ProteinAlignFeatureAdaptor because they're not base classes. Similarly there are still other places (especially direct SQL queries) where ${table}_id is used (ex: https://github.com/Ensembl/ensembl/blob/release/86/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm#L2130 )