### PR TITLE
Updating script to be able to update the EBI Copyright every year. No…

### DIFF
--- a/misc-scripts/annual_copyright_updater.sh
+++ b/misc-scripts/annual_copyright_updater.sh
@@ -35,7 +35,7 @@ for var in $dirs; do
   last_year=$(($year - 1))
 
   search="^\(.*\)\\[2016\(-*[0-9]*\)\\] EMBL-European Bioinformatics Institute"
-  replacement="Copyright [2016-$year] EMBL-European Bioinformatics Institute"
+  replacement="\1[2016-$year] EMBL-European Bioinformatics Institute"
 
   echo "About to scan $(pwd) for files to replace '$search' with '$replacement'"
 

--- a/misc-scripts/annual_copyright_updater.sh
+++ b/misc-scripts/annual_copyright_updater.sh
@@ -34,12 +34,12 @@ for var in $dirs; do
   year=$(date "+%Y")
   last_year=$(($year - 1))
 
-  search="^\(.*\)\\[1999-[0-9]*\\] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute"
-  replacement="\1[1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute\n\1[2016] EMBL-European Bioinformatics Institute"
+  search="^\(.*\)\\[2016\(-*[0-9]*\)\\] EMBL-European Bioinformatics Institute"
+  replacement="Copyright [2016-$year] EMBL-European Bioinformatics Institute"
 
   echo "About to scan $(pwd) for files to replace '$search' with '$replacement'"
 
-  for file in $(grep -R --files-with-matches "$search" .); do
+  for file in $(grep -R --files-with-matches "$search" --exclude-dir=.git .); do
     echo "Replacing date in $file"
     if [ "$(uname)" = "Darwin" ]; then
       LC_CTYPE=C LANG=C sed -i '' -e "s/$search/$replacement/g" $file


### PR DESCRIPTION
…w excluding the .git directory from the file search as this was corrupting the git repos

@dzerbino and @magaliruffier updated the script last year so that we now display a copyright like the following in our scripts:

> # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
> # Copyright [2016] EMBL-European Bioinformatics Institute

I've updated the script so that we can update the EMBL-EBI part every year (similar to what the script was doing in the past). For this year, I believe we would want something like:

> # Copyright [2016-2017] EMBL-European Bioinformatics Institute

I've also excluded the ".git" directory from the grep as this was corrupting the Git repos :-/

