### PR TITLE
Statsgenerator biotype

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
@@ -215,7 +215,7 @@ sub fetch_all_by_group_object_db_type {
   my ($self, $biotype_group, $object_type, $db_type) = @_;
 
   $db_type //= 'core';
-  $db_type = "%${db_type}%";
+  $db_type = '%' . $db_type . '%';
 
   my $constraint = "b.biotype_group = ? AND b.object_type = ? AND b.db_type LIKE ? ";
   $self->bind_param_generic_fetch($biotype_group, SQL_VARCHAR);

--- a/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
@@ -215,8 +215,9 @@ sub fetch_all_by_group_object_db_type {
   my ($self, $biotype_group, $object_type, $db_type) = @_;
 
   $db_type //= 'core';
+  $db_type = "%${db_type}%";
 
-  my $constraint = "b.biotype_group = ? AND b.object_type = ? AND FIND_IN_SET( ? , db_type)>0 ";
+  my $constraint = "b.biotype_group = ? AND b.object_type = ? AND b.db_type LIKE ? ";
   $self->bind_param_generic_fetch($biotype_group, SQL_VARCHAR);
   $self->bind_param_generic_fetch($object_type, SQL_VARCHAR);
   $self->bind_param_generic_fetch($db_type, SQL_VARCHAR);

--- a/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
@@ -138,7 +138,7 @@ sub _objs_from_sth {
                The name of the biotype to retrieve
   Arg [2]    : String $object_type
                The object type of the biotype to retrieve (gene or transcript)
-  Example    : $biotype = $biotype_adaptor->fetch_by_name_object_type('gene', 'protein_coding');
+  Example    : $biotype = $biotype_adaptor->fetch_by_name_object_type('mRNA', 'gene');
   Description: Retrieves a biotype object from the database via its combined key (name, object_type).
                If the Biotype requested does not exist in the database, a new Biotype object is
                created with the provided name and object_type to be returned.
@@ -185,6 +185,41 @@ sub fetch_all_by_object_type {
 
   my $constraint = "b.object_type = ?";
   $self->bind_param_generic_fetch($object_type, SQL_VARCHAR);
+  my @biotypes = @{$self->generic_fetch($constraint)};
+
+  if ( !@biotypes ) {
+    warning("No objects retrieved. Check if object_type '$object_type' is correct.")
+  }
+
+  return \@biotypes;
+}
+
+=head2 fetch_all_by_group_object_db_type
+
+  Arg [1]    : String $biotype_group
+               The group of the biotypes to retrieve
+  Arg [2]    : String $object_type
+               The object type of the biotypes to retrieve (gene or transcript)
+  Arg [3]    : (optional) String $db_type
+               The db_type of the biotypes to retrieve. If not provided defaults to 'core'.
+  Example    : $biotype = $biotype_adaptor->fetch_all_by_group_object_db_type('gene', 'protein_coding');
+  Description: Retrieves an array reference of biotype objects from the database of the provided
+               biotype_group and object_type and core db_type.
+  Returntype : arrayref of Bio::EnsEMBL::Biotype objects or empty arrayref
+  Warning    : If empty arrayref is to be returned
+  Exceptions : none
+
+=cut
+
+sub fetch_all_by_group_object_db_type {
+  my ($self, $biotype_group, $object_type, $db_type) = @_;
+
+  $db_type //= 'core';
+
+  my $constraint = "b.biotype_group = ? AND b.object_type = ? AND FIND_IN_SET( ? , db_type)>0 ";
+  $self->bind_param_generic_fetch($biotype_group, SQL_VARCHAR);
+  $self->bind_param_generic_fetch($object_type, SQL_VARCHAR);
+  $self->bind_param_generic_fetch($db_type, SQL_VARCHAR);
   my @biotypes = @{$self->generic_fetch($constraint)};
 
   if ( !@biotypes ) {

--- a/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
@@ -202,7 +202,7 @@ sub fetch_all_by_object_type {
                The object type of the biotypes to retrieve (gene or transcript)
   Arg [3]    : (optional) String $db_type
                The db_type of the biotypes to retrieve. If not provided defaults to 'core'.
-  Example    : $biotype = $biotype_adaptor->fetch_all_by_group_object_db_type('gene', 'protein_coding');
+  Example    : $biotype = $biotype_adaptor->fetch_all_by_group_object_db_type('coding', 'gene');
   Description: Retrieves an array reference of biotype objects from the database of the provided
                biotype_group and object_type and core db_type.
   Returntype : arrayref of Bio::EnsEMBL::Biotype objects or empty arrayref

--- a/modules/t/biotype.t
+++ b/modules/t/biotype.t
@@ -88,17 +88,25 @@ is($biotype4->so_acc, undef, 'Biotype SO acc is not set');
 
 # test fetch biotypes of object_type gene
 debug("fetch biotypes by object_type");
-my $biotypes = $biotype_adaptor->fetch_all_by_object_type('gene');
-is(ref $biotypes, 'ARRAY', 'Got an array');
-is(scalar @{$biotypes}, '2', 'of size 2');
-is_deeply($biotypes, [$biotype1, $biotype3], 'with the correct objects');
-my $warning = warning { $biotypes = $biotype_adaptor->fetch_all_by_object_type('none') };
-like( $warning,
+my $biotypes1 = $biotype_adaptor->fetch_all_by_object_type('gene');
+is(ref $biotypes1, 'ARRAY', 'Got an array');
+is(scalar @{$biotypes1}, '2', 'of size 2');
+is_deeply($biotypes1, [$biotype1, $biotype3], 'with the correct objects');
+my $warning1 = warning { 
+  $biotypes1 = $biotype_adaptor->fetch_all_by_object_type('none') };
+like( $warning1,
     qr/No objects retrieved. Check if object_type 'none' is correct./,
-    "Got a warning from fetch_all_by_object_type('none') ",
-) or diag 'Got warning: ', explain($warning);
-is(ref $biotypes, 'ARRAY', 'Got an array');
-is(scalar @{$biotypes}, '0', 'of size 0');
-is_deeply($biotypes, [], 'totally empty');
+    "Got a warning from fetch_all_by_object_type",
+) or diag 'Got warning: ', explain($warning1);
+is(ref $biotypes1, 'ARRAY', 'Got an array');
+is(scalar @{$biotypes1}, '0', 'of size 0');
+is_deeply($biotypes1, [], 'totally empty');
+my $biotypes2 = $biotype_adaptor->fetch_all_by_group_object_db_type('coding', 'gene');
+is_deeply($biotypes2, [$biotype1], 'fetch_all_by_group_object_db_type retrieves correct data');
+my $warning2 = warning { $biotypes2 = $biotype_adaptor->fetch_all_by_group_object_db_type('coding', 'none', 'core') };
+like( $warning2,
+    qr/No objects retrieved. Check if object_type 'none' is correct./,
+    "Got a warning from fetch_all_by_group_object_db_type",
+) or diag 'Got warning: ', explain($warning2);
 
 done_testing();


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_One or more sentences describing in detail the proposed changes._

Changes required to close ENSCORESW-2633
Added new method to BiotypeAdaptor, to be used in production pipelines.
fetch_all_by_group_object_db_type() allows fetching of the biotypes of a given biotype group.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

To replace direct queries in production pipelines to the production schema with core API calls.

## Benefits

_If applicable, describe the advantages the changes will have._

Might be useful elsewhere.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.
