### PR TITLE
[ENSCORESW-2465] Fix comparisons in Exon::is_coding() to prevent fals…

### DIFF
--- a/modules/Bio/EnsEMBL/Exon.pm
+++ b/modules/Bio/EnsEMBL/Exon.pm
@@ -1302,11 +1302,15 @@ sub is_coding {
   my ( $self, $transcript) = @_;
 
   if (!$transcript->translate) { return 0; }
-  if ($transcript->coding_region_start < $self->start && $self->start < $transcript->coding_region_end) { return 1; }
-  if ($transcript->coding_region_end > $self->end && $self->end > $transcript->coding_region_start) { return 1; }
+
+  # coding region overlaps start of exon
+  if ($transcript->coding_region_start <= $self->start && $self->start <= $transcript->coding_region_end) { return 1; }
+
+  # coding region overlaps end of exon
+  if ($transcript->coding_region_end >= $self->end && $self->end >= $transcript->coding_region_start) { return 1; }
 
   # to handle cases where transcript coding region can fall within the exon start and exon end, eg: if it is one exon transcript
-  if ($transcript->coding_region_start > $self->start &&  $transcript->coding_region_end < $self->end ) { return 1; }
+  if ($transcript->coding_region_start >= $self->start &&  $transcript->coding_region_end <= $self->end ) { return 1; }
   return 0;
 }
 


### PR DESCRIPTION
…e-negatives when transcript and exon boundaries match exactly. Added additional transcript and translation structures to exon test cases.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Changes comparisons in Exon::is_coding() to use <= and >= so that they catch cases where coding region boundaries exactly match exon boundaries. Also added several new test cases to exon.t to check for correct behaviour when exon boundaries exactly match coding region boundaries in both single- and multi-exon transcripts.

## Use case

When exon boundaries exactly match coding region boundaries, Exon::is_coding() was returning zero, even though the exons were coding (false negative).


## Benefits

Fixes a user-reported bug, and increases test coverage to identify if this (or a similar) bug reoccurs.

## Possible Drawbacks

None

## Testing

Yes, in exon.t

_If so, do the tests pass/fail?_

Pass. Checked that they fail with previous version of is_coding()

_Have you run the entire test suite and no regression was detected?_

Yes.
