### PR TITLE
Added missing import

### DIFF
--- a/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
@@ -50,6 +50,7 @@ use vars qw(@ISA);
 use Bio::SimpleAlign;
 use Bio::LocatableSeq;
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
+use Bio::EnsEMBL::Utils::Exception qw(throw);
 
 @ISA = qw( Bio::EnsEMBL::BaseAlignFeature );
 


### PR DESCRIPTION
## Description

Without the import, `throw` doesn't work

## Use case

Call `alignment_strings` on a `DnaDnaAlignFeature` that is not of _ensembl_ type and you'll get

```
Undefined subroutine &Bio::EnsEMBL::DnaDnaAlignFeature::throw called at /home/matthieu/workspace/src/rel91/ensembl/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm line 262.
```

## Benefits

with the import, you'll get the much nicer

```
-------------------- EXCEPTION --------------------
MSG: alignment_strings method not implemented for CACTUS_HAL_PW
STACK Bio::EnsEMBL::DnaDnaAlignFeature::alignment_strings /home/matthieu/workspace/src/rel91/ensembl/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm:263
STACK toplevel HAL/HALXS/test_anne.pl:192
Date (localtime)    = Thu Nov 30 16:20:36 2017
Ensembl API version = 91
---------------------------------------------------
```

## Possible Drawbacks

[Every change breaks someone's workflow](https://xkcd.com/1172/)

## Testing

_Have you added/modified unit tests to test the changes?_

No

_Have you run the entire test suite and no regression was detected?_

No
