### PR TITLE
Bugfix/official naming

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
@@ -538,28 +538,27 @@ sub set_transcript_and_gene_display_xref_via_clone_name{
   my $g_source_id;
   my $desc;
   my $name;
-      if (defined($ens_clone_names->{$gene_id})) {
-	  if(defined($clone_name)){
-	      $name = $clone_name;
-	      $t_source_id = $dbname_to_source_id->{"Clone_based_ensembl_transcript"};
-	      $g_source_id = $dbname_to_source_id->{"Clone_based_ensembl_gene"};
-	      $desc = "via ensembl clone name";
-	  }
-	  else{
-	      croak "No name";
-	  }
-	  my $num = 1;
-	  my $unique_name = $name.".".$num;
-	  while(defined($xref_added->{$unique_name.":".$g_source_id})){
-	      $num++;
-	      $unique_name = $name.".".$num;
-	  }
-	  $name = $unique_name;
-      } else {	  
-	  $ens_clone_names->{$gene_id} = 1;
-	  $keep_gene = 1;
-	  return $keep_gene;
-      }
+  if (defined($ens_clone_names->{$gene_id})) {
+    if(defined($clone_name)){
+      $name = $clone_name;
+      $t_source_id = $dbname_to_source_id->{"Clone_based_ensembl_transcript"};
+      $g_source_id = $dbname_to_source_id->{"Clone_based_ensembl_gene"};
+      $desc = "via ensembl clone name";
+    } else{
+      croak "No name";
+    }
+    my $num = 1;
+    my $unique_name = $name.".".$num;
+    while(defined($xref_added->{$unique_name.":".$g_source_id})){
+      $num++;
+      $unique_name = $name.".".$num;
+    }
+    $name = $unique_name;
+  } else {
+    $ens_clone_names->{$gene_id} = 1;
+    $keep_gene = 1;
+    return $keep_gene;
+  }
   
   # first add the gene xref and set display_xref_id
   # store the data
@@ -588,7 +587,6 @@ sub set_transcript_and_gene_display_xref_via_clone_name{
     $xref_added->{$id.":".$t_source_id} = $$max_xref_id;
     
     $$max_object_xref_id++;
-    #	  print "$id\t$t_source_id\t".$xref_added->{$id.":".$t_source_id}."\n";
     $ins_object_xref_sth->execute($$max_object_xref_id, $tran_id, 'Transcript', $xref_added->{$id.":".$t_source_id}, undef);
     $ins_dep_ix_sth->execute($$max_object_xref_id, 100, 100);
     $set_tran_display_xref_sth->execute($$max_xref_id, $tran_id);

--- a/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
@@ -631,7 +631,6 @@ sub set_transcript_display_xrefs{
   }
 
   foreach my $tran_id ( @{$gene_to_transcripts->{$gene_id}} ){
-    $ext = 201;
     my $id = $gene_symbol."-".$ext;
     if(!defined($source_id)){
       croak "id = $id\n but NO source_id for this entry for $tran_source???\n";


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The transcript name extension is overwritten every time a new loop is started.
This results in all transcripts having -201 as an extension, rather than -201, -202 within the same gene. This bugfix re-establishes the former behaviour.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
All transcripts within the same gene have the same name. This means it is harder to distinguish between transcripts without using the stable ID.

## Benefits

_If applicable, describe the advantages the changes will have._
Transcripts within the same gene have the same name.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
Users rely on the transcript name and expect it to be stable, which it is fundamentally not.

## Testing

_Have you added/modified unit tests to test the changes?_
The whole pipeline was run and results compared with previous run.

_If so, do the tests pass/fail?_
Results are comparable.

_Have you run the entire test suite and no regression was detected?_

