### PR TITLE
Fix meta entry in patch_93_94_b.sql

### DIFF
--- a/sql/patch_93_94_b.sql
+++ b/sql/patch_93_94_b.sql
@@ -25,4 +25,4 @@ UPDATE object_xref SET analysis_id = NULL WHERE analysis_id = 0;
 
 # patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)
-  VALUES (NULL, 'patch', 'patch_93_94_c.sql|nullable_ox_analysis');
+  VALUES (NULL, 'patch', 'patch_93_94_b.sql|nullable_ox_analysis');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -316,7 +316,7 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_93_94_a.sql|schema_version');
 INSERT INTO meta (species_id, meta_key, meta_value)
-  VALUES (NULL, 'patch', 'patch_93_94_c.sql|nullable_ox_analysis');
+  VALUES (NULL, 'patch', 'patch_93_94_b.sql|nullable_ox_analysis');
 
 
 /**


### PR DESCRIPTION

## Description

patch_93_94_b.sql incorrectly identified itself as _c in its entry in the meta table. Fixed.

## Use case

The old behaviour introduced an inconsistency and could perhaps cause problems with automatic patching of databases.

## Benefits

Patch _b is now correctly logged as _b in the meta table.

## Possible Drawbacks

None I can think of.
