### PR TITLE
Bugfix/default aln method

### DIFF
--- a/sql/patch_93_94_b.sql
+++ b/sql/patch_93_94_b.sql
@@ -25,4 +25,4 @@ UPDATE object_xref SET analysis_id = NULL WHERE analysis_id = 0;
 
 # patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
-  VALUES (NULL, 'patch', 'patch_93_94_c.sql|nullable_ox_analysis');
+  VALUES (NULL, 'patch', 'patch_93_94_b.sql|nullable_ox_analysis');

--- a/sql/patch_93_94_c.sql
+++ b/sql/patch_93_94_c.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2018] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_93_94_c.sql
+#
+# Title: Default align_type is 'ensembl'
+#
+# Description:
+#   Ensure default align_type in align_feature tables is 'ensembl'
+
+ALTER TABLE protein_feature MODIFY COLUMN align_type ENUM('ensembl', 'cigar', 'cigarplus', 'vulgar', 'mdtag') DEFAULT NULL;
+UPDATE protein_feature SET align_type = NULL WHERE align_type = '';
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_93_94_c.sql|default_aln_type');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -316,7 +316,7 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_93_94_a.sql|schema_version');
 INSERT INTO meta (species_id, meta_key, meta_value)
-  VALUES (NULL, 'patch', 'patch_93_94_c.sql|nullable_ox_analysis');
+  VALUES (NULL, 'patch', 'patch_93_94_b.sql|nullable_ox_analysis');
 
 
 /**

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -317,6 +317,8 @@ INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_93_94_a.sql|schema_version');
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_93_94_b.sql|nullable_ox_analysis');
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_93_94_c.sql|default_aln_type');
 
 
 /**
@@ -962,7 +964,7 @@ CREATE TABLE protein_feature (
   external_data               TEXT,
   hit_description             TEXT,
   cigar_line                  TEXT,
-  align_type                  ENUM('ensembl', 'cigar', 'cigarplus', 'vulgar', 'mdtag'),
+  align_type                  ENUM('ensembl', 'cigar', 'cigarplus', 'vulgar', 'mdtag') default NULL,
 
   UNIQUE KEY aln_idx (translation_id,hit_name,seq_start,seq_end,hit_start,hit_end,analysis_id),
   PRIMARY KEY (protein_feature_id),


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Ensure there is a default align_type for protein_feature and it is ensembl

## Use case

The align_type column in the protein_feature table is an enum. Existing scripts and pipeline that do not use this column should not have to worry about assigning it, hence it is useful to have a default value that makes sense. This is set to 'ensembl' by default. Other

## Benefits

When new entries are added, the align_type will not be set to an empty string.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

This will be updating the protein_feature table in all existing core databases, so this might take a while to run

## Testing

_Have you added/modified unit tests to test the changes?_

No additional tests required.

_If so, do the tests pass/fail?_

All tests pass, in particular schemaPatches, that ensures the patch file is in sync with table.sql

_Have you run the entire test suite and no regression was detected?_

Yes.
