### PR TITLE
ENSCORESW-2695: expand methods for REST support

### DIFF
--- a/modules/t/biotype.t
+++ b/modules/t/biotype.t
@@ -112,4 +112,24 @@ like( $warning2,
     "Got a warning from fetch_all_by_group_object_db_type",
 ) or diag 'Got warning: ', explain($warning2);
 
+# Test fetching by biotype name
+debug("fetch biotypes by name");
+my $biotypes3 = $biotype_adaptor->fetch_all_by_name('protein_coding');
+is(ref $biotypes3, 'ARRAY', 'Got an array');
+cmp_ok(scalar(@$biotypes3), ">", "0", 'Array is not empty');
+is_deeply($biotypes3, [$biotype1, $biotype2], 'with the correct objects');
+my $warning3 = warning {
+  $biotypes3 = $biotype_adaptor->fetch_all_by_name('none') };
+like( $warning3,
+    qr/No objects retrieved. Check if name 'none' is correct./,
+    "Got a warning from fetch_all_by_name",
+) or diag 'Got warning: ', explain($warning3);
+is(ref $biotypes3, 'ARRAY', 'Got an array');
+is(scalar @{$biotypes3}, '0', 'of size 0');
+is_deeply($biotypes3, [], 'totally empty');
+
+my $biotypes4 = $biotype_adaptor->fetch_all_by_name('protein_coding', 'gene');
+my $biotypes5 = $biotype_adaptor->fetch_by_name_object_type('protein_coding', 'gene');
+is_deeply($biotypes4->[0], $biotypes5, "fetch_all_by_name with an object type is identical to fetch_by_name_object_type");
+
 done_testing();


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

New fetch_all_by_name method, used for REST endpoints.

## Use case

Some REST endpoints retrieve information on biotypes by their names. The original implementation uses straight SQL queries. Replacement methods have now been implemented on the BiotypeAdaptor.

## Benefits

Some direct SQL removed, makes it easier to protect the REST endpoints from schema changes.

## Possible Drawbacks

Some scenarios might not be tested for

## Testing

_Have you added/modified unit tests to test the changes?_

Yes. Added some tests in the biotype.t

_If so, do the tests pass/fail?_

Yes
_Have you run the entire test suite and no regression was detected?_

Yes.
