### PR TITLE
Allow translation start and stop to be defined within a transcript-level seq-edit

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -974,13 +974,20 @@ sub cdna_coding_start {
     # adjust cdna coords if sequence edits are enabled
     if($self->edits_enabled()) {
       my @seqeds = @{$self->get_all_SeqEdits()};
-      # sort in reverse order to avoid adjustment of downstream edits
-      @seqeds = sort {$b->start() <=> $a->start()} @seqeds;
+      if (scalar @seqeds) {
+        my $transl_start = $self->get_all_Attributes('_transl_start');
+        if (@{$transl_start}) {
+          $start = $transl_start->[0]->value;
+        } else {
+          # sort in reverse order to avoid adjustment of downstream edits
+          @seqeds = sort {$b->start() <=> $a->start()} @seqeds;
 
-      foreach my $se (@seqeds) {
-        # use less than start so that start of CDS can be extended
-        if($se->start() < $start) {
-          $start += $se->length_diff();
+          foreach my $se (@seqeds) {
+            # use less than start so that start of CDS can be extended
+            if($se->start() < $start) {
+              $start += $se->length_diff();
+            }
+          }
         }
       }
     }
@@ -1034,13 +1041,20 @@ sub cdna_coding_end {
     # adjust cdna coords if sequence edits are enabled
     if($self->edits_enabled()) {
       my @seqeds = @{$self->get_all_SeqEdits()};
-      # sort in reverse order to avoid adjustment of downstream edits
-      @seqeds = sort {$b->start() <=> $a->start()} @seqeds;
+      if (scalar @seqeds) {
+        my $transl_end = $self->get_all_Attributes('_transl_end');
+        if (@{$transl_end}) {
+          $end = $transl_end->[0]->value;
+        } else {
+          # sort in reverse order to avoid adjustment of downstream edits
+          @seqeds = sort {$b->start() <=> $a->start()} @seqeds;
 
-      foreach my $se (@seqeds) {
-        # use less than or equal to end+1 so end of the CDS can be extended
-        if($se->start() <= $end + 1) {
-          $end += $se->length_diff();
+          foreach my $se (@seqeds) {
+            # use less than or equal to end+1 so end of the CDS can be extended
+            if($se->start() <= $end + 1) {
+              $end += $se->length_diff();
+            }
+          }
         }
       }
     }

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -680,6 +680,72 @@ is_deeply(
 
 $multi->restore('core');
 
+#
+# tests for translation start/end within a seq_edit
+#
+$tr = $ta->fetch_by_stable_id( "ENST00000217347" );
+$tr->edits_enabled(1);
+
+$tr->add_Attributes(
+  Bio::EnsEMBL::Attribute->new(
+    -code => '_rna_edit',
+    -value => "1 0 CGTCGATGTTG",
+  )
+);
+is(substr($tr->translateable_seq, 0, 6), 'ATGGCA', 'translation start in a seq_edit - seq before');
+is(length($tr->translateable_seq),       804,      'translation start in a seq_edit - length before');
+
+$tr->add_Attributes(
+  Bio::EnsEMBL::Attribute->new(
+    -code => '_transl_start',
+    -value => "6",
+  )
+);
+is(substr($tr->translateable_seq, 0, 6), 'ATGTTG', 'translation start in a seq_edit - seq after');
+is(length($tr->translateable_seq),       874,      'translation start in a seq_edit - length after');
+
+$tr->add_Attributes(
+  Bio::EnsEMBL::Attribute->new(
+    -code => '_rna_edit',
+    -value => "869 868 CGTCGTGATTG",
+  )
+);
+is(substr(reverse($tr->translateable_seq), 0, 11), reverse('CGTCGTGATTG'), 'translation end in a seq_edit - seq before');
+is(length($tr->translateable_seq),                 885,                    'translation end in a seq_edit - length before');
+
+$tr->add_Attributes(
+  Bio::EnsEMBL::Attribute->new(
+    -code => '_transl_end',
+    -value => "884",
+  )
+);
+is(substr(reverse($tr->translateable_seq), 0, 11), reverse('GAGTATCGTCG'), 'translation end in a seq_edit - seq after');
+is(length($tr->translateable_seq),                 879,                    'translation end in a seq_edit - length after');
+
+$multi->restore('core');
+
+$tr = $ta->fetch_by_stable_id( "ENST00000217347" );
+$tr->edits_enabled(1);
+
+is(length($tr->translateable_seq), 804, 'explicit translation end with no seq_edit - length before');
+
+$tr->add_Attributes(
+  Bio::EnsEMBL::Attribute->new(
+    -code => '_transl_end',
+    -value => "873",
+  )
+);
+is(length($tr->translateable_seq), 804, 'explicit translation end with no seq_edit - length after');
+
+$tr->add_Attributes(
+  Bio::EnsEMBL::Attribute->new(
+    -code => '_rna_edit',
+    -value => "869 868 CGTCGTGATTG",
+  )
+);
+is(length($tr->translateable_seq), 809, 'explicit translation end with seq_edit - length after');
+
+$multi->restore('core');
 
 #
 # tests for multiple versions of transcripts in a database


### PR DESCRIPTION
The way that translation start and end are defined in the core db schema make it impossible to insert sequence at the start or end that contains both UTR and CDS; in other words, translation cannot start or stop within a seq-edit.

Where you have a fragmented assembly, and therefore need to add seq_edits, it is common to have this situation, since genes will tend to be truncated, at one or both ends, rather than having missing coding sequence in the middle. The best workaround with the current code is to remove the UTRs, which is obviously not ideal.

There are probably much cleverer, and correspondingly more complicated, ways to address this. The simple/stupid solution I propose here is for a translation_attrib which overrides whatever is derived from the translation table, for start and/or stop. This attrib is only applied in the presence of seq-edits, so shouldn't slow down the module by looking for an attrib that won't exist for most species. I used an underscore prefix for the attrib codes, since that seemed to be the convention for seq-edit things. If this PR is accepted, I'll add the attribs to the production db.

I'd like this to be available for VectorBase, which is currently running on release 88 code. So if possible (and assuming you are happy to accept this change, of course) please could this be cherry-picked onto release/88 and release/89.