### PR TITLE
Remove artificial dependency on XML::Simple

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,5 @@ feature 'xref_mapping', 'Xref mapping pipeline' => sub {
   requires 'Digest::MD5';
   requires 'Text::Glob';
   requires 'XML::LibXML';
-  requires 'XML::Simple';
 };
 =cut

--- a/misc-scripts/xref_mapping/XrefParser/TAIROntologyParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/TAIROntologyParser.pm
@@ -102,7 +102,6 @@ use Data::Dumper;
 use File::Basename 'basename';
 use Readonly;
 use List::MoreUtils 'uniq';
-use XML::Simple 'XMLin';
 
 use base qw( XrefParser::BaseParser );
 


### PR DESCRIPTION
## Description

Remove the only line in the whole of the repository which (still?) depended on XML::Simple, and no longer require that module in _cpanfile_.

## Use case

The bit of code in question, TAIROntologyParser, did not actually *use* that module - it merely imported _XMLin_ from it and left it at that. Moreover, XML::Simple has long been deprecated.

## Benefits

Gets rid of an unnecessary dependency.

## Possible Drawbacks

None I can think of, considering the status of XML::Simple and that there is still at least one XML parser - namely _XML::LibXML_ - we depend on.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

n/a

_Have you run the entire test suite and no regression was detected?_

Run the entire test suite both before and after the change. It has passed on both occasions.