### PR TITLE
Fixed typo for new Vertebrate division name in metaContainer test

### DIFF
--- a/modules/t/metaContainer.t
+++ b/modules/t/metaContainer.t
@@ -74,7 +74,7 @@ ok($taxid == 9606);
 my $div = $mc->get_division();
 ok(!defined $div);
 
-my $divname = 'EnsemblVertebrate';
+my $divname = 'EnsemblVertebrates';
 $mc->store_key_value('species.division',$divname);
 $div = $mc->get_division();
 ok($div eq $divname);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixed typo for new Vertebrate division name in metaContainer test. The new name for the Vertebrate division is "EnsemblVertebrates" and not "EnsemblVertebrate", see https://www.ebi.ac.uk/panda/jira/browse/ENSINT-104 for details.

## Use case

The test is wrong so it's failing when we introduce the new division name when testing human.

## Benefits

_If applicable, describe the advantages the changes will have._

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

Changes have been tested. 

