### PR TITLE
ENSCORESW-2740: fetch correct xref

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
@@ -597,7 +597,7 @@ sub transcript_names_from_gene {
   my $xref_id_sth = $core_dbi->prepare("SELECT max(xref_id) FROM xref");
   my $ox_id_sth = $core_dbi->prepare("SELECT max(object_xref_id) FROM object_xref");
   my $del_xref_sth = $core_dbi->prepare("DELETE x FROM xref x, object_xref ox WHERE x.xref_id = ox.xref_id AND ensembl_object_type = 'Transcript' AND display_label REGEXP '-2[0-9]{2}\$'");
-  my $reuse_xref_sth = $core_dbi->prepare("SELECT xref_id FROM xref x WHERE external_db_id = ? AND display_label = ? AND description = ? AND info_type = 'MISC'");
+  my $reuse_xref_sth = $core_dbi->prepare("SELECT xref_id FROM xref x WHERE external_db_id = ? AND display_label = ? AND info_type = 'MISC'");
   my $del_ox_sth = $core_dbi->prepare("DELETE ox FROM object_xref ox LEFT JOIN xref x ON x.xref_id = ox.xref_id WHERE isnull(x.xref_id)");
   my $ins_xref_sth = $core_dbi->prepare("INSERT IGNORE into xref (xref_id, external_db_id, dbprimary_acc, display_label, version, description, info_type, info_text) values(?, ?, ?, ?, 0, ?, 'MISC', ?)");
   my $ins_ox_sth = $core_dbi->prepare("INSERT into object_xref (object_xref_id, ensembl_id, ensembl_object_type, xref_id) values(?, ?, 'Transcript', ?)");
@@ -627,7 +627,7 @@ sub transcript_names_from_gene {
     while ($get_transcripts->fetch) {
       $xref_id++;
       $ox_id++;
-      $reuse_xref_sth->execute($external_db_id, $label . '-' . $ext, $description);
+      $reuse_xref_sth->execute($external_db_id, $label . '-' . $ext);
       $reuse_xref_sth->bind_columns(\$reuse_xref_id);
       if ($reuse_xref_sth->fetch()) {
         $ins_ox_sth->execute($ox_id, $transcript_id, $reuse_xref_id);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_One or more sentences describing in detail the proposed changes._

Allows to re-use duplicated entries with null descriptions.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

When assigning display_xrefs, it is possible to re-use the same display_xref for the transcript if the gene name is assigned to multiple genes. In this case, it is not possible to store the same entry twice and the existing entry should be re-used. As the description field can be null, it cannot be included in the query, otherwise the existing entry is not found and a new one is attempted to store but fails.

## Benefits

_If applicable, describe the advantages the changes will have._

The DisplayXref HC is not failing any more and transcripts get correctly assigned a display_xref.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

If we have two xrefs with the same display_label and accession but different descriptions, we will not store the description for the second one. Fundamentally, the same display_label should not have two different descriptions.

## Testing

_Have you added/modified unit tests to test the changes?_

The xref pipeline was run with the SQL query updated on a species which failed DisplayXref in release 93. Running the pipeline on the exact same database, including the change means the HC does not fail.

_If so, do the tests pass/fail?_

The pipeline and HCs pass, the test suite does not include xref code.

_Have you run the entire test suite and no regression was detected?_

NA