### PR TITLE
Don't version_check metadata db

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -2875,6 +2875,9 @@ sub version_check {
     if ( $dba->dbc()->dbname() =~ /^_test_db_/x ) {
       return 1;
     }
+    if ( $dba->dbc()->dbname() =~ /ensembl_metadata/x ) {
+      return 1;
+    }
     if ( $dba->dbc()->dbname() =~ /(\d+)_\S+$/x ) {
       $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_compara_(\d+)/x ) {


### PR DESCRIPTION
## Description
The metadata database is unversioned, and exists apart from the release cycle. So the version check is not required.

## Use case
Loading the metadata db in the registry gives warnings about a missing db version.

## Benefits
Incorrect warnings are removed.

## Possible Drawbacks
None

## Testing
No new test, it's a minor change. registry.t passes.
