### PR TITLE
Backport of Fix for ENSCORESW-2340 (handling NULL translation versions)

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -921,6 +921,8 @@ sub fetch_all_by_Transcript_list {
          -version => $version,
 	 -created_date => $created_date || undef,
 	 -modified_date => $modified_date || undef);
+
+      $tl->{version} = undef unless defined $version;
       
       $tl->adaptor($self);
       my $canonical_translation_id = $canonical_lookup->{$transcript_id};

--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -922,6 +922,9 @@ sub fetch_all_by_Transcript_list {
 	 -created_date => $created_date || undef,
 	 -modified_date => $modified_date || undef);
 
+      # Calling the new method will set $tl->version to '1' if $version is not defined.
+      # But if the version in the database is NULL, $version will be undef; and so we
+      # need to override the default version of '1', and set it back to undef.
       $tl->{version} = undef unless defined $version;
       
       $tl->adaptor($self);


### PR DESCRIPTION

## Description

This is a backport of https://github.com/Ensembl/ensembl/pull/242

## Use case

Check original PR

## Benefits

Have this fix on release/93

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

