### PR TITLE
foreach requires the list to be given between brackets

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -1561,7 +1561,7 @@ sub load_registry_from_db {
   }
 
   # Register Core like databases
-  foreach my $type qw (core cdna vega otherfeatures rnaseq){
+  foreach my $type (qw (core cdna vega otherfeatures rnaseq)) {
 
     my @dbs = grep { /^[a-z]+_[a-z0-9]+  # species name
                        _


### PR DESCRIPTION
## Description

Fixed a syntax error in Registry.pm that prevents the module to be loaded
```
$ perl -c modules/Bio/EnsEMBL/Registry.pm 
syntax error at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1564, near "$type qw (core cdna vega otherfeatures rnaseq)"
Global symbol "@dbs" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1575.
Global symbol "$type" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1583.
Global symbol "$type" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1598.
Global symbol "$species_suffix" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1599.
Global symbol "$host" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1600.
Global symbol "$user" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1601.
Global symbol "$pass" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1602.
Global symbol "$port" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1603.
Global symbol "$wait_timeout" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1605.
Global symbol "$no_cache" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1606.
Global symbol "$verbose" requires explicit package name at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1608.
syntax error at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1613, near "}"
/home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm has too many errors.
Compilation failed in require at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/DBSQL/DBConnection.pm line 64.
BEGIN failed--compilation aborted at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/DBSQL/DBConnection.pm line 64.
Compilation failed in require at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm line 59.
BEGIN failed--compilation aborted at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm line 59.
Compilation failed in require at modules/Bio/EnsEMBL/Registry.pm line 125.
BEGIN failed--compilation aborted at modules/Bio/EnsEMBL/Registry.pm line 125.
```
```
$ ./misc-scripts/ping_ensembl.pl 
ERROR: Error detcted when connecting to Ensembl!
================================================================================
If the problem persists please send the following error message to helpdesk@ensembl.org
syntax error at /home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm line 1564, near "$type qw (core cdna vega otherfeatures rnaseq)"
(...)
/home/matthieu/workspace/src/64/ensembl/modules/Bio/EnsEMBL/Registry.pm has too many errors.
Compilation failed in require at ping_ensembl.pl line 22.
================================================================================
```

## Benefits

Can now use the API

## Possible Drawbacks

None

## Testing

On that branch there are no tests for Registry.pm
