### PR TITLE
Remove $registry_register{_TYPE}

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -980,12 +980,6 @@ sub add_adaptor {
     push( @{ $registry_register{_SPECIES}{$species}{'list'} }, $type );
   }
 
-  if ( !defined( $registry_register{_TYPE}{ $lc_type }{$species} ) ) {
-    $registry_register{_TYPE}{ $lc_type }{$species} = [$adap];
-  } 
-  else {
-    push( @{ $registry_register{_TYPE}{ $lc_type }{$species} }, $adap );
-  }
   return;
 } ## end sub add_adaptor
 


### PR DESCRIPTION
as it does not seem to be used anywhere. Furthermore, the same information
can be derived from $registry_register{_SPECIES}.

This piece of duplicated information take up a lot of spaces for a registry
with large number of species (e.g. ~600MB for Ensembl Bacteria at ~44k species).