### PR TITLE
ENSCORESW-2827: minimal test on xref config validity

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@ requires 'DBD::mysql';
 requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';
+requires 'Config::IniFiles';
 
 test_requires 'Test::Warnings';
 test_requires 'Test::Differences';

--- a/modules/t/xrefs.t
+++ b/modules/t/xrefs.t
@@ -1,0 +1,50 @@
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2018] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Cwd;
+use File::Spec;
+use File::Basename qw/dirname/;
+use File::Temp;
+use Test::More;
+use Test::Warnings;
+
+#chdir into the file's target & request cwd() which should be fully resolved now.
+#then go back
+my $file_dir = dirname(__FILE__);
+my $original_dir = cwd();
+chdir($file_dir);
+my $cur_dir = cwd();
+chdir($original_dir);
+my $root = File::Spec->catdir($cur_dir, File::Spec->updir(),File::Spec->updir());
+
+my $script = File::Spec->catfile($root, "misc-scripts/xref_mapping/xref_config2sql.pl");
+my $config = File::Spec->catfile($root, "misc-scripts/xref_mapping/xref_config.ini");
+
+my $tmpdir = File::Temp->newdir();
+my $dirname = $tmpdir->dirname;
+my $tmpfile = File::Temp->new(DIR => $dirname, SUFFIX => ".txt");
+my $cmd = "perl $script $config > $tmpfile";
+system($cmd);
+
+my $content = do { local(@ARGV, $/) = $tmpfile; <> };
+
+# Test the file was written in entirety
+like($content, qr/FINISHED SUCCESSFULLY/, "Config was parsed successfully");
+
+
+done_testing();


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The xref_config.ini file is large and messy. Additionally, a small change in the configuration can have dire consequences on the results of the xref pipeline update.
This change aims to provide a basic test on the syntax of the configuration and that there is available configuration for any source mentioned.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
If a source is removed but is referenced somewhere else in the configuration file, the generation of the metadata sql file is interrupted. This is not captured within the eHive pipeline but will cause downstream consequences, in particular missing data and species.

## Benefits

_If applicable, describe the advantages the changes will have._
Avoid breaking the xref pipeline for a misformatted configuration.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
This is a new test unit

_If so, do the tests pass/fail?_
The test passes

_Have you run the entire test suite and no regression was detected?_
Yes
