### PR TITLE
ENSCORESW-2744: remove dependent_xref when removing master

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/XrefLoader.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/XrefLoader.pm
@@ -147,6 +147,7 @@ SQL
   my $go_sth       =  $core_dbi->prepare('DELETE ontology_xref.* FROM ontology_xref, object_xref, xref WHERE ontology_xref.object_xref_id = object_xref.object_xref_id AND object_xref.xref_id = xref.xref_id  AND xref.external_db_id = ?');
   my $identity_sth =  $core_dbi->prepare('DELETE identity_xref FROM identity_xref, object_xref, xref WHERE identity_xref.object_xref_id = object_xref.object_xref_id AND object_xref.xref_id = xref.xref_id AND xref.external_db_id = ?');
   my $object_sth   =  $core_dbi->prepare('DELETE object_xref FROM object_xref, xref WHERE object_xref.xref_id = xref.xref_id AND xref.external_db_id = ?');
+  my $master_sth    = $core_dbi->prepare('DELETE ox, d FROM xref mx, xref x, dependent_xref d LEFT JOIN object_xref ox ON ox.object_xref_id = d.object_xref_id WHERE mx.xref_id = d.master_xref_id AND dependent_xref_id = x.xref_id AND mx.external_db_id = ?');
   my $dependent_sth = $core_dbi->prepare('DELETE d FROM dependent_xref d, xref x WHERE d.dependent_xref_id = x.xref_id and x.external_db_id = ?');
   my $xref_sth     =  $core_dbi->prepare('DELETE FROM xref WHERE xref.external_db_id = ?');
   my $unmapped_sth =  $core_dbi->prepare('DELETE FROM unmapped_object WHERE type="xref" and external_db_id = ?');
@@ -181,6 +182,8 @@ SQL
     print "\tDeleted $affected_rows identity_xref row(s)\n" if $verbose;
     $affected_rows = $object_sth->execute($ex_id);  
     print "\tDeleted $affected_rows object_xref row(s)\n" if $verbose;
+    $affected_rows = $master_sth->execute($ex_id);
+    print "\tDeleted $affected_rows xref, object_xref and dependent_xref row(s)\n" if $verbose;
     $affected_rows = $dependent_sth->execute($ex_id);
     print "\tDeleted $affected_rows dependent_xref row(s)\n" if $verbose;
     $affected_rows = $xref_sth->execute($ex_id);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Remove all dependent_xref when the main xref is removed

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Before loading a new set of xrefs into the core database, existing xrefs from updated sources are removed from the core database. This is done source by source, meaning that dependent sources are only deleted if there is an update to that source. As their mapping depends on the master source, they should be removed at the same time.

## Benefits

_If applicable, describe the advantages the changes will have._
If a dependent source is not updated but its master is, we do not end up with orphan entries. This also means we remove older mappings more regularly.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
The query is not optimised and can take a while to run on the server. It also leaves the xref entries in the xref table as they can be dependent of multiple sources.

## Testing

_Have you added/modified unit tests to test the changes?_
This was tested on gorilla which failed last release due to a single PDB that was left as an orphan. It is left as an orphan before the code change but is cleanly removed with this update. This was also run on a hundred species to check for regression.

_If so, do the tests pass/fail?_
The identified edge case is fixed and no new regressions are detected.

_Have you run the entire test suite and no regression was detected?_
NA
