### PR TITLE
only_proteing_coding filter added to SliceAdaptor::fetch_all

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -1145,7 +1145,7 @@ sub fetch_all {
 
   my @out;
   while($sth->fetch()) {
-    if(!defined($bad_vals{$seq_region_id}) && (!%good_vals || $good_vals{$seq_region_id})){
+    if(!defined($bad_vals{$seq_region_id}) && (!$only_protein_coding || $good_vals{$seq_region_id})){
       my $cs = $csa->fetch_by_dbID($cs_id);
 
       if(!$cs) {

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -690,7 +690,7 @@ my $exceptions = $initial_slice->get_all_AssemblyExceptionFeatures();
 is($unique_slice->start, $exceptions->[0]->start, "Start of patch");
 is($unique_slice->end, $exceptions->[0]->end, "End of patch");
 
-## Test fetch_all with only_protein_conding atfer patch
+## Test fetch_all with only_protein_coding after patch
 $slices = $slice_adaptor->fetch_all("chromosome", undef, undef, undef, undef, 0);
 is(scalar(@$slices), 4, 'Fetched chromosomes number');
 

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -690,6 +690,13 @@ my $exceptions = $initial_slice->get_all_AssemblyExceptionFeatures();
 is($unique_slice->start, $exceptions->[0]->start, "Start of patch");
 is($unique_slice->end, $exceptions->[0]->end, "End of patch");
 
+## Test fetch_all with only_protein_conding atfer patch
+$slices = $slice_adaptor->fetch_all("chromosome", undef, undef, undef, undef, 0);
+is(scalar(@$slices), 4, 'Fetched chromosomes number');
+
+$slices = $slice_adaptor->fetch_all("chromosome", undef, undef, undef, undef, 1);
+is(scalar(@$slices), 2, 'Fetched chromosomes number, only_protein_coding ');
+
 
 ## Test karyotype data
 


### PR DESCRIPTION
optimization for SliceAdaptor::fetch_all to get only regions, that have 'coding_cnt' attribute > 0.
used to speed up the whole proteome download for vb_proteome_download projects.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description
optimization for SliceAdaptor::fetch_all to get only regions, that have 'coding_cnt' attribute > 0.
used to speed up the whole proteome download for vb_proteome_download projects.


## Use case
used to speed up the whole proteome download for vb_proteome_download projects.
i.e. in the  sequence/proteome/:species  rest-api endpoint:

`my ($toplevel, $ver, $non_ref, $dup, $lrg, $only_protein_coding) =
                                                                                          ('toplevel', undef, undef, undef, undef, 1);`
`my $slices = $adaptor->fetch_all($toplevel, $ver, $non_ref, $dup, $lrg, $only_protein_coding);`
`Catalyst::Exception->throw("No slice found for the toplevel coord system") unless $slices;`


## Benefits
will speed up the whole proteome downloads for genomes, having large number contigs without any genes or without  protein coding ones (i.e. partly assembled genomes) 

## Possible Drawbacks
The 'coding_cnt' attribute should be set for the 'seq_region_atrrib' for the filter to work. 

## Testing
test are added to t/sliceAdaptor.t
tests are ok.  no regression.
'All tests successful. Result: PASS'
