### PR TITLE
create_release_tasks.pl: explicitly dereference arguments to 'keys'

### DIFF
--- a/misc-scripts/jira/create_release_tasks.pl
+++ b/misc-scripts/jira/create_release_tasks.pl
@@ -253,7 +253,7 @@ sub validate_parameters {
 	  $parameters->{config} );
 
   print "Dates:\n";
-  foreach my $date_label (keys $parameters->{dates}) {
+  foreach my $date_label (keys %{$parameters->{dates}}) {
       printf( "%33s: %s\n",
 	      $date_label,
 	      $parameters->{dates}->{$date_label} );
@@ -513,7 +513,7 @@ sub replace_placeholders {
       }
   }
 
-  for my $param (keys $parameters->{dates}) {
+  for my $param (keys %{$parameters->{dates}}) {
       if($line =~ /<$param>/) {
 	  $line =~ s/<$param>/$parameters->{dates}->{$param}/eg;
       }
@@ -693,7 +693,7 @@ sub fetch_dates {
 
   my $events = $hash->{events};
 
-  foreach my $milestone_name (keys $parameters->{ical}) {
+  foreach my $milestone_name (keys %{$parameters->{ical}}) {
       my $calendar_label = $parameters->{ical}->{$milestone_name};
       $calendar_label = replace_placeholders($calendar_label, $parameters);
       print "Looking for '$calendar_label' in ical...";
@@ -730,9 +730,9 @@ sub find_event_by_name {
   my ( $label, $events ) = @_;
 
   foreach my $year (keys %$events) {
-      foreach my $month (keys $events->{$year}) {
-	  foreach my $day (keys $events->{$year}->{$month}) {
-	      foreach my $event (keys $events->{$year}->{$month}->{$day} ) {
+      foreach my $month (keys %{$events->{$year}}) {
+	  foreach my $day (keys %{$events->{$year}->{$month}}) {
+	      foreach my $event (keys %{$events->{$year}->{$month}->{$day}} ) {
 		  if($events->{$year}->{$month}->{$day}->{$event}->{SUMMARY} eq $label) {
 		      return $events->{$year}->{$month}->{$day}->{$event};
 		  }


### PR DESCRIPTION
## Description

Make sure all calls to keys() in misc-scripts/jira/create_release_tasks.pl are passed hashes and not scalar hashrefs.

## Use case

Being able to pass a scalar to each, keys, push, pop, shift, splice, unshift, and values was an experimental feature that was added in Perl 5.14 and since declared failed, thus causing the script to fail with an "Experimental keys on scalar is now forbidden" error.

## Benefits

create_release_tasks.pl can now run under Perl 5.24 and newer.

## Possible Drawbacks

None, other than the script being a few bytes (!) longer now.

## Testing

_Have you added/modified unit tests to test the changes?_

n/a

_If so, do the tests pass/fail?_

n/a

_Have you run the entire test suite and no regression was detected?_

n/a, I have however tested the script by using it to create e! 95 core release tickets and it has worked fine.
