### PR TITLE
Enabled perlcritic on misc-scripts

### DIFF
--- a/modules/t/housekeeping_perlCritic.t
+++ b/modules/t/housekeeping_perlCritic.t
@@ -50,6 +50,7 @@ Test::Perl::Critic->import(-profile => File::Spec->catfile($root, 'perlcriticrc'
 
 #Find all files & run
 my @perl_files = Perl::Critic::Utils::all_perl_files(
+  File::Spec->catdir($root, 'misc-scripts'),
   File::Spec->catdir($root, 'modules')
 );
 foreach my $perl (@perl_files) {


### PR DESCRIPTION
I don't know if misc-scripts was intentionally skipped, but it contains 76 non-compliant perl files