### PR TITLE
$species must be defined in Registry::add_DBAdaptor

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -590,6 +590,10 @@ sub get_all_db_adaptors {
 sub add_DBAdaptor {
   my ( $class, $species, $group, $adap ) = @_;
 
+  if ( !defined($species) ) {
+    throw('Species not defined.');
+  }
+
   if ( !( $class->alias_exists($species) ) ) {
     $class->add_alias( $species, $species );
   }

--- a/modules/t/registry.t
+++ b/modules/t/registry.t
@@ -142,4 +142,6 @@ warns_like(
 dies_ok { $reg->load_all('i really hope there is no file named this way', undef, undef, undef, 1) } 'Pointing to a non-existing file should throw an error (if the option is switched on)';
 is($reg->load_all('i really hope there is no file named this way'), 0, 'Pointing to a non-existing file does not throw an error if the option is switched off');
 
+dies_ok { $reg->add_DBAdaptor() } 'add_DBAdaptor() must get a valid species';
+
 done_testing();


### PR DESCRIPTION
TBH, most of the Registry methods don't properly check all their arguments, so this PR is not making the module much safer. I'm adding this test because the lack of it bit me and since the same safety check is in `get_DBAdaptor` I thought it could rightly be in `add_DBAdaptor` too