### PR TITLE
ENSCORESW-2758: default align type is NULL

### DIFF
--- a/modules/Bio/EnsEMBL/ProteinFeature.pm
+++ b/modules/Bio/EnsEMBL/ProteinFeature.pm
@@ -108,7 +108,7 @@ sub new {
   $self->{'external_data'} = $external_data || '';
   $self->{'hit_description'} = $hit_description || '';
   $self->{'cigar_string'} = $cigar_string || '';
-  $self->{'align_type'} = $align_type || '';
+  $self->{'align_type'} = $align_type;
 
   return $self;
 }

--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:28:02 2018
+-- Created on Thu Jun 28 16:50:47 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -121,3 +121,4 @@
 121	\N	patch	patch_92_93_c.sql|collate_index_interpro
 122	\N	patch	patch_93_94_a.sql|schema_version
 123	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+124	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=124 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=125 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:28:13 2018
+-- Created on Thu Jun 28 16:50:58 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -100,3 +100,4 @@
 167	\N	patch	patch_92_93_c.sql|collate_index_interpro
 168	\N	patch	patch_93_94_a.sql|schema_version
 169	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+170	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=170 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:28:23 2018
+-- Created on Thu Jun 28 16:51:08 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -100,3 +100,4 @@
 149	\N	patch	patch_92_93_c.sql|collate_index_interpro
 150	\N	patch	patch_93_94_a.sql|schema_version
 151	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+152	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=152 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:28:34 2018
+-- Created on Thu Jun 28 16:51:18 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -105,3 +105,4 @@
 2112	\N	patch	patch_92_93_c.sql|collate_index_interpro
 2113	\N	patch	patch_93_94_a.sql|schema_version
 2114	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+2115	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2115 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2116 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:28:44 2018
+-- Created on Thu Jun 28 16:51:29 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -61,3 +61,4 @@
 154	\N	patch	patch_92_93_c.sql|collate_index_interpro
 155	\N	patch	patch_93_94_a.sql|schema_version
 156	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+157	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=157 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=158 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:29:04 2018
+-- Created on Thu Jun 28 16:51:47 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -178,3 +178,4 @@
 1690	\N	patch	patch_92_93_c.sql|collate_index_interpro
 1691	\N	patch	patch_93_94_a.sql|schema_version
 1692	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+1693	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1693 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1694 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:29:14 2018
+-- Created on Thu Jun 28 16:51:58 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/nameless/core/meta.txt
+++ b/modules/t/test-genome-DBs/nameless/core/meta.txt
@@ -99,3 +99,4 @@
 153	\N	patch	patch_92_93_c.sql|collate_index_interpro
 154	\N	patch	patch_93_94_a.sql|schema_version
 155	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+156	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -479,7 +479,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=156 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=157 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:29:29 2018
+-- Created on Thu Jun 28 16:52:13 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -154,3 +154,4 @@
 234	\N	patch	patch_92_93_c.sql|collate_index_interpro
 235	\N	patch	patch_93_94_a.sql|schema_version
 236	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+237	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -489,7 +489,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=237 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=238 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Apr 25 09:29:39 2018
+-- Created on Thu Jun 28 16:52:23 2018
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -174,3 +174,4 @@
 216	\N	patch	patch_92_93_c.sql|collate_index_interpro
 217	\N	patch	patch_93_94_a.sql|schema_version
 218	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
+219	\N	patch	patch_93_94_c.sql|default_aln_type

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -479,7 +479,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=219 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=220 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/sql/patch_93_94_c.sql
+++ b/sql/patch_93_94_c.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2018] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_93_94_c.sql
+#
+# Title: Default align_type is 'ensembl'
+#
+# Description:
+#   Ensure default align_type in align_feature tables is 'ensembl'
+
+ALTER TABLE protein_feature MODIFY COLUMN align_type ENUM('ensembl', 'cigar', 'cigarplus', 'vulgar', 'mdtag') DEFAULT NULL;
+UPDATE protein_feature SET align_type = NULL WHERE align_type = '';
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_93_94_c.sql|default_aln_type');

--- a/sql/patch_93_94_c.sql
+++ b/sql/patch_93_94_c.sql
@@ -15,7 +15,7 @@
 
 # patch_93_94_c.sql
 #
-# Title: Default align_type is 'ensembl'
+# Title: Default align_type is NULL
 #
 # Description:
 #   Ensure default align_type in align_feature tables is 'ensembl'

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -317,6 +317,8 @@ INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_93_94_a.sql|schema_version');
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_93_94_b.sql|nullable_ox_analysis');
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_93_94_c.sql|default_aln_type');
 
 
 /**
@@ -962,7 +964,7 @@ CREATE TABLE protein_feature (
   external_data               TEXT,
   hit_description             TEXT,
   cigar_line                  TEXT,
-  align_type                  ENUM('ensembl', 'cigar', 'cigarplus', 'vulgar', 'mdtag'),
+  align_type                  ENUM('ensembl', 'cigar', 'cigarplus', 'vulgar', 'mdtag') DEFAULT NULL,
 
   UNIQUE KEY aln_idx (translation_id,hit_name,seq_start,seq_end,hit_start,hit_end,analysis_id),
   PRIMARY KEY (protein_feature_id),


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Ensure there is a default align_type for protein_feature and it is ensembl

## Use case

The align_type column in the protein_feature table is an enum. Existing scripts and pipeline that do not use this column should not have to worry about assigning it, hence it is useful to have a default value that makes sense. This is set to 'ensembl' by default. Other

## Benefits

When new entries are added, the align_type will not be set to an empty string.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

This will be updating the protein_feature table in all existing core databases, so this might take a while to run

## Testing

_Have you added/modified unit tests to test the changes?_

No additional tests required.

_If so, do the tests pass/fail?_

All tests pass, in particular schemaPatches, that ensures the patch file is in sync with table.sql

_Have you run the entire test suite and no regression was detected?_

Yes.