### PR TITLE
fixed cpanfile syntax

### DIFF
--- a/misc-scripts/jira/cpanfile
+++ b/misc-scripts/jira/cpanfile
@@ -1,2 +1,2 @@
-requires 'iCal::Parser'
-requires 'Term::ReadKey'
+requires 'iCal::Parser';
+requires 'Term::ReadKey';


### PR DESCRIPTION
## Description
Correct perl syntax required for `cpanfile`. The `;` chars are missing at the end of the lines.

## Use case

Installing the perl requisites requires the `cpanfile` to have correct perl syntax.

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

NA

_Have you run the entire test suite and no regression was detected?_

No
