### PR TITLE
Test for IndelCoordinate first because IndelCoordinate can be a Gap

### DIFF
--- a/modules/Bio/EnsEMBL/MappedSlice.pm
+++ b/modules/Bio/EnsEMBL/MappedSlice.pm
@@ -574,20 +574,14 @@ sub seq {
       
       # indel / gap
       else {
-        
-        if($ref_coord->isa('Bio::EnsEMBL::Mapper::Gap')) {
-          $ms_seq .= '-' x $ref_coord->length();
-        }
-        
-        else {
-          # if there's a gap here aswell, add corresponding sequence
+        if($ref_coord->isa('Bio::EnsEMBL::Mapper::IndelCoordinate')) {
           if($ref_coord->gap_length > 0) {
             $ms_seq .= substr($seq, $start, $ref_coord->gap_length);
             $start += $ref_coord->gap_length;
           }
-          
-          # add "-" to the sequence
           $ms_seq .= '-' x ($ref_coord->length() - $ref_coord->gap_length());
+        } else {
+          $ms_seq .= '-' x $ref_coord->length();
         }
       }
     }


### PR DESCRIPTION
This fixes a problem when drawing strain slice sequence against reference sequence in the Resequencing view. Sometimes a IndelCoordinate was treated only as a Gap because Gap is the base class.