### PR TITLE
ENSCORESW-2792: one UCSC parser per species

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/UCSC_human_parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSC_human_parser.pm
@@ -1,0 +1,27 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+# This module replicates the generic UCSC parser for human specific data
+# This prevents cross-mapping between species by treating each species as a separate source
+
+package XrefParser::UCSC_human_parser;
+
+use base qw( XrefParser::UCSCParser);
+
+1;

--- a/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_parser.pm
@@ -20,7 +20,7 @@ limitations under the License.
 # This module replicates the generic UCSC parser for mouse specific data
 # This prevents cross-mapping between species by treating each species as a separate source
 
-package XrefParser::UCSC_mouse_Parser;
+package XrefParser::UCSC_mouse_parser;
 
 use base qw( XrefParser::UCSCParser);
 

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -1993,7 +1993,7 @@ download        = Y
 order           = 70
 priority        = 1
 prio_descr      =
-parser          = UCSCParser
+parser          = UCSC_human_parser
 release_uri     = ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt
 data_uri        = ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz
 
@@ -2004,7 +2004,7 @@ download        = Y
 order           = 70
 priority        = 1
 prio_descr      =
-parser          = UCSC_mouse_Parser
+parser          = UCSC_mouse_parser
 release_uri     = ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt
 data_uri        = ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Human has a dedicated UCSC parser rather than using the generic one.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Mouse has a separate UCSC parser to avoid cross contamination between species. To be consistent, human now also has a separate parser and the generic one is only inherited from.
Also updated the naming to remove the camel casing

## Benefits

_If applicable, describe the advantages the changes will have._
It is clearer that every species has a dedicated parser rather than mouse being the exception. It will also make it easier to add more species if we so desired.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
Pipeline has been run on mouse and human, all UCSC xrefs were correctly updated.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
NA

