### PR TITLE
ENSCORESW-2810: pass RFAMParser even if no xrefs found

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
@@ -185,9 +185,6 @@ sub run_script {
   }
 
   print "Added $xref_count RFAM xrefs and $direct_count direct xrefs\n" if($verbose);
-  if ( !$xref_count ) {
-      return 1;    # 1 error
-  }
 
   return 0; # successfull
  


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The proposed change prevents the RFAMParser from failing if no xrefs are created.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
The RFAMParser relies on finding transcripts which have RFAM accessions as supporting features. This happens when the ncRNA pipeline has been run for the species in question. Not all species will have that data, but we still want to run the xref pipeline for those species without failing on the RFAMParser. Two species that triggered this change are mus spretus and mus castanus.

## Benefits

_If applicable, describe the advantages the changes will have._
The xref pipeline does not fail if no RFAM annotation is available for a species.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
Most species should have RFAM annotation and we will not be picking this up with the xref pipeline. However, this should probably be spotted by other mechanisms than the xref update.

## Testing

_Have you added/modified unit tests to test the changes?_
The parser has been run on several species before and after the change. Before the change, species without RFAM annotation fail the parser. With the fix, the parser passes for all species, with or without RFAM annotation.
This is also noted in ENSCORESW-2810

