### PR TITLE
SequenceOntologyMapper deprecation

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,6 +8,15 @@ When a method is deprecated, a deprecation warning is thrown whenever the method
 The warning also contains instructions on replacing the deprecated method and when it will be removed.
 A year after deprecation (4 Ensembl releases), the method is removed from the API.
 
+### Removed in Ensembl Release 98 ###
+
+ - Bio::EnsEMBL::Utils::**SequenceOntologyMapper**::*new()*
+ - Bio::EnsEMBL::Utils::**SequenceOntologyMapper**::*to_accession()*
+ - Bio::EnsEMBL::Utils::**SequenceOntologyMapper**::*to_name()*
+ - Bio::EnsEMBL::Utils::**SequenceOntologyMapper**::*gene_biotype_to_name()*
+ - Bio::EnsEMBL::Utils::**SequenceOntologyMapper**::*transcript_biotype_to_name()*
+ - Bio::EnsEMBL::Utils::**SequenceOntologyMapper**::*_fetch_SO_name_by_accession()*
+
 ### Removed in Ensembl Release 95 ###
 
  - Bio::EnsEMBL::**AlignStrainSlice**::*alignFeature()*

--- a/modules/Bio/EnsEMBL/CDS.pm
+++ b/modules/Bio/EnsEMBL/CDS.pm
@@ -66,6 +66,7 @@ use Scalar::Util qw(weaken isweak);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0000316';
 
 =head2 new
 
@@ -238,21 +239,6 @@ sub phase {
   my $self = shift;
   $self->{'phase'} = shift if( @_ );
   return ( $self->{'phase'} || 0 );
-}
-
-
-=head2 feature_so_acc
-
-  Example    : print $cds->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of CDS.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000316';
 }
 
 

--- a/modules/Bio/EnsEMBL/CDS.pm
+++ b/modules/Bio/EnsEMBL/CDS.pm
@@ -241,6 +241,21 @@ sub phase {
 }
 
 
+=head2 feature_so_acc
+
+  Example    : print $cds->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of CDS.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000316';
+}
+
+
 =head2 summary_as_hash
 
   Example    : my $hash = $cds->summary_as_hash();

--- a/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
@@ -54,6 +54,7 @@ use Bio::EnsEMBL::Utils::Exception qw(throw);
 
 @ISA = qw( Bio::EnsEMBL::BaseAlignFeature );
 
+use constant SO_ACC => 'SO:0000347';
 
 =head2 new
 
@@ -524,20 +525,6 @@ sub transfer {
   }
   
   return $new_feature;
-}
-
-=head2 feature_so_acc
-
-  Example    : print $feat->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of nucleotide_match.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000347';
 }
 
 1;

--- a/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
@@ -526,5 +526,18 @@ sub transfer {
   return $new_feature;
 }
 
+=head2 feature_so_acc
+
+  Example    : print $feat->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of nucleotide_match.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000347';
+}
 
 1;

--- a/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
@@ -51,6 +51,7 @@ use vars qw(@ISA);
 
 @ISA = qw( Bio::EnsEMBL::BaseAlignFeature );
 
+use constant SO_ACC => 'SO:0000349';
 
 =head2 _hit_unit
 
@@ -85,21 +86,6 @@ sub _hit_unit {
 
 sub _query_unit {
   return 3;
-}
-
-
-=head2 feature_so_acc
-
-  Example    : print $feat->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of protein_match.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000349';
 }
 
 

--- a/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
@@ -88,6 +88,19 @@ sub _query_unit {
 }
 
 
+=head2 feature_so_acc
+
+  Example    : print $feat->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of protein_match.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000349';
+}
 
 
 1;

--- a/modules/Bio/EnsEMBL/Exon.pm
+++ b/modules/Bio/EnsEMBL/Exon.pm
@@ -80,6 +80,8 @@ use Bio::EnsEMBL::DBSQL::SupportingFeatureAdaptor;
 use vars qw(@ISA);
 @ISA = qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0000147';
+
 
 =head2 new
 
@@ -1631,21 +1633,6 @@ sub load {
   $self->analysis();
   $self->stable_id();
   $self->get_all_supporting_features();
-}
-
-
-=head2 feature_so_acc
-
-  Example    : print $exon->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of Exon.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000147';
 }
 
 

--- a/modules/Bio/EnsEMBL/Exon.pm
+++ b/modules/Bio/EnsEMBL/Exon.pm
@@ -1633,6 +1633,22 @@ sub load {
   $self->get_all_supporting_features();
 }
 
