### PR TITLE
Undefine seq when changing start or end unless an adaptor is present

### DIFF
--- a/modules/Bio/EnsEMBL/Translation.pm
+++ b/modules/Bio/EnsEMBL/Translation.pm
@@ -206,6 +206,9 @@ sub start{
       my $value = shift;
       
       $obj->{'start'} = $value;
+      if (!defined($obj->adaptor())) {
+        $obj->{seq} = undef;
+      }
     }
     return $obj->{'start'};
 
@@ -234,6 +237,9 @@ sub end {
       my $value = shift;
       
       $self->{'end'} = $value;
+      if (!defined($self->adaptor())) {
+        $self->{seq} = undef;
+      }
     }
     return $self->{'end'};
 


### PR DESCRIPTION
This could be useful when creating a Translation but a change to the start or end is need for a stop codon for example and $obj->seq has already been called.