### PR TITLE
Bugfix/pf multispecies db

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -542,13 +542,19 @@ sub _generate_sql {
       push( @tabs, [ 'coord_system', $cs_alias ] );
     }
 
-    $extra_default_where = sprintf(
-				   'transcript.seq_region_id = %s.seq_region_id '
-				   . 'AND transcript.transcript_id = translation.transcript_id'
-				   . 'AND translation.translation_id = %s.translation_id'
-				   . 'AND %s.coord_system_id = %s.coord_system_id '
-				   . 'AND %s.species_id = ?',
-				   $sr_alias, $tabs[0]->[1], $sr_alias, $cs_alias, $cs_alias );
+    
+    $extra_default_where =
+      $self->isa('Bio::EnsEMBL::DBSQL::ProteinFeatureAdaptor')?sprintf('transcript.seq_region_id = %s.seq_region_id '
+								       . 'AND transcript.transcript_id = translation.transcript_id '
+								       . 'AND translation.translation_id = %s.translation_id '
+								       . 'AND %s.coord_system_id = %s.coord_system_id '
+								       . 'AND %s.species_id = ?',
+								       $sr_alias, $tabs[0]->[1], $sr_alias, $cs_alias, $cs_alias ):
+									 sprintf('%s.seq_region_id = %s.seq_region_id '
+										 . 'AND %s.coord_system_id = %s.coord_system_id '
+										 . 'AND %s.species_id = ?',
+										 $tabs[0]->[1], $sr_alias, $sr_alias,
+										 $cs_alias,     $cs_alias );
 
     $self->bind_param_generic_fetch( $self->species_id(), SQL_INTEGER );
   } ## end if ( $self->is_multispecies...)

--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -520,7 +520,7 @@ sub _generate_sql {
 
   # Hack for feature types that needs to be restricted to species_id (in
   # coord_system).
-  if ( $self->is_multispecies()
+  if (    $self->is_multispecies()
        && $self->isa('Bio::EnsEMBL::DBSQL::BaseFeatureAdaptor')
        && !$self->isa('Bio::EnsEMBL::DBSQL::BaseAlignFeatureAdaptor')
        && !$self->isa('Bio::EnsEMBL::DBSQL::UnmappedObjectAdaptor') )
@@ -544,11 +544,11 @@ sub _generate_sql {
     }
 
     $extra_default_where = sprintf(
-				   '%s.seq_region_id = %s.seq_region_id '
-				   . 'AND %s.coord_system_id = %s.coord_system_id '
-				   . 'AND %s.species_id = ?',
-				   $tabs[0]->[1], $sr_alias, $sr_alias,
-				   $cs_alias,     $cs_alias );
+                      '%s.seq_region_id = %s.seq_region_id '
+                        . 'AND %s.coord_system_id = %s.coord_system_id '
+                        . 'AND %s.species_id = ?',
+                      $tabs[0]->[1], $sr_alias, $sr_alias,
+                      $cs_alias,     $cs_alias );
 
     $self->bind_param_generic_fetch( $self->species_id(), SQL_INTEGER );
   } ## end if ( $self->is_multispecies...)

--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -543,11 +543,12 @@ sub _generate_sql {
     }
 
     $extra_default_where = sprintf(
-                      '%s.seq_region_id = %s.seq_region_id '
-                        . 'AND %s.coord_system_id = %s.coord_system_id '
-                        . 'AND %s.species_id = ?',
-                      $tabs[0]->[1], $sr_alias, $sr_alias,
-                      $cs_alias,     $cs_alias );
+				   'transcript.seq_region_id = %s.seq_region_id '
+				   . 'AND transcript.transcript_id = translation.transcript_id'
+				   . 'AND translation.translation_id = %s.translation_id'
+				   . 'AND %s.coord_system_id = %s.coord_system_id '
+				   . 'AND %s.species_id = ?',
+				   $sr_alias, $tabs[0]->[1], $sr_alias, $cs_alias, $cs_alias );
 
     $self->bind_param_generic_fetch( $self->species_id(), SQL_INTEGER );
   } ## end if ( $self->is_multispecies...)

--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -469,7 +469,6 @@ sub generate_in_constraint {
 sub generic_fetch {
   my ($self, $constraint, $mapper, $slice) = @_;
   my $sql = $self->_generate_sql($constraint);
-  print "#####\n\n$sql\n\n####\n\n";
   my $params = $self->bind_param_generic_fetch();
   $params ||= [];
   $self->{_bind_param_generic_fetch} = undef;

--- a/modules/t/proteinFeatureAdaptor.t
+++ b/modules/t/proteinFeatureAdaptor.t
@@ -38,8 +38,21 @@ my $pfa = $dba->get_ProteinFeatureAdaptor();
 ok($pfa && ref($pfa) && $pfa->isa('Bio::EnsEMBL::DBSQL::ProteinFeatureAdaptor'));
 
 my $pfs = $pfa->fetch_all_by_translation_id(21724);
-
 ok(@$pfs == 15);
+
+#check if the pfa is multispecies
+isnt($pfa->is_multispecies(), 0, "Adaptor is not multispecies");
+
+#set it to multispecies mode to test if it works for collection dbs
+$pfa->is_multispecies(1);
+
+#check if the pfa is multispecies
+is($pfa->is_multispecies(), 1, "Adaptor is multispecies");
+$pfs = $pfa->fetch_all_by_translation_id(21724);
+ok(@$pfs == 15);
+
+#set it back to single species mode
+$pfa->is_multispecies(0);
 
 sub print_features {
   my $features = shift;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

In e!92 ProteinFeatureAdaptor.pm was updated to be a BaseAlignFeatureAdaptor rather than a BaseAdaptor to support GIFTS import, with a side effect of failing for collection databases. There is already a hack in place for feature types that needs to be restricted to species_id (in coord_system table), which helps the UnmappedObjectAdaptor to get around it. Similar workaround is implemented for BaseAlignFeatureAdaptor.

## Use case

The production pipeline  (VEP cache creation pipeline on EG collection databases) and the transcript pages for species that are in collection db failed with similar error messages  ( 'Unknown column 'pf.seq_region_id' in 'where clause' at BaseAdaptor.pm).

## Benefits

Both the above use cases works with the changes in place.

## Possible Drawbacks

None.

## Testing

Yes

_If so, do the tests pass/fail?_

Pass

