### PR TITLE
Bugfix/reactome acc

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
@@ -113,6 +113,7 @@ sub run {
     while (my $line = $reactome_io->getline() ) {
       chomp $line;
       my ($ensembl_stable_id, $reactome_id, $url, $description, $evidence, $species) = split /\t+/,$line;
+      if ($description!~ /^[A-Za-z0-9_,\(\)\/\-\.:\+'&;>\s]+$/) { next; }
   
       $species =~ s/\s//;
       $species = lc($species);

--- a/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
@@ -113,7 +113,7 @@ sub run {
     while (my $line = $reactome_io->getline() ) {
       chomp $line;
       my ($ensembl_stable_id, $reactome_id, $url, $description, $evidence, $species) = split /\t+/,$line;
-      if ($description!~ /^[A-Za-z0-9_,\(\)\/\-\.:\+'&;>\s]+$/) { next; }
+      if ($description!~ /^[A-Za-z0-9_,\(\)\/\-\.:\+'&;"\/\?%>\s\[\]]+$/) { next; }
   
       $species =~ s/\s//;
       $species = lc($species);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The description field is compared to a regex and if the description does not match, it is skipped

## Use case

Some Reactome descriptions have characters that do not comply with MySQL ASCII. This regex will skip these.
An example of skipped description is 'Biosynthesis of electrophilic ω-3 PUFA oxo-derivatives', because of the greek omega (ω)

## Benefits

The pipeline does not fail for everything because some characters in the Reactome source are not compatible with MySQL

## Possible Drawbacks

The regex is not comprehensive, so it can skip some descriptions we have not yet accounted for.

## Testing

_Have you added/modified unit tests to test the changes?_

The xref pipeline does not have any tests, so the test suite has not been changed. The parser has been tested on the latest Reactome file though. 1648 entries were skipped out of the 1077438 lines in the file. These entries correspond to two distinct descriptions, 'Biosynthesis of electrophilic ω-3 PUFA oxo-derivatives' and 'Loss of proteins required for interphase microtubule organization from the centrosome'

