### PR TITLE
Oracle DB connections: if host is given, use it

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/Driver/Oracle.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/Oracle.pm
@@ -45,10 +45,18 @@ sub new {
 sub connect_params {
     my ($self, $conn) = @_;
 
+    my $host = $conn->host();
     my $dbname = $conn->dbname();
+    my ($dsn, $username);
 
-    my $dsn      = "DBI:Oracle:";
-    my $username = sprintf("%s@%s", $conn->username(), $dbname );
+    if (defined $host) {
+      my $port = $conn->port() || 1521;
+      $dsn = sprintf("DBI:Oracle://%s:%s/%s", $host, $port, $dbname);
+      $username = $conn->username();
+    } else {
+      $dsn      = "DBI:Oracle:";
+      $username = sprintf("%s@%s", $conn->username(), $dbname );
+    }
 
     return {
         dsn        => $dsn,


### PR DESCRIPTION
## Description
The existing code for establishing Oracle DB connections does not use host/port parameters, it relies on a tnsnames.ora file to map database instances to a host and port. With this proposed change, if a host is not defined, this behaviour is unchanged, and the connection happens in the same way it always has. If a host _is_ defined, then that is used to construct the dsn.

## Use case
The EG xref pipeline retrieves data from EBI Oracle instances. The Oracle environment is now loaded via homebrew, as part of the standard Ensembl software environment, rather than being maintained by EG. In the past, the connection details for the EBI Oracle servers were maintained in a tnsnames.ora file, alongside the Oracle client installation. It remains possible to use such a file, but this PR means that connections can be established without the tnsnames.ora file.

## Benefits
More flexibility in configuring Oracle db connections. 

## Possible Drawbacks
None that I can think of.

## Testing
No new tests; I regard spoofing an Oracle database to test this relatively minor change to be overkill...

I have not run the entire test suite, only the dbconnection test (which passed), because this functionality isn't used anywhere in the codebase/other tests.