+
+=head2 feature_so_acc
+
+  Example    : print $exon->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of Exon.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000147';
+}
+
+
 =head2 summary_as_hash
 
   Example       : $exon_summary = $exon->summary_as_hash();

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1449,6 +1449,7 @@ sub get_nearest_Gene {
 
   Description: This method returns a string containing the SO accession number of the feature
   Returntype : String (Sequence Ontology accession number)
+  Exceptions : Thrown if no SO accession can be returned for caller object type
 
 =cut
 
@@ -1480,7 +1481,11 @@ sub feature_so_acc {
     'Bio::EnsEMBL::KaryotypeBand'                         => 'SO:0000341', # chromosome_band
   );
 
-  return $feature_so_mapping{ ref $self };
+  my $ref = ref $self;
+
+  return $feature_so_mapping{ $ref } //
+    throw( "Bio::EnsEMBL::Feature::feature_so_acc is not defined for $ref objects. " .
+      "Please update Bio::EnsEMBL::Feature::feature_so_acc or implement ${ref}::feature_so_acc");
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -82,6 +82,7 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Scalar qw(check_ref assert_ref);
 use Bio::EnsEMBL::Slice;
+use Try::Tiny;
 use vars qw(@ISA);
 
 use Scalar::Util qw(weaken);
@@ -1448,9 +1449,9 @@ sub get_nearest_Gene {
 =head2 feature_so_acc
 
   Description: This method returns a string containing the SO accession number of the feature
-               Override this method in child classes that require it.
+               Define constant SO_ACC in classes that require it, or override it for multiple possible values for a class.
   Returntype : String (Sequence Ontology accession number)
-  Exceptions : Thrown if caller is not a Bio::EnsEMBL::Feature
+  Exceptions : Thrown if caller SO_ACC is undefined and is not a Bio::EnsEMBL::Feature
 
 =cut
 
@@ -1458,12 +1459,18 @@ sub feature_so_acc {
   my ($self) = @_;
 
   my $ref = ref $self;
+  my $so_acc;
 
-  unless ($ref eq 'Bio::EnsEMBL::Feature') {
-    throw( "${ref}::feature_so_acc is not implemented");
+  # Get the caller class SO acc
+  try {
+    $so_acc = $ref->SO_ACC;
+  };
+ 
+  unless ($so_acc || $ref eq 'Bio::EnsEMBL::Feature' ) {
+    throw( "constant SO_ACC in ${ref} is not defined");
   }
 
-  return 'SO:0000001';
+  return $so_acc // 'SO:0000001';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1480,7 +1480,7 @@ sub feature_so_acc {
     'Bio::EnsEMBL::KaryotypeBand'                         => 'SO:0000341', # chromosome_band
   );
 
-  return %feature_so_mapping{ ref $self };
+  return $feature_so_mapping{ ref $self };
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1448,44 +1448,22 @@ sub get_nearest_Gene {
 =head2 feature_so_acc
 
   Description: This method returns a string containing the SO accession number of the feature
+               Override this method in child classes that require it.
   Returntype : String (Sequence Ontology accession number)
-  Exceptions : Thrown if no SO accession can be returned for caller object type
+  Exceptions : Thrown if caller is not a Bio::EnsEMBL::Feature
 
 =cut
 
 sub feature_so_acc {
   my ($self) = @_;
 
-  # Classes that inherit Feature will inherit this method
-  # Slice and UTR override this method for better SO accs based on type
-  my %feature_so_mapping = (
-    'Bio::EnsEMBL::Feature'                               => 'SO:0000001', # region
-    'Bio::EnsEMBL::Gene'                                  => 'SO:0000704', # gene
-    'Bio::EnsEMBL::Transcript'                            => 'SO:0000673', # transcript
-    'Bio::EnsEMBL::PredictionTranscript'                  => 'SO:0000673', # transcript
-    'Bio::EnsEMBL::Exon'                                  => 'SO:0000147', # exon
-    'Bio::EnsEMBL::PredictionExon'                        => 'SO:0000147', # exon
-    'Bio::EnsEMBL::UTR'                                   => 'SO:0000203', # UTR
-    'Bio::EnsEMBL::ExonTranscript'                        => 'SO:0000147', # Exon
-    'Bio::EnsEMBL::CDS'                                   => 'SO:0000316', # CDS
-    'Bio::EnsEMBL::Slice'                                 => 'SO:0000001', # region
-    'Bio::EnsEMBL::SimpleFeature'                         => 'SO:0001411', # biological_region
-    'Bio::EnsEMBL::MiscFeature'                           => 'SO:0001411', # biological_region
-    'Bio::EnsEMBL::RepeatFeature'                         => 'SO:0000657', # repeat region
-    'Bio::EnsEMBL::Variation::VariationFeature'           => 'SO:0001060', # sequence variant
-    'Bio::EnsEMBL::Variation::StructuralVariationFeature' => 'SO:0001537', # structural variant
-    'Bio::EnsEMBL::Compara::ConstrainedElement'           => 'SO:0001009', # DNA_constraint_sequence ????
-    'Bio::EnsEMBL::Funcgen::RegulatoryFeature'            => 'SO:0005836', # regulatory_region
-    'Bio::EnsEMBL::DnaDnaAlignFeature'                    => 'SO:0000347', # nucleotide_match
-    'Bio::EnsEMBL::DnaPepAlignFeature'                    => 'SO:0000349', # protein_match
-    'Bio::EnsEMBL::KaryotypeBand'                         => 'SO:0000341', # chromosome_band
-  );
-
   my $ref = ref $self;
 
-  return $feature_so_mapping{ $ref } //
-    throw( "Bio::EnsEMBL::Feature::feature_so_acc is not defined for $ref objects. " .
-      "Please update Bio::EnsEMBL::Feature::feature_so_acc or implement ${ref}::feature_so_acc");
+  unless ($ref eq 'Bio::EnsEMBL::Feature') {
+    throw( "${ref}::feature_so_acc is not implemented");
+  }
+
+  return 'SO:0000001';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1445,6 +1445,44 @@ sub get_nearest_Gene {
   }
 }
 
+=head2 feature_so_acc
+
+  Description: This method returns a string containing the SO accession number of the feature
+  Returntype : String (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+  my ($self) = @_;
+
+  # Classes that inherit Feature will inherit this method
+  # Slice and UTR override this method for better SO accs based on type
+  my %feature_so_mapping = (
+    'Bio::EnsEMBL::Feature'                               => 'SO:0000001', # region
+    'Bio::EnsEMBL::Gene'                                  => 'SO:0000704', # gene
+    'Bio::EnsEMBL::Transcript'                            => 'SO:0000673', # transcript
+    'Bio::EnsEMBL::PredictionTranscript'                  => 'SO:0000673', # transcript
+    'Bio::EnsEMBL::Exon'                                  => 'SO:0000147', # exon
+    'Bio::EnsEMBL::PredictionExon'                        => 'SO:0000147', # exon
+    'Bio::EnsEMBL::UTR'                                   => 'SO:0000203', # UTR
+    'Bio::EnsEMBL::ExonTranscript'                        => 'SO:0000147', # Exon
+    'Bio::EnsEMBL::CDS'                                   => 'SO:0000316', # CDS
+    'Bio::EnsEMBL::Slice'                                 => 'SO:0000001', # region
+    'Bio::EnsEMBL::SimpleFeature'                         => 'SO:0001411', # biological_region
+    'Bio::EnsEMBL::MiscFeature'                           => 'SO:0001411', # biological_region
+    'Bio::EnsEMBL::RepeatFeature'                         => 'SO:0000657', # repeat region
+    'Bio::EnsEMBL::Variation::VariationFeature'           => 'SO:0001060', # sequence variant
+    'Bio::EnsEMBL::Variation::StructuralVariationFeature' => 'SO:0001537', # structural variant
+    'Bio::EnsEMBL::Compara::ConstrainedElement'           => 'SO:0001009', # DNA_constraint_sequence ????
+    'Bio::EnsEMBL::Funcgen::RegulatoryFeature'            => 'SO:0005836', # regulatory_region
+    'Bio::EnsEMBL::DnaDnaAlignFeature'                    => 'SO:0000347', # nucleotide_match
+    'Bio::EnsEMBL::DnaPepAlignFeature'                    => 'SO:0000349', # protein_match
+    'Bio::EnsEMBL::KaryotypeBand'                         => 'SO:0000341', # chromosome_band
+  );
+
+  return %feature_so_mapping{ ref $self };
+}
+
 =head2 summary_as_hash
 
   Example       : $feature_summary = $feature->summary_as_hash();

--- a/modules/Bio/EnsEMBL/Gene.pm
+++ b/modules/Bio/EnsEMBL/Gene.pm
@@ -1595,4 +1595,18 @@ sub biotype {
   return $self->get_Biotype->name;
 }
 
+=head2 feature_so_acc
+
+  Example    : print $gene->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of Gene.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000704';
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Gene.pm
+++ b/modules/Bio/EnsEMBL/Gene.pm
@@ -73,6 +73,7 @@ use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 
 use parent qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0000704';
 
 =head2 new
 
@@ -1593,20 +1594,6 @@ sub biotype {
 
   # Getter? get_Biotype()
   return $self->get_Biotype->name;
-}
-
-=head2 feature_so_acc
-
-  Example    : print $gene->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of Gene.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000704';
 }
 
 1;

--- a/modules/Bio/EnsEMBL/KaryotypeBand.pm
+++ b/modules/Bio/EnsEMBL/KaryotypeBand.pm
@@ -221,6 +221,22 @@ sub display_id {
   return $self->{'name'} || '';
 }
 
+
+=head2 feature_so_acc
+
+  Example    : print $feat->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of chromosome_band.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000341';
+}
+
+
 =head2 summary_as_hash
 
   Example       : $karyotype_band_summary = $band->summary_as_hash();

--- a/modules/Bio/EnsEMBL/KaryotypeBand.pm
+++ b/modules/Bio/EnsEMBL/KaryotypeBand.pm
@@ -82,6 +82,7 @@ use Bio::EnsEMBL::Utils::Exception qw(warning);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0000341';
 
 =head2 new
 
@@ -219,21 +220,6 @@ sub move {
 sub display_id {
   my $self = shift;
   return $self->{'name'} || '';
-}
-
-
-=head2 feature_so_acc
-
-  Example    : print $feat->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of chromosome_band.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000341';
 }
 
 

--- a/modules/Bio/EnsEMBL/MiscFeature.pm
+++ b/modules/Bio/EnsEMBL/MiscFeature.pm
@@ -360,6 +360,22 @@ sub display_id {
   }
 }
 
+
+=head2 feature_so_acc
+
+  Example    : print $feat->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of biological_region.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0001411';
+}
+
+
 =head2 summary_as_hash
 
   Example    : my $hash = $misc_feature->summary_as_hash();

