### PR TITLE
Schema patch to update Vertebrates division names in the meta table f…

### DIFF
--- a/sql/patch_94_95_b.sql
+++ b/sql/patch_94_95_b.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2018] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_94_95_b.sql
+#
+# Title: Update vertebrates division name
+#
+# Description:
+#   Update Vertebrates division name from Ensembl to EnsemblVertebrates in the meta table for consistency
+
+UPDATE meta SET meta_value = 'EnsemblVertebrates' where meta_key = 'species.division' and meta_value = 'Ensembl';
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_94_95_b.sql|vertebrate_division_rename');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -316,6 +316,9 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_94_95_a.sql|schema_version');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_94_95_b.sql|vertebrate_division_rename');
+
 
 /**
 @table meta_coord


### PR DESCRIPTION
…rom Ensembl to EnsemblVertebrates for consistency. See declaration for details: https://www.ebi.ac.uk/panda/jira/browse/ENSINT-104.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Schema patch to update Vertebrates division names in the meta table from Ensembl to EnsemblVertebrates for consistency. See declaration for details: https://www.ebi.ac.uk/panda/jira/browse/ENSINT-104.

## Use case

Group leaders agreed that the Vertebrate division name will be renamed from "Ensembl" to "EnsemblVertebrates", see here: https://www.ebi.ac.uk/panda/jira/browse/ENSINT-104

## Benefits

_If applicable, describe the advantages the changes will have._

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

All tested.

