### PR TITLE
Do not skip first mapping when making chain file

### DIFF
--- a/misc-scripts/assembly/ensembl_assembly_to_chain.pl
+++ b/misc-scripts/assembly/ensembl_assembly_to_chain.pl
@@ -256,27 +256,25 @@ sub build_chain_mappings {
       $t_end = $current->{asm_end};
       $q_end = ($ori == 1) ? $current->{cmp_end} : $current->{cmp_start};
 
-      if ($i != 0) {
-        #If strand was negative we need to represent all data as reverse complemented regions
-        if($q_strand == -1) {
-          # $t_start = ($t_size - $t_start)+1;
-          # $t_end = ($t_size - $t_end)+1;
-          $q_start = ($q_size - $q_start)+1;
-          $q_end = ($q_size - $q_end)+1;
-        }
-        # Convert to UCSC formats (0-based half-open intervals and +/- strands)
-        $t_start--;
-        $q_start--;
-        $t_strand = ($t_strand == 1) ? '+' : '-';
-        $q_strand = ($q_strand == 1) ? '+' : '-';
-
-        #Store the chain
-        my $chain_score = 1;
-        push(@chain_mappings, {
-          header => ['chain', $chain_score, $t_name, $t_size, $t_strand, $t_start, $t_end, $q_name, $q_size, $q_strand, $q_start, $q_end, $chain_id],
-          gaps => [@chain_gaps]
-        });
+      #If strand was negative we need to represent all data as reverse complemented regions
+      if($q_strand == -1) {
+        # $t_start = ($t_size - $t_start)+1;
+        # $t_end = ($t_size - $t_end)+1;
+        $q_start = ($q_size - $q_start)+1;
+        $q_end = ($q_size - $q_end)+1;
       }
+      # Convert to UCSC formats (0-based half-open intervals and +/- strands)
+      $t_start--;
+      $q_start--;
+      $t_strand = ($t_strand == 1) ? '+' : '-';
+      $q_strand = ($q_strand == 1) ? '+' : '-';
+
+      #Store the chain
+      my $chain_score = 1;
+      push(@chain_mappings, {
+        header => ['chain', $chain_score, $t_name, $t_size, $t_strand, $t_start, $t_end, $q_name, $q_size, $q_strand, $q_start, $q_end, $chain_id],
+        gaps => [@chain_gaps]
+      });
 
       if(! defined $next) {
         last;
@@ -390,4 +388,3 @@ sub ensembl_to_ucsc_name {
   }
   return $ucsc_name_cache{$prod_name}{$ensembl_name} = $ucsc_name;  
 }
-


### PR DESCRIPTION
I think this is a bug, but the logic is a bit complicated, so I'm not entirely sure. As I see it, the mappings are pulled into an array, then iterated over with an index, $i. The first mapping (ie $i == 0) is skipped, which seems like an error; the first mapping should be just as valid as the rest (?)