--- a/modules/Bio/EnsEMBL/MiscFeature.pm
+++ b/modules/Bio/EnsEMBL/MiscFeature.pm
@@ -125,6 +125,8 @@ use vars qw(@ISA);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0001411';
+
 =head2 new
 
   Arg [-SLICE]: Bio::EnsEMBL::SLice - Represents the sequence that this
@@ -358,21 +360,6 @@ sub display_id {
   } else {
     return '';
   }
-}
-
-
-=head2 feature_so_acc
-
-  Example    : print $feat->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of biological_region.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0001411';
 }
 
 

--- a/modules/Bio/EnsEMBL/RepeatFeature.pm
+++ b/modules/Bio/EnsEMBL/RepeatFeature.pm
@@ -82,6 +82,8 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 
 use base qw/Bio::EnsEMBL::Feature/;
 
+use constant SO_ACC => 'SO:0000657';
+
 =head2 new
 
   Arg [REPEAT_CONSENSUS] : Bio::EnsEMBL::RepeatConsensus (optional)
@@ -265,20 +267,6 @@ sub display_id {
   }
 
   return $id;
-}
-
-=head2 feature_so_acc
-
-  Example    : print $feat->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of repeat_region.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000657';
 }
 
 

--- a/modules/Bio/EnsEMBL/RepeatFeature.pm
+++ b/modules/Bio/EnsEMBL/RepeatFeature.pm
@@ -267,6 +267,20 @@ sub display_id {
   return $id;
 }
 
+=head2 feature_so_acc
+
+  Example    : print $feat->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of repeat_region.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000657';
+}
+
 
 =head2 summary_as_hash
 

--- a/modules/Bio/EnsEMBL/SimpleFeature.pm
+++ b/modules/Bio/EnsEMBL/SimpleFeature.pm
@@ -172,6 +172,22 @@ sub score {
   return $self->{'score'};
 }
 
+
+=head2 feature_so_acc
+
+  Example    : print $feat->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of biological_region.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0001411';
+}
+
+
 =head2 summary_as_hash
 
   Example    : my $hash = $simple_feature->summary_as_hash();

--- a/modules/Bio/EnsEMBL/SimpleFeature.pm
+++ b/modules/Bio/EnsEMBL/SimpleFeature.pm
@@ -69,6 +69,7 @@ use Scalar::Util qw(weaken isweak);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0001411';
 
 =head2 new
 
@@ -170,21 +171,6 @@ sub score {
   my $self = shift;
   $self->{'score'} = shift if(@_);
   return $self->{'score'};
-}
-
-
-=head2 feature_so_acc
-
-  Example    : print $feat->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of biological_region.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0001411';
 }
 
 

--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -3777,7 +3777,9 @@ sub feature_so_acc {
   );
 
   # return the region SO acc, or Slice acc
-  return %region_so_mapping{$self->coord_system_name} // 'SO:0000001';
+  my $so_acc = %region_so_mapping{$self->coord_system_name} // 'SO:0000001';
+
+  return $so_acc;
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -3759,6 +3759,27 @@ sub add_synonym{
   return;
 }
 
+=head2 feature_so_acc
+
+  Example     : $slice_so_acc = $slice->feature_so_acc;
+  Description : This method returns a string containing the SO accession number of the slice, based on the coordinate system name.
+  Returns     : string (Sequence Ontology accession number)
+=cut
+
+sub feature_so_acc {
+  my $self = shift;
+
+  my %region_so_mapping = (
+   'chromosome'  => 'SO:0000340',
+   'supercontig' => 'SO:0000148',
+   'scaffold'    => 'SO:0000148',
+   'contig'      => 'SO:0000149'
+  );
+
+  # return the region SO acc, or Slice acc
+  return %region_so_mapping{$self->coord_system_name} // 'SO:0000001';
+}
+
 =head2 summary_as_hash
 
   Example       : $slice_summary = $slice->summary_as_hash();

--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -3777,7 +3777,7 @@ sub feature_so_acc {
   );
 
   # return the region SO acc, or Slice acc
-  return %region_so_mapping{$self->coord_system_name} // 'SO:0000001';
+  return $region_so_mapping{$self->coord_system_name} // 'SO:0000001';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -3777,9 +3777,7 @@ sub feature_so_acc {
   );
 
   # return the region SO acc, or Slice acc
-  my $so_acc = %region_so_mapping{$self->coord_system_name} // 'SO:0000001';
-
-  return $so_acc;
+  return %region_so_mapping{$self->coord_system_name} // 'SO:0000001';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -3759,6 +3759,15 @@ sub add_synonym{
   return;
 }
 
+
+# package variable to minimize duplication
+my %region_so_mapping = (
+ 'chromosome'  => 'SO:0000340',
+ 'supercontig' => 'SO:0000148',
+ 'scaffold'    => 'SO:0000148',
+ 'contig'      => 'SO:0000149'
+);
+
 =head2 feature_so_acc
 
   Example     : $slice_so_acc = $slice->feature_so_acc;
