### PR TITLE
eHive DBConnections don't allow hash access on the StatementHandle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
   - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
   - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-compara.git
+  - git clone --depth 1 https://github.com/Ensembl/ensembl-hive.git
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:

--- a/modules/Bio/EnsEMBL/DBSQL/AssemblyMapperAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AssemblyMapperAdaptor.pm
@@ -1462,7 +1462,9 @@ sub register_all_chained {
          sr_asm.seq_region_id = asm.asm_seq_region_id AND
          sr_cmp.seq_region_id = asm.cmp_seq_region_id AND
          sr_asm.coord_system_id = ? AND
-         sr_cmp.coord_system_id = ?');
+         sr_cmp.coord_system_id = ?',
+      { 'mysql_use_result' => 1 }
+     );
 
   my $csa = $self->db()->get_CoordSystemAdaptor();
 
@@ -1497,7 +1499,6 @@ sub register_all_chained {
 
   my ($asm_cs,$cmp_cs) = @path;
 
-  $sth->{mysql_use_result} = 1;
   $sth->bind_param(1,$asm_cs->dbID,SQL_INTEGER);
   $sth->bind_param(2,$cmp_cs->dbID,SQL_INTEGER);
   $sth->execute();

--- a/modules/Bio/EnsEMBL/Utils/SqlHelper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SqlHelper.pm
@@ -948,7 +948,7 @@ sub _execute {
   my $sth_processor;
   if($use_hashrefs) {
     $sth_processor = sub {
-      return unless $sth->{Active};
+      return unless ($sth->can('dbi_sth') ? $sth->dbi_sth : $sth)->{Active};
       while( my $row = $sth->fetchrow_hashref() ) {
         my $v = $callback->($row, $sth);
         return $v if $has_return;
@@ -959,7 +959,7 @@ sub _execute {
   }
   else {
     $sth_processor = sub {
-      return unless $sth->{Active};
+      return unless ($sth->can('dbi_sth') ? $sth->dbi_sth : $sth)->{Active};
       while( my $row = $sth->fetchrow_arrayref() ) {
         my $v = $callback->($row, $sth);
         return $v if $has_return;

--- a/modules/t/sqlHelper.t
+++ b/modules/t/sqlHelper.t
@@ -27,6 +27,8 @@ use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Test::TestUtils;
 use Bio::EnsEMBL::Utils::SqlHelper;
 
+use Bio::EnsEMBL::Hive::DBSQL::DBConnection;
+
 #Redefine the WARN sig to note the errors (most are just from transaction retry)
 $SIG{__WARN__} = sub {
   note @_;
@@ -64,6 +66,12 @@ is(
   'Checking count of meta key is right with params'
 );
 
+my $hive_dbc = Bio::EnsEMBL::Hive::DBSQL::DBConnection->new(-dbconn => $dba->dbc);
+is(
+  $hive_dbc->sql_helper->execute_single_result(-SQL => qq{select count(*) from meta where meta_key = '$meta_key'}),
+  1,
+  'SqlHelper::_execute works with eHive DBConnections',
+);
 
 throws_ok { $helper->execute_single_result(-SQL => 'select * from meta') } qr/Too many results/, 'More than 1 row causes an error';
 throws_ok { $helper->execute_single_result(-SQL => 'select * from meta where species_id =?', -PARAMS => [-1]) } qr/No results/, 'Less than 1 row causes an error';

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -2,7 +2,7 @@
 
 ENSDIR="${ENSDIR:-$PWD}"
 
-export PERL5LIB=$ENSDIR/bioperl-live:$ENSDIR/ensembl-test/modules:$PWD/modules:$ENSDIR/ensembl-variation/modules:$ENSDIR/ensembl-compara/modules
+export PERL5LIB=$ENSDIR/bioperl-live:$ENSDIR/ensembl-test/modules:$PWD/modules:$ENSDIR/ensembl-variation/modules:$ENSDIR/ensembl-compara/modules:$ENSDIR/ensembl-hive/modules
 export TEST_AUTHOR=$USER
 
 if [ "$DB" = 'mysql' ]; then


### PR DESCRIPTION
## Description

eHive uses different encapsulation of `DBI::st` (containment rather than inheritance), meaning that the hash interface `$sth->{Active}` doesn't work. Instead we need to call `dbi_sth()` first. Alternatively, attributes like _mysql_use_result_ can be passed to `prepare()`.

## Use case

In Compara we use eHive's DBConnections as 1) they can be constructed with an URL and 2) they are more resilient to database disconnections

## Benefits

With this change, SqlHelper compatible with eHive

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

