### PR TITLE
ENSCORESW-1910: stable id mapping incompatible with multi-species db

### DIFF
--- a/sql/patch_89_90_c.sql
+++ b/sql/patch_89_90_c.sql
@@ -1,0 +1,26 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2017] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_89_90_c.sql
+#
+# Title: Add species_id field
+#
+# Description:
+# 		Add species_id column in the mapping_session table is a possible solution to help identifying the strain with the multiSpecies database mapping sessions.
+
+ALTER TABLE mapping_session ADD COLUMN species_id INT(10) UNSIGNED NOT NULL DEFAULT 1 ,ADD KEY ( species_id );
+										  							  
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_89_90_c.sql|add_species_id');	

--- a/sql/patch_89_90_c.sql
+++ b/sql/patch_89_90_c.sql
@@ -18,9 +18,10 @@
 # Title: Add species_id field
 #
 # Description:
-#    Add species_id column in the mapping_session table is a possible solution to help identifying the strain with the multiSpecies database mapping sessions.
+# Add species_id column in the mapping_session table is a possible solution to help identifying the strain with the multiSpecies database mapping sessions.
 
 ALTER TABLE mapping_session ADD COLUMN species_id INT(10) UNSIGNED NOT NULL DEFAULT 1 ,ADD KEY ( species_id );
 										  							  
 # Patch identifier
+
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_89_90_c.sql|add_species_id');	

--- a/sql/patch_89_90_c.sql
+++ b/sql/patch_89_90_c.sql
@@ -18,7 +18,7 @@
 # Title: Add species_id field
 #
 # Description:
-# 		Add species_id column in the mapping_session table is a possible solution to help identifying the strain with the multiSpecies database mapping sessions.
+#    Add species_id column in the mapping_session table is a possible solution to help identifying the strain with the multiSpecies database mapping sessions.
 
 ALTER TABLE mapping_session ADD COLUMN species_id INT(10) UNSIGNED NOT NULL DEFAULT 1 ,ADD KEY ( species_id );
 										  							  

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1839,6 +1839,7 @@ CREATE TABLE gene_archive (
 @desc Stores details of ID mapping sessions - a mapping session represents the session when stable IDs where mapped from one database to another. Details of the "old" and "new" databases are stored.
 
 @column mapping_session_id          Primary key, internal identifier.
+@column species_id                  Indentifies the species for multi-species databases.
 @column old_db_name                 Old Ensembl database name.
 @column new_db_name                 New Ensembl database name.
 @column old_release                 Old Ensembl database release.
@@ -1853,9 +1854,10 @@ CREATE TABLE gene_archive (
 */
 
 
-CREATE TABLE mapping_session (
+ CREATE TABLE mapping_session (
 
   mapping_session_id          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  species_id                  INT(10) UNSIGNED NOT NULL DEFAULT 1,
   old_db_name                 VARCHAR(80) NOT NULL DEFAULT '',
   new_db_name                 VARCHAR(80) NOT NULL DEFAULT '',
   old_release                 VARCHAR(5) NOT NULL DEFAULT '',
@@ -1864,9 +1866,10 @@ CREATE TABLE mapping_session (
   new_assembly                VARCHAR(20) NOT NULL DEFAULT '',
   created                     DATETIME NOT NULL,
 
-  PRIMARY KEY (mapping_session_id)
+  PRIMARY KEY (mapping_session_id),
+  KEY species_idx (species_id)
 
-) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;		
 
 
 /**

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1853,8 +1853,7 @@ CREATE TABLE gene_archive (
 
 */
 
-
- CREATE TABLE mapping_session (
+CREATE TABLE mapping_session (
 
   mapping_session_id          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   species_id                  INT(10) UNSIGNED NOT NULL DEFAULT 1,
@@ -1869,7 +1868,7 @@ CREATE TABLE gene_archive (
   PRIMARY KEY (mapping_session_id),
   KEY species_idx (species_id)
 
-) COLLATE=latin1_swedish_ci ENGINE=MyISAM;		
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
 
 /**


### PR DESCRIPTION
A possible solution by adding a new field: species_id in the mapping_session table.