### PR TITLE
ENSCORESW-2742: clean up descriptions from automatic updates

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
@@ -234,7 +234,7 @@ sub set_display_xrefs_from_stable_table{
 
   # Remove descriptions assigned through the xref pipeline, recognisable by the 'Source' field
   # This will maintain any manually added descriptions
-  $reset_sth = $core_dbi->prepare("UPDATE gene SET description = null WHERE description like '%Source%'");
+  $reset_sth = $core_dbi->prepare("UPDATE gene SET description = null WHERE description like '%[Source:%]%'");
   $reset_sth->execute();
   $reset_sth->finish;
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_One or more sentences describing in detail the proposed changes._

Descriptions assigned by the automatic xref update have a 'Source' field and are removed before adding the newly assigned descriptions.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

For merged species, there will be a mix of descriptions assigned by the annotators and descriptions assigned by the automatic xref pipeline. While xref updates can be run every release, the annotation is not updated every release. When running xref updates on an annotation that has not changed since the last release, the database will contain two types of descriptions: the manually assigned ones to be conserved and the automatically assigned ones that might become obsolete through the xref update. By deleting the descriptions of type '%Source%', we ensure the latter ones are deleted while the former are conserved.

## Benefits

_If applicable, describe the advantages the changes will have._

We do not keep descriptions which are obsolete due to updated mappings.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

Some genes will lose all description if their xref mapping is lost.

## Testing

_Have you added/modified unit tests to test the changes?_

The xref pipeline has been tested with the change and the results are identical to the previous run.

_If so, do the tests pass/fail?_

NA

_Have you run the entire test suite and no regression was detected?_

NA
