### PR TITLE
ENSCORESW-2837: do not import dependent VGNC

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -451,6 +451,10 @@ sub create_xrefs {
       	if($source =~ "HGNC"){
       	  next;
       	}
+        # Nomenclature data is imported directly from the source
+        if($source =~ "VGNC"){
+          next;
+        }
       	if($source =~ "Orphanet"){
       	  #we don't want to parse Orphanet xrefs via Uniprot, we get them from Orphanet with descriptions
       	  next;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Ignore VGNC xrefs in UniProt data as we already get the data elsewhere.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
VGNC is imported directly from the VGNC website with curated links to Ensembl data.
We want to avoid importing additional links via UniProt. The data will not be as up to date as getting the data directly from VGNC. Additionally, this means we would add links via a third-party source, meaning it is less accurate.

## Benefits

_If applicable, describe the advantages the changes will have._
VGNC mappings are consistent and as up-to-date as possible

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
Coverage of VGNC mappings may decrease.

## Testing

_Have you added/modified unit tests to test the changes?_
This was run on cow, chimp, dog and horse, the 4 species with VGNC data.

_If so, do the tests pass/fail?_
No changes noticed

_Have you run the entire test suite and no regression was detected?_
NA
