### PR TITLE
Do not call fetchrow_hashref() if the statement has been exhausted

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/SqlHelper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SqlHelper.pm
@@ -948,6 +948,7 @@ sub _execute {
   my $sth_processor;
   if($use_hashrefs) {
     $sth_processor = sub {
+      return unless $sth->{Active};
       while( my $row = $sth->fetchrow_hashref() ) {
         my $v = $callback->($row, $sth);
         return $v if $has_return;
@@ -958,6 +959,7 @@ sub _execute {
   }
   else {
     $sth_processor = sub {
+      return unless $sth->{Active};
       while( my $row = $sth->fetchrow_arrayref() ) {
         my $v = $callback->($row, $sth);
         return $v if $has_return;

--- a/modules/t/sqlHelper.t
+++ b/modules/t/sqlHelper.t
@@ -152,6 +152,17 @@ my $null_count_hash = $helper->execute_into_hash(
 
 ok(!exists $null_count_hash->{1}, 'Checking hash doesnt contain key for NULL value');
 
+my $iterator = $helper->execute(
+  -SQL => 'SELECT 1',
+  -ITERATOR => 1,
+);
+
+ok($iterator->has_next, 'The iterator is not empty');
+ok($iterator->has_next, 'The iterator is still not empty');
+is_deeply($iterator->to_arrayref, [[1]], 'The iterator returns all the data');
+ok(!$iterator->has_next, 'The iterator is now empty');
+ok(!$iterator->has_next, 'The iterator is still empty');
+
 ##### CHECKING WORKING WITH A STH DIRECTLY
 {
   my $v = $helper->execute_with_sth(-SQL => 'select count(*) from meta', -CALLBACK => sub {


### PR DESCRIPTION
## Description

`has_next` in `Utils::Iterator` calls `next`, and expects `next` to repeatedly return _undef_ once the iterator has been exhausted.

`Utils::SqlHelper` can return an iterator based on the sub below, but the sub calls `fetchrow_hashref()` every time it is called, even when the iterator has already reached the end.

So if you build an iterator with SqlHelper, exhaust it, and then call `has_next`, you'll get this error
```
DBD::mysql::st fetchrow_arrayref failed: fetch() without execute() at ensembl/modules/Bio/EnsEMBL/Utils/SqlHelper.pm line 961.
```

My solution is to check whether the handle is still _Active_ as it is set to false when all the rows have been retrieved (or `$sth->finish`) has been called, cf https://metacpan.org/pod/DBI#Active

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass, of course.

_Have you run the entire test suite and no regression was detected?_

Yes.
