### PR TITLE
ENSCORESW-2853: match Ensembl species casing

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
@@ -115,7 +115,7 @@ sub run {
       my ($ensembl_stable_id, $reactome_id, $url, $description, $evidence, $species) = split /\t+/,$line;
       if ($description!~ /^[A-Za-z0-9_,\(\)\/\-\.:\+'&;"\/\?%>\s\[\]]+$/) { next; }
   
-      $species =~ s/\s//;
+      $species =~ s/\s/_/;
       $species = lc($species);
       if ( $alias2species_id{$species} ){
         $parsed_count++;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Match species name between Reactome syntax and Ensembl syntax

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Reactome write species names like Homo sapiens
Ensembl write species name like homo_sapiens
We want to match the Homo sapiens data to homo_sapiens, so need a reliable way to compare species names.

## Benefits

_If applicable, describe the advantages the changes will have._
Reactome data is mapped to new and existing species

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
It is a fragile mapping, so extra spaces or special characters will probably break this.

## Testing

_Have you added/modified unit tests to test the changes?_
The parser was run on the same file before and after code changes.

_If so, do the tests pass/fail?_
No data is parsed with the current code, data is parsed with the bugfix.

_Have you run the entire test suite and no regression was detected?_

