### PR TITLE
registry_public_cores.t now uses frozen test database

### DIFF
--- a/modules/t/registry_public_cores.t
+++ b/modules/t/registry_public_cores.t
@@ -22,10 +22,24 @@ use Bio::EnsEMBL::Test::MultiTestDB;
 
 my $multi = Bio::EnsEMBL::Test::MultiTestDB->new();
 
-my $db = $multi->get_DBAdaptor('core');
-if ($db->dbc->driver() eq 'SQLite') {
-	plan skip_all => 'No registry support for SQLite yet';
+my $multi_config = $multi->db_conf();
+if (lc($multi_config->{'driver'}) ne 'mysql') {
+  plan skip_all => 'Registry only supports MySQL for now';
 }
+
+my $mysql_connect_string = "$multi_config->{'driver'}://";
+if (exists $multi_config->{'user'}) {
+  $mysql_connect_string .= "$multi_config->{'user'}";
+  if (exists $multi_config->{'pass'}) {
+    $mysql_connect_string .= ":$multi_config->{'pass'}";
+  }
+  $mysql_connect_string .= '@';
+}
+$mysql_connect_string .= $multi_config->{'host'};
+if (exists $multi_config->{'port'}) {
+  $mysql_connect_string .= ":$multi_config->{'port'}";
+}
+Bio::EnsEMBL::Registry->load_registry_from_url($mysql_connect_string);
 
 my $dbas = Bio::EnsEMBL::Registry->get_all_DBAdaptors(-GROUP=>'core');
 isnt($dbas, undef, 'Can retrieve list of DBAs from Registry');

--- a/modules/t/registry_public_cores.t
+++ b/modules/t/registry_public_cores.t
@@ -16,21 +16,20 @@
 use strict;
 use warnings;
 
-use Config;
 use Test::More;
-use Test::Exception;
-use Bio::EnsEMBL::Registry;
-use Bio::EnsEMBL::ApiVersion;
 
-# [ENSCORESW-2475]. With the new branching policy, next release DBs are unavailable
-# when adding a version upgrade to the following one.
-my $version = software_version()-2;
+use Bio::EnsEMBL::Test::MultiTestDB;
 
-Bio::EnsEMBL::Registry->load_registry_from_url('mysql://anonymous@ensembldb.ensembl.org/'.$version);
+my $multi = Bio::EnsEMBL::Test::MultiTestDB->new();
+
+my $db = $multi->get_DBAdaptor('core');
+if ($db->dbc->driver() eq 'SQLite') {
+	plan skip_all => 'No registry support for SQLite yet';
+}
 
 my $dbas = Bio::EnsEMBL::Registry->get_all_DBAdaptors(-GROUP=>'core');
-my $min = 10;
-ok(defined $dbas && scalar(@$dbas)>$min,'More than '.$min.' DBAs found');
+isnt($dbas, undef, 'Can retrieve list of DBAs from Registry');
+cmp_ok(scalar @{$dbas}, '>', 0, 'DBA list is not empty');
 ok($dbas->[0]->isa('Bio::EnsEMBL::DBSQL::DBAdaptor'),'First DBA is core');
 
 my $species = 'homo_sapiens';


### PR DESCRIPTION
## Description

The test _registry_public_cores.t_ now uses frozen test database

## Use case

Using the public registry server in tests is fragile, especially around release time.
See https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-2325

## Benefits

Registry tests can now work offline and not have to worry about version mismatches between the API and what the public server provides.

## Possible Drawbacks

Had to rewrite the "registry knows more than 10 DBAs" test to "registry knows at least 1 DBA" because by default that is what MultiTestDB provides. _Might make sense to tweak the settings to get at least two so that we can make sure the list  of DBAdaptor is really appended to._

## Testing

_Have you added/modified unit tests to test the changes?_

It was a test itself that needed changes.

_If so, do the tests pass/fail?_

The modified test passes.

_Have you run the entire test suite and no regression was detected?_

Not run, under the assumption that a change in one test suite that does not write anything to the database really shouldn't affect any of the others.
