### PR TITLE
ENSCORESW-2792: separate mouse UCSC to avoid clashes

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_Parser.pm
@@ -17,6 +17,9 @@ limitations under the License.
 
 =cut
 
+# This module replicates the generic UCSC parser for mouse specific data
+# This prevents cross-mapping between species by treating each species as a separate source
+
 package XrefParser::UCSC_mouse_Parser;
 
 use base qw( XrefParser::UCSCParser);

--- a/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_Parser.pm
@@ -1,0 +1,24 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package XrefParser::UCSC_mouse_Parser;
+
+use base qw( XrefParser::UCSCParser);
+
+1;

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -2004,7 +2004,7 @@ download        = Y
 order           = 70
 priority        = 1
 prio_descr      =
-parser          = UCSCParser
+parser          = UCSC_mouse_Parser
 release_uri     = ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt
 data_uri        = ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Mouse UCSC xref parsing uses a separate parser from human UCSC xrefs to avoid re-using IDs between the two sources.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
As we scale up the number of species, each source can be parsed by any species and the taxon id is extracted from the source. For UCSC xrefs, there is no information about the species in the original data. As a workaround, we use two separate parsers for the two species which use UCSC data.

## Benefits

_If applicable, describe the advantages the changes will have._
We will map human xrefs to human and mouse xrefs to mouse, no cross-contamination. This will also prevent core foreign key breakages which happened before.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
It will not scale well if we wanted UCSC xrefs for more species.

## Testing

_Have you added/modified unit tests to test the changes?_
The pipeline was run on human and mouse in parallel to check for any possible contamination. 

_If so, do the tests pass/fail?_
There are no CoreForeignKey HC failure, the number of xrefs obtained is comparable to previous releases and the data looks sane.

_Have you run the entire test suite and no regression was detected?_
NA
