### PR TITLE
Update Bio::EnsEMBL::Exon->is_coding():

### DIFF
--- a/modules/Bio/EnsEMBL/Exon.pm
+++ b/modules/Bio/EnsEMBL/Exon.pm
@@ -1281,8 +1281,7 @@ sub is_constitutive {
 
 =head2 is_coding
 
-  Arg [1]    : Boolean $is_coding
-  Arg [2]    : Bio::EnsEMBL::Transcript
+  Arg [1]    : Bio::EnsEMBL::Transcript
   Example    : $exon->is_coding()
   Description: Says if the exon is within the translation or not
   Returntype : Int
@@ -1294,6 +1293,8 @@ sub is_constitutive {
 
 sub is_coding {
   my ( $self, $transcript) = @_;
+
+  if (!$transcript) { throw("Transcript parameter is required for " . __PACKAGE__ . "->is_coding()."); }
 
   if (!$transcript->translate) { return 0; }
 

--- a/modules/t/exon.t
+++ b/modules/t/exon.t
@@ -76,6 +76,9 @@ ok(&test_getter_setter($exon, 'end_phase', 1));
 ok( test_getter_setter( $exon, "created_date", time() ));
 ok( test_getter_setter( $exon, "modified_date", time() ));
 
+# Test that no parameter to is_coding() throws an exception
+throws_ok { $exon->is_coding() } qr/parameter is required/, "Transcript parameter required for is_coding()";
+
 #
 # find supporting evidence for the exon
 #


### PR DESCRIPTION
- Update documentation on required parameters
- Throw an error if a Transcript isn't given
- Add a test for regression

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Updating Bio::EnsEMBL::Exon->is_coding(), documentation is out of date and parameters are properly scrutinized.

## Use case

So people know how to properly use the function, and can't abuse it.

## Benefits

Accurate documentation is good.

## Possible Drawbacks

Code that might not properly handle an exception, but honestly, if they're not passing a transcript in already the $transcript->translation would already blow up.

## Testing

Added a regression test to ensure the parameter is properly scrutinized.

_If so, do the tests pass/fail?_

Pass

_Have you run the entire test suite and no regression was detected?_

Yes