@@ -3768,13 +3777,6 @@ sub add_synonym{
 
 sub feature_so_acc {
   my $self = shift;
-
-  my %region_so_mapping = (
-   'chromosome'  => 'SO:0000340',
-   'supercontig' => 'SO:0000148',
-   'scaffold'    => 'SO:0000148',
-   'contig'      => 'SO:0000149'
-  );
 
   # return the region SO acc, or Slice acc
   return $region_so_mapping{$self->coord_system_name} // 'SO:0000001';

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3289,7 +3289,19 @@ sub biotype {
   return $self->get_Biotype->name;
 }
 
+=head2 feature_so_acc
 
+  Example    : print $transcript->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of Transcript.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+
+  return 'SO:0000673';
+}
 
 1;
 

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -77,6 +77,7 @@ use Bio::EnsEMBL::Utils::Scalar qw( assert_ref );
 
 use parent qw(Bio::EnsEMBL::Feature);
 
+use constant SO_ACC => 'SO:0000673';
 
 =head2 new
 
@@ -3289,19 +3290,4 @@ sub biotype {
   return $self->get_Biotype->name;
 }
 
-=head2 feature_so_acc
-
-  Example    : print $transcript->feature_so_acc;
-  Description: This method returns a string containing the SO accession number of Transcript.
-               Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returntype : string (Sequence Ontology accession number)
-
-=cut
-
-sub feature_so_acc {
-
-  return 'SO:0000673';
-}
-
 1;
-

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -220,6 +220,26 @@ sub type {
   return ( $self->{'type'} || 'UTR' );
 }
 
+=head2 feature_so_acc
+
+  Example    : print $utr->feature_so_acc;
+  Description: This method returns a string containing the SO accession number of the UTR, based on type.
+               Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returntype : string (Sequence Ontology accession number)
+
+=cut
+
+sub feature_so_acc {
+  my $self = shift;
+
+  my %utr_type_so_mapping = (
+   'five_prime_utr'  => 'SO:0000204',
+   'three_prime_utr' => 'SO:0000205'
+  );
+
+  # return UTR type SO acc, or UTR acc
+  return %utr_type_so_mapping{$self->type} // 'SO:0000203';
+}
 
 =head2 summary_as_hash
 

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -220,6 +220,13 @@ sub type {
   return ( $self->{'type'} || 'UTR' );
 }
 
+
+# package variable to minimize duplication
+my %utr_type_so_mapping = (
+ 'five_prime_utr'  => 'SO:0000204',
+ 'three_prime_utr' => 'SO:0000205'
+);
+
 =head2 feature_so_acc
 
   Example    : print $utr->feature_so_acc;
@@ -231,11 +238,6 @@ sub type {
 
 sub feature_so_acc {
   my $self = shift;
-
-  my %utr_type_so_mapping = (
-   'five_prime_utr'  => 'SO:0000204',
-   'three_prime_utr' => 'SO:0000205'
-  );
 
   # return UTR type SO acc, or UTR acc
   return $utr_type_so_mapping{$self->type} // 'SO:0000203';

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -238,9 +238,7 @@ sub feature_so_acc {
   );
 
   # return UTR type SO acc, or UTR acc
-  my $so_acc = %utr_type_so_mapping{$self->type} // 'SO:0000203';
-
-  return $so_acc;
+  return %utr_type_so_mapping{$self->type} // 'SO:0000203';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -238,7 +238,9 @@ sub feature_so_acc {
   );
 
   # return UTR type SO acc, or UTR acc
-  return %utr_type_so_mapping{$self->type} // 'SO:0000203';
+  my $so_acc = %utr_type_so_mapping{$self->type} // 'SO:0000203';
+
+  return $so_acc;
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -238,7 +238,7 @@ sub feature_so_acc {
   );
 
   # return UTR type SO acc, or UTR acc
-  return %utr_type_so_mapping{$self->type} // 'SO:0000203';
+  return $utr_type_so_mapping{$self->type} // 'SO:0000203';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/GFFSerializer.pm
@@ -49,7 +49,6 @@ package Bio::EnsEMBL::Utils::IO::GFFSerializer;
 use strict;
 use warnings;
 use Bio::EnsEMBL::Utils::Exception;
-use Bio::EnsEMBL::Utils::SequenceOntologyMapper;
 use URI::Escape;
 use Bio::EnsEMBL::Utils::IO::FeatureSerializer;
 use Bio::EnsEMBL::Utils::Scalar qw/check_ref/;
@@ -80,8 +79,7 @@ sub new {
     if ( ! check_ref($self->{'ontology_adaptor'}, "Bio::EnsEMBL::DBSQL::OntologyTermAdaptor" )) {
         throw("GFF format requires an instance of Bio::EnsEMBL::DBSQL::OntologyTermAdaptor to function.");        
     }
-    $self->{'mapper'} = Bio::EnsEMBL::Utils::SequenceOntologyMapper->new($self->{'ontology_adaptor'});
-    
+
     if (!defined ($self->{'filehandle'})) {
         # no file handle, let the handle point to a copy of STDOUT instead
         open $self->{'filehandle'}, ">&STDOUT";
@@ -108,7 +106,6 @@ sub new {
 sub print_feature {
     my $self = shift;
     my $feature = shift;
-    my $so_mapper = $self->{'mapper'};
 
     my $text_buffer = "";
     if ($feature->can('summary_as_hash') ) {
@@ -134,8 +131,22 @@ sub print_feature {
         $row .= qq{\t};
 
 #   Column 3 - feature, the ontology term for the kind of feature this row is
-	my $so_term = eval { $so_mapper->to_name($feature); };
-	$@ and throw sprintf "Unable to map feature %s to SO term.\n$@", $summary{id};
+        my $so_acc;
+        # get biotype SO acc if feature can do it
+        if ( $feature->can('get_Biotype') ) {
+            $so_acc = $feature->get_Biotype->so_acc;
+        }
+        # if no biotype SO acc, get the feature one
+        if ( !$so_acc ) {
+            $so_acc = $feature->feature_so_acc;
+        }
+        # could not get it, throw exception
+        if ( !$so_acc ) {
+            throw "Unable to map feature %s to SO.", $summary{id};
+        }
+        # with the acc, get the name
+        my $so_term = $self->{'ontology_adaptor'}->fetch_by_accession($so_acc)->name;
+
         if ($so_term eq 'protein_coding_gene') { 
 # Special treatment for protein_coding_gene, as more commonly expected term is 'gene'
           $so_term = 'gene';

--- a/modules/Bio/EnsEMBL/Utils/SequenceOntologyMapper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SequenceOntologyMapper.pm
@@ -305,6 +305,7 @@ my %feature_so_mapping =
 
 =head2 new
 
+    Deprecated. Please use $feature->feature_so_acc and $gene->get_Biotype instead.
     Constructor
     Arg [1]    : OntologyTermAdaptor from the EnsEMBL registry
     Returntype : Bio::EnsEMBL::SequenceOntologyMapper
@@ -314,6 +315,9 @@ my %feature_so_mapping =
 
 sub new {
   my ($class, $oa) = @_;
+
+  deprecate("new is deprecated and will be removed in e99.");
+
   defined $oa or throw "No ontology term adaptor specified";
 
   my $self =
@@ -338,6 +342,7 @@ sub new {
 
 =head2 to_accession
 
+    Deprecated. Please use $feature->feature_so_acc and $gene->get_Biotype->so_acc instead.
     Arg [0]    : Instance of Bio::EnsEMBL::Feature, subclass or
                  related Storable
     Description: translates a Feature type into an SO term accession
@@ -349,6 +354,8 @@ sub new {
 sub to_accession {
   my $self = shift;
   my $feature = shift;
+
+  deprecate("to_accession is deprecated and will be removed in e99.");
 
   my $so_accession;
   my $ref = ref($feature);
@@ -385,6 +392,10 @@ sub to_accession {
 
 =head2 to_name
 
+    Deprecated. Please use $feature->feature_so_acc and $gene->get_Biotype->so_acc instead to get the SO accession number.
+                Then initialize an Ontology adaptor to fetch the SO term name for that acc, as in the following example:
+                my $oa = Bio::EnsEMBL::Registry->get_adaptor('multi','ontology','OntologyTerm');
+                my $feat_so_name = $oa->fetch_by_accession($feature->feature_so_acc)->name;
     Arg [0]    : Instance of Bio::EnsEMBL::Feature, subclass or
                  related Storable
     Description: translates a Feature type into an SO term name
@@ -396,6 +407,8 @@ sub to_accession {
 sub to_name {
   my $self = shift;
   my $feature = shift;
+
+  deprecate("to_name is deprecated and will be removed in e99.");
 
   my $so_name;
   my $so_accession = eval {
@@ -416,6 +429,10 @@ sub to_name {
 
 =head2 gene_biotype_to_name
 
+    Deprecated. Please use $gene->get_Biotype->so_acc instead to get the SO accession number.
+                Then initialize an Ontology adaptor to fetch the SO term name for that acc, as in the following example:
+                my $oa = Bio::EnsEMBL::Registry->get_adaptor('multi','ontology','OntologyTerm');
+                my $biotype_so_name = $oa->fetch_by_accession($gene->get_Biotype->so_acc)->name;
     Arg [0]    : Biotype string
     Description: translates a biotype into an SO term name
     Returntype : String; the SO term name
@@ -427,6 +444,8 @@ sub gene_biotype_to_name {
   my $self = shift;
   my $biotype = shift;
 
+  deprecate("gene_biotype_to_name is deprecated and will be removed in e99.");
+
   if (exists $gene_so_mapping{$biotype}) {
     return $gene_so_mapping{$biotype};
   } else {
@@ -436,6 +455,10 @@ sub gene_biotype_to_name {
 
 =head2 transcript_biotype_to_name
 
+    Deprecated. Please use $transcript->get_Biotype->so_acc instead to get the SO accession number.
+                Then initialize an Ontology adaptor to fetch the SO term name for that acc, as in the following example:
+                my $oa = Bio::EnsEMBL::Registry->get_adaptor('multi','ontology','OntologyTerm');
+                my $biotype_so_name = $oa->fetch_by_accession($transcript->get_Biotype->so_acc)->name;
     Arg [0]    : Biotype string
     Description: translates a biotype into an SO term name
     Returntype : String; the SO term name
@@ -446,6 +469,8 @@ sub gene_biotype_to_name {
 sub transcript_biotype_to_name {
   my $self = shift;
   my $biotype = shift;
+
+  deprecate("transcript_biotype_to_name is deprecated and will be removed in e99.");
 
   if (exists $transcript_so_mapping{$biotype}) {
     return $transcript_so_mapping{$biotype};
@@ -459,6 +484,7 @@ sub transcript_biotype_to_name {
 
 =head2 _fetch_SO_name_by_accession
 
+  Deprecated. Please instantiate an ontology_adaptor and use $oa->fetch_by_accession($so_accession) directly
   Arg [0]    : String; Sequence Ontology accession
   Description: Returns the name linked to the given accession. These are
                internally cached for speed.
@@ -469,6 +495,9 @@ sub transcript_biotype_to_name {
 
 sub _fetch_SO_name_by_accession {
   my ($self, $so_accession) = @_;
+
+  deprecate("_fetch_SO_name_by_accession is deprecated and will be removed in e99.");
+
   my $so_name = $self->{cache}->{$so_accession};
 
   if(!$so_name) {

--- a/modules/Bio/EnsEMBL/Utils/SequenceOntologyMapper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SequenceOntologyMapper.pm
@@ -316,7 +316,7 @@ my %feature_so_mapping =
 sub new {
   my ($class, $oa) = @_;
 
-  deprecate("new is deprecated and will be removed in e99.");
+  deprecate("new is deprecated and will be removed in e98.");
 
   defined $oa or throw "No ontology term adaptor specified";
 
@@ -355,7 +355,7 @@ sub to_accession {
   my $self = shift;
   my $feature = shift;
 
-  deprecate("to_accession is deprecated and will be removed in e99.");
+  deprecate("to_accession is deprecated and will be removed in e98.");
 
   my $so_accession;
   my $ref = ref($feature);
@@ -408,7 +408,7 @@ sub to_name {
   my $self = shift;
   my $feature = shift;
 
-  deprecate("to_name is deprecated and will be removed in e99.");
+  deprecate("to_name is deprecated and will be removed in e98.");
 
   my $so_name;
   my $so_accession = eval {
@@ -444,7 +444,7 @@ sub gene_biotype_to_name {
   my $self = shift;
   my $biotype = shift;
 
-  deprecate("gene_biotype_to_name is deprecated and will be removed in e99.");
+  deprecate("gene_biotype_to_name is deprecated and will be removed in e98.");
 
   if (exists $gene_so_mapping{$biotype}) {
     return $gene_so_mapping{$biotype};
@@ -470,7 +470,7 @@ sub transcript_biotype_to_name {
   my $self = shift;
   my $biotype = shift;
 
-  deprecate("transcript_biotype_to_name is deprecated and will be removed in e99.");
+  deprecate("transcript_biotype_to_name is deprecated and will be removed in e98.");
 
   if (exists $transcript_so_mapping{$biotype}) {
     return $transcript_so_mapping{$biotype};
@@ -496,7 +496,7 @@ sub transcript_biotype_to_name {
 sub _fetch_SO_name_by_accession {
   my ($self, $so_accession) = @_;
 
-  deprecate("_fetch_SO_name_by_accession is deprecated and will be removed in e99.");
+  deprecate("_fetch_SO_name_by_accession is deprecated and will be removed in e98.");
 
   my $so_name = $self->{cache}->{$so_accession};
 

--- a/modules/t/MultiTestDB.conf.sqlite
+++ b/modules/t/MultiTestDB.conf.sqlite
@@ -1,0 +1,5 @@
+{
+  'driver' => 'SQLite',
+  'dbdir'  => '/home/tgrego/temp/',
+  'user'   => 'test_user',
+}

--- a/modules/t/MultiTestDB.conf.sqlite
+++ b/modules/t/MultiTestDB.conf.sqlite
@@ -1,5 +1,0 @@
-{
-  'driver' => 'SQLite',
-  'dbdir'  => '/home/tgrego/temp/',
-  'user'   => 'test_user',
-}

--- a/modules/t/cds.t
+++ b/modules/t/cds.t
@@ -50,5 +50,6 @@ for (my $i = 0; $i < $n; $i++) {
 
 is($cds[0]->start, $transcript->coding_region_start, "First cds is coding start");
 is($cds[$n-1]->end, $transcript->coding_region_end, "Last cds is coding end");
+is($cds[0]->feature_so_acc, 'SO:0000316', 'CDS feature SO acc is correct (CDS)');;
 
 done_testing();

--- a/modules/t/dnaDnaAlignFeature.t
+++ b/modules/t/dnaDnaAlignFeature.t
@@ -158,5 +158,6 @@ $f = $f->transfer($chr_slice->invert);
 ok($f);
 
 
+is($dnaf->feature_so_acc, 'SO:0000347', 'DnaDnaAlignFeature feature SO acc is correct (nucleotide_match)');
 
 done_testing();

--- a/modules/t/dnaPepAlignFeature.t
+++ b/modules/t/dnaPepAlignFeature.t
@@ -115,6 +115,7 @@ ok($dnaf->end == 16);
 #
 ok( scalar($dnaf->ungapped_features) == 2);
 
+is($dnaf->feature_so_acc, 'SO:0000349', 'dnaPepAlignFeature feature SO acc is correct (protein_match)');
 
 #
 # 12 Test retrieval from database

--- a/modules/t/exon.t
+++ b/modules/t/exon.t
@@ -110,6 +110,8 @@ allow_warnings(0) if $db->dbc->driver() eq 'SQLite';
 
 ok($exon->dbID() && $exon->adaptor == $exonad);
 
+is($exon->feature_so_acc, 'SO:0000147', 'Exon feature SO acc is correct (exon)');
+
 # now test fetch_by_dbID
 
 my $newexon = $exonad->fetch_by_dbID($exon->dbID);

--- a/modules/t/feature.t
+++ b/modules/t/feature.t
@@ -67,6 +67,7 @@ ok($feature->end == $end);
 ok($feature->strand == $strand);
 ok($feature->analysis == $analysis);
 ok($feature->slice == $slice);
+is($feature->feature_so_acc, 'SO:0000001', 'Feature feature SO acc is correct (feature)');
 
 #
 # Test setters
@@ -220,6 +221,7 @@ $slice = $db->get_SliceAdaptor->fetch_by_region('chromosome',
                                                  '20',
                                                  1_000_000,
                                                  2_000_000);
+is($slice->feature_so_acc, 'SO:0000340', 'Slice feature SO acc is correct (chromosome)');
 $feature->slice($slice);
 
 ok(!defined($feature->transform('contig')));
@@ -263,6 +265,7 @@ ok($feature->strand() == -1);
 $slice = $db->get_SliceAdaptor->fetch_by_region('contig',
                                                 'AL359765.6.1.13780',
                                                 '30', '3000');
+is($slice->feature_so_acc, 'SO:0000149', 'Slice feature SO acc is correct (supercontig)');
 
 $feature = $feature->transfer($slice);
 debug("\ntransfer to contig slice");
@@ -635,6 +638,7 @@ ok( scalar( @alt ) == 0 );
 
 my $gene_adaptor = $db->get_GeneAdaptor;
 my $gene = $gene_adaptor->fetch_by_stable_id('ENSG00000171456');
+is($gene->feature_so_acc, 'SO:0000704', 'Gene feature SO acc is correct (gene)');
 my $o_genes = $gene->get_overlapping_Genes;
 is($o_genes->[0]->stable_id,'ENSG00000171456','Check overlap with a feature that overlaps nothing');
 $chr_slice = $o_genes->[0]->feature_Slice;

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -98,6 +98,8 @@ ok($gene->external_db eq "Uniprot/SPTREMBL");
 debug("Gene display xref id: " . $gene->display_xref->dbID);
 ok($gene->display_xref->dbID() == 128324);
 
+is($gene->feature_so_acc, 'SO:0000704', 'Gene feature SO acc is correct (gene)');
+
 # test the getters and setters
 ok(test_getter_setter($gene, "external_name", "banana"));
 ok(test_getter_setter($gene, "external_db",   "dummy"));

--- a/modules/t/karyotypeBand.t
+++ b/modules/t/karyotypeBand.t
@@ -57,6 +57,7 @@ ok($kb->stain() eq $stain);
 ok($kb->name() eq $name);
 ok($kb->slice == $slice);
 ok($kb->display_id eq $name);
+is($kb->feature_so_acc, 'SO:0000341', 'KaryotypeBand feature SO acc is correct (chromosome_band)');
 
 #
 # test getter/setters

--- a/modules/t/miscFeature.t
+++ b/modules/t/miscFeature.t
@@ -31,7 +31,7 @@ my $mf = Bio::EnsEMBL::MiscFeature->new(-START => 10,
                                         -END   => 100);
 
 ok($mf->start() == 10 && $mf->end() == 100);
-
+is($mf->feature_so_acc, 'SO:0001411', 'MiscFeature feature SO acc is correct (biological_region)');
 
 
 #

--- a/modules/t/operon_transcript.t
+++ b/modules/t/operon_transcript.t
@@ -18,6 +18,7 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use Test::Exception;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
 use Bio::EnsEMBL::Operon;
@@ -55,6 +56,7 @@ my $operon = Bio::EnsEMBL::Operon->new( -START         => $start,
 										-SLICE         => $slice,
 										-DISPLAY_LABEL => $display_label, -STABLE_ID=>"op1", -ANALYSIS=>$analysis );
 	is( $analysis,        $operon->analysis());
+throws_ok { $operon->feature_so_acc } qr/not implemented/, 'Operon feature_so_acc is not implemented';
 
 my $gene_name    = "accB";
 my $gene_start   = 31225346;
@@ -136,6 +138,8 @@ my $operon_transcript =
 									   -SLICE  => $slice, -STABLE_ID=>"opt1", -ANALYSIS=>$analysis  );
 $operon_transcript->add_Gene($gene);
 $operon_transcript->add_Gene($gene2);
+throws_ok { $operon_transcript->feature_so_acc } qr/not implemented/, 'OperonTranscript feature_so_acc is not implemented';
+
 $operon->add_OperonTranscript($operon_transcript);
 is( $analysis,        $operon_transcript->analysis(), "Analysis" );
 

--- a/modules/t/operon_transcript.t
+++ b/modules/t/operon_transcript.t
@@ -56,7 +56,7 @@ my $operon = Bio::EnsEMBL::Operon->new( -START         => $start,
 										-SLICE         => $slice,
 										-DISPLAY_LABEL => $display_label, -STABLE_ID=>"op1", -ANALYSIS=>$analysis );
 	is( $analysis,        $operon->analysis());
-throws_ok { $operon->feature_so_acc } qr/not implemented/, 'Operon feature_so_acc is not implemented';
+throws_ok { $operon->feature_so_acc } qr/not defined/, 'Operon feature_so_acc is not implemented';
 
 my $gene_name    = "accB";
 my $gene_start   = 31225346;
@@ -138,7 +138,7 @@ my $operon_transcript =
 									   -SLICE  => $slice, -STABLE_ID=>"opt1", -ANALYSIS=>$analysis  );
 $operon_transcript->add_Gene($gene);
 $operon_transcript->add_Gene($gene2);
-throws_ok { $operon_transcript->feature_so_acc } qr/not implemented/, 'OperonTranscript feature_so_acc is not implemented';
+throws_ok { $operon_transcript->feature_so_acc } qr/not defined/, 'OperonTranscript feature_so_acc is not implemented';
 
 $operon->add_OperonTranscript($operon_transcript);
 is( $analysis,        $operon_transcript->analysis(), "Analysis" );

--- a/modules/t/predictionTranscript.t
+++ b/modules/t/predictionTranscript.t
@@ -131,6 +131,7 @@ $exon->slice( $slice );
 $exon->strand( 1 );
 $pt->add_Exon($exon);
 
+is($exon->feature_so_acc, 'SO:0000147', 'PredictionExon feature SO acc is correct (exon)');
 
 #check that transcript start + end updated
 ok( $pt->end() == 50 );
@@ -174,7 +175,7 @@ $all_exons = $pt->get_all_Exons();
 ok( $all_exons->[0]->start() == 40 );
 ok( $all_exons->[2]->end() == 10 );
 
-
+is($pt->feature_so_acc, 'SO:0000673', 'PredictionTranscript feature SO acc is correct (transcript)');
 
 
 

--- a/modules/t/repeatFeature.t
+++ b/modules/t/repeatFeature.t
@@ -86,6 +86,7 @@ ok($rf->hend == $hend);
 ok($rf->score == $score);
 ok($rf->repeat_consensus == $repeat_consensus);
 
+is($rf->feature_so_acc, 'SO:0000657', 'RepeatFeature feature SO acc is correct (repeat_region)');
 
 #
 # Test Getter/Setters

--- a/modules/t/simpleFeature.t
+++ b/modules/t/simpleFeature.t
@@ -150,6 +150,7 @@ print_features([$feat]);
 my $ids = $sfa->list_dbIDs();
 ok (@{$ids});
 
+is($feat->feature_so_acc, 'SO:0001411', 'SimpleFeature feature SO acc is correct (biological_region)');
 
 ok($feat->display_id eq $feat->display_label);
 

--- a/modules/t/slice.t
+++ b/modules/t/slice.t
@@ -56,7 +56,7 @@ is($slice->start, $START, "Slice start is $START");
 is($slice->end, $END, "Slice end is $END");
 is($slice->seq_region_length, 62842997, "Slice length is correct");
 is($slice->adaptor, $slice_adaptor, "Slice has adaptor $slice_adaptor");
-
+is($slice->feature_so_acc, 'SO:0000340', 'Slice feature SO acc is correct (chromosome)');
 
 #
 #TEST - Slice::new
@@ -219,6 +219,8 @@ is($clone->end(), $len + 1000, "Clone end matches $len + 1000");
 $clone = $clone->expand(-1000, 0, 1);
 is($clone->start, 1001, "Expanded clone start is correct if forced");
 is($clone->end(), $len + 1000, "Expanded clone end is correct if forced");
+
+is($clone->feature_so_acc, 'SO:0000001', 'Clone feature SO acc is correct (region)');
 
 #
 # Test constrain_to_seq_region

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -162,6 +162,8 @@ is( $tr->coding_region_start(), 85834, 'Correct coding region start' );
 
 is( $tr->coding_region_end(), 108631, 'Correct coding region end' );
 
+is( $tr->feature_so_acc, 'SO:0000673', 'Transcript feature SO acc is correct (transcript)' );
+
 my @pepcoords = $tr->pep2genomic( 10, 20 );
 is( $pepcoords[0]->start(), 85861, 'Correct translation start' );
 

--- a/modules/t/utr.t
+++ b/modules/t/utr.t
@@ -77,7 +77,8 @@ sub try_utrs {
     is($three_utrs[$three-1]->end, $transcript->end, "Three prime ends at transcript end");
     is($five_utrs[0]->seq_region_start, $transcript->seq_region_start, "Five prime seq_region_starts at transcript seq_region_start");
     is($three_utrs[$three-1]->seq_region_end, $transcript->seq_region_end, "Three prime seq_region_ends at transcript seq_region_end");
-
+    is($five_utrs[0]->feature_so_acc, 'SO:0000204', 'UTR feature SO acc is correct (five_prime_utr)');
+    is($three_utrs[0]->feature_so_acc, 'SO:0000205', 'UTR feature SO acc is correct (three_prime_utr)');
 
 }
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This PR deprecates the SequenceOntologyMapper, providing the missing alternative ways to have all the functionality it provides.
To get the SO acc of a feature:
`$feature->feature_so_acc`
To get the SO acc of a gene/transcript biotype:
`$feature->get_Biotype->so_acc`
To get the SO name of a SO acc:
`$oa = Bio::EnsEMBL::Registry->get_adaptor('multi','ontology','OntologyTerm');`
`$so_name = $oa->fetch_by_accession($so_acc)->name;`

If you want biotype SOs and fallback to feature SOs, implement that logic in your code.



## Use case

SequenceOntologyMapper provides a way to access SO terms for biotypes and feature types, through a series of lookup tables.
The Gene and Transcript biotype SO terms could already be accessed alternatively using the Biotype object that can be accessed by the get_Biotype method on gene and transcript objects.
Feature type SO terms were missing and are now implemented, through the new method feature_so_acc that is inherited and can be overridden by features. 

## Benefits

Removing the SequenceOntologyMapper

## Possible Drawbacks

Although a 'feature' thing, Slice implements feature_so_acc. Slice is however not a feature, but will return either the SO of its coordinate system if available or of a generic region.

Bio::EnsEMBL::Compara::ConstrainedElement was included in the SequenceOntologyMapper. It is however not a feature, and thus will need implementation of feature_so_acc. Attention, this is in ensembl-compara.

GFFSerializer in this repo used the SequenceOntologyMapper and was updated to use the alternative ways, removing the SequenceOntologyMapper requirement.
Other modules in ensembl-production and ensembl-io (and maybe more?) make use of SequenceOntologyMapper and require similar updates.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.
