### PR TITLE
Escape seq_region_name before querying the synonyms

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -302,7 +302,9 @@ sub fetch_by_region {
         $syn_sql .= "AND cs.version = '" . $version . "' ";
       }
       my $syn_sql_sth = $self->prepare($syn_sql);
-      $syn_sql_sth->bind_param(1, "$seq_region_name%", SQL_VARCHAR);
+      my $escaped_seq_region_name = $seq_region_name;
+      $escaped_seq_region_name =~ s/_/\\_/g;
+      $syn_sql_sth->bind_param(1, "$escaped_seq_region_name%", SQL_VARCHAR);
       $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER);
       $syn_sql_sth->execute();
       my ($new_name, $new_coord_system, $new_version);

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -294,7 +294,7 @@ sub fetch_by_region {
     unless ( @row ) {
 
       # try synonyms
-      my $syn_sql = "select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? and cs.species_id =? ";
+      my $syn_sql = 'select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? ESCAPE "\" and cs.species_id =? ';
       if (defined $coord_system_name && defined $cs) {
         $syn_sql .= "AND cs.name = '" . $coord_system_name . "' ";
       }

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -294,7 +294,12 @@ sub fetch_by_region {
     unless ( @row ) {
 
       # try synonyms
-      my $syn_sql = 'select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? ESCAPE "\" and cs.species_id =? ';
+      my $escape_char = '\\';
+      # MySQL and apparently PostgreSQL need two backslashs in the ESCAPE keyword...
+      if ($self->dbc->driver ne 'sqlite') {
+        $escape_char .= '\\';
+      }
+      my $syn_sql = "select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? ESCAPE '$escape_char' and cs.species_id =? ";
       if (defined $coord_system_name && defined $cs) {
         $syn_sql .= "AND cs.name = '" . $coord_system_name . "' ";
       }


### PR DESCRIPTION
If seq_region_name is not escaped, the API might return the wrong slice if two synonyms are the same except for the '_' character: Contig10_1/Contig1041