### PR TITLE
backport ENSCORESW-2767: multi-species support for protein feature

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -522,6 +522,7 @@ sub _generate_sql {
   # coord_system).
   if (    $self->is_multispecies()
        && $self->isa('Bio::EnsEMBL::DBSQL::BaseFeatureAdaptor')
+       && !$self->isa('Bio::EnsEMBL::DBSQL::BaseAlignFeatureAdaptor')
        && !$self->isa('Bio::EnsEMBL::DBSQL::UnmappedObjectAdaptor') )
   {
     # We do a check to see if there is already seq_region

--- a/modules/t/proteinFeatureAdaptor.t
+++ b/modules/t/proteinFeatureAdaptor.t
@@ -38,8 +38,21 @@ my $pfa = $dba->get_ProteinFeatureAdaptor();
 ok($pfa && ref($pfa) && $pfa->isa('Bio::EnsEMBL::DBSQL::ProteinFeatureAdaptor'));
 
 my $pfs = $pfa->fetch_all_by_translation_id(21724);
-
 ok(@$pfs == 15);
+
+#check if the pfa is multispecies
+isnt($pfa->is_multispecies(), 0, "Adaptor is not multispecies");
+
+#set it to multispecies mode to test if it works for collection dbs
+$pfa->is_multispecies(1);
+
+#check if the pfa is multispecies
+is($pfa->is_multispecies(), 1, "Adaptor is multispecies");
+$pfs = $pfa->fetch_all_by_translation_id(21724);
+ok(@$pfs == 15);
+
+#set it back to single species mode
+$pfa->is_multispecies(0);
 
 sub print_features {
   my $features = shift;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._

In e!92 ProteinFeatureAdaptor.pm was updated to be a BaseAlignFeatureAdaptor rather than a BaseAdaptor to support GIFTS import, with a side effect of failing for collection databases. There is already a hack in place for feature types that needs to be restricted to species_id (in coord_system table), which helps the UnmappedObjectAdaptor to get around it. Similar workaround is implemented for BaseAlignFeatureAdaptor.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

The production pipeline (VEP cache creation pipeline on EG collection databases) and the transcript pages for species that are in collection db failed with similar error messages ( 'Unknown column 'pf.seq_region_id' in 'where clause' at BaseAdaptor.pm).

## Benefits

_If applicable, describe the advantages the changes will have._

Both the above use cases works with the changes in place.


## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

We might be missing some scenarios where this could still fail.

## Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes

