### PR TITLE
EntrezGene/HPA parsers update

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -1,3 +1,4 @@
+
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
@@ -29,40 +30,41 @@ use IO::File;
 use English;
 
 sub new {
-  my ($proto, $arg_ref) = @_;
+  my ( $proto, $arg_ref ) = @_;
 
   my $class = ref $proto || $proto;
-  my $self =  bless {}, $class;
-  
-  $self->dbc(ref $arg_ref eq 'Bio::EnsEMBL::DBSQL::DBConnection' 
-    ? $arg_ref : Bio::EnsEMBL::DBSQL::DBConnection->new(
-    -HOST => $arg_ref->{host},
-    -DBNAME => $arg_ref->{dbname},
-    -USER => $arg_ref->{user},
-    -PASS => $arg_ref->{pass} || '',
-    -PORT => $arg_ref->{port} || '3306'
-  ));
-  $self->verbose($arg_ref->{verbose});
+  my $self = bless {}, $class;
+
+  $self->dbc(
+        ref $arg_ref eq 'Bio::EnsEMBL::DBSQL::DBConnection' ? $arg_ref :
+          Bio::EnsEMBL::DBSQL::DBConnection->new(
+                                     -HOST   => $arg_ref->{host},
+                                     -DBNAME => $arg_ref->{dbname},
+                                     -USER   => $arg_ref->{user},
+                                     -PASS   => $arg_ref->{pass} || '',
+                                     -PORT => $arg_ref->{port} || '3306'
+          ) );
+  $self->verbose( $arg_ref->{verbose} );
 
   return $self;
 }
 
 sub verbose {
-  my ($self, $arg) = @_;
+  my ( $self, $arg ) = @_;
 
-  (defined $arg) &&
-    ($self->{_verbose} = $arg );
+  ( defined $arg ) && ( $self->{_verbose} = $arg );
   return $self->{_verbose};
 }
 
 sub dbc {
   my $self = shift;
 
-  if(@_) {
+  if (@_) {
     my $arg = shift;
 
-    if(defined($arg)) {
-      croak "$arg is not a DBConnection" unless $arg->isa('Bio::EnsEMBL::DBSQL::DBConnection');
+    if ( defined($arg) ) {
+      croak "$arg is not a DBConnection"
+        unless $arg->isa('Bio::EnsEMBL::DBSQL::DBConnection');
       $self->{_dbc} = $arg;
     }
   }
@@ -71,71 +73,71 @@ sub dbc {
 }
 
 sub host {
-  my ($self, $arg) = @_;
+  my ( $self, $arg ) = @_;
   $self->dbc->host($arg) if defined $arg;
   return $self->dbc->host;
 }
 
 sub dbname {
-  my ($self, $arg) = @_;
+  my ( $self, $arg ) = @_;
   $self->dbc->dbname($arg) if defined $arg;
   return $self->dbc->dbname;
 }
 
 sub user {
-  my ($self, $arg) = @_;
+  my ( $self, $arg ) = @_;
   $self->dbc->user($arg) if defined $arg;
   return $self->dbc->user;
 }
 
 sub pass {
-  my ($self, $arg) = @_;
+  my ( $self, $arg ) = @_;
   $self->dbc->pass($arg) if defined $arg;
   return $self->dbc->pass;
 }
 
 sub port {
-  my ($self, $arg) = @_;
+  my ( $self, $arg ) = @_;
   $self->dbc->port($arg) if defined $arg;
   return $self->dbc->port;
 }
 
 sub dbi {
-    my $self = shift;
-    my $dbi;
+  my $self = shift;
+  my $dbi;
 
-    if ( !defined $dbi || !$dbi->ping() ) {
-        my $connect_string =
-          sprintf( "dbi:mysql:host=%s;port=%s;database=%s",
-            $self->host, $self->port, $self->dbname );
+  if ( !defined $dbi || !$dbi->ping() ) {
+    my $connect_string =
+      sprintf( "dbi:mysql:host=%s;port=%s;database=%s",
+               $self->host, $self->port, $self->dbname );
 
-        $dbi =
-          DBI->connect( $connect_string, $self->user, $self->pass,
-            { 'RaiseError' => 1 } )
-          or croak( "Can't connect to database: " . $DBI::errstr );
-        $dbi->{'mysql_auto_reconnect'} = 1; # Reconnect on timeout
-    }
-    return $dbi;
+    $dbi =
+      DBI->connect( $connect_string, $self->user, $self->pass,
+                    { 'RaiseError' => 1 } ) or
+      croak( "Can't connect to database: " . $DBI::errstr );
+    $dbi->{'mysql_auto_reconnect'} = 1;    # Reconnect on timeout
+  }
+  return $dbi;
 }
 
-# Create database if required. 
+# Create database if required.
 # Assumes sql/table.sql and sql/populate_metadata.sql are present.
 sub create {
-  my ($self, $sql_dir, $force, $drop_db) = @_;
-  $self->recreate_database($force,$drop_db);
-  $self->populate($sql_dir, $force);
+  my ( $self, $sql_dir, $force, $drop_db ) = @_;
+  $self->recreate_database( $force, $drop_db );
+  $self->populate( $sql_dir, $force );
 }
 
 sub populate {
-  my ($self, $sql_dir, $force) = @_;
+  my ( $self, $sql_dir, $force ) = @_;
   my $table_file = catfile( $sql_dir, 'sql', 'table.sql' );
-  my $metadata_file = $self->prepare_metadata_file($sql_dir, $force);
+  my $metadata_file = $self->prepare_metadata_file( $sql_dir, $force );
   $self->populate_with_file($table_file);
   $self->populate_with_file($metadata_file);
 }
 
 sub prepare_metadata_file {
-  my ($self, $sql_dir, $force) = @_;
+  my ( $self, $sql_dir, $force ) = @_;
   my $metadata_file =
     catfile( $sql_dir, 'sql', 'populate_metadata.sql' );
   my $ini_file = catfile( $sql_dir, 'xref_config.ini' );
@@ -149,13 +151,14 @@ sub prepare_metadata_file {
 
   if ( !defined($meta_tm) || $ini_tm > $meta_tm ) {
     my $reply;
-    if($force){
+    if ($force) {
       $reply = 'y';
     }
-    else{
+    else {
       printf( "==> Your copy of 'xref_config.ini' is newer than '%s'\n",
-	      catfile( 'sql', 'populate_metadata.sql' ) );
-      print("==> Should I re-run 'xref_config2sql.pl' for you? [y/N]: ");
+              catfile( 'sql', 'populate_metadata.sql' ) );
+      print(
+           "==> Should I re-run 'xref_config2sql.pl' for you? [y/N]: ");
 
       $reply = <ARGV>;
       chomp $reply;
@@ -166,74 +169,80 @@ sub prepare_metadata_file {
                          $ini_file, $metadata_file );
 
       if ( system($cmd) == 0 ) {
-        print("==> Done.\n") if($self->verbose);
-      } else {
+        print("==> Done.\n") if ( $self->verbose );
+      }
+      else {
         if ( $? == -1 ) {
           croak("Failed to execute: $!\n");
-        } elsif ( $? & 127 ) {
-          croak(
-                 sprintf( "Command died with signal %d, %s coredump\n",
+        }
+        elsif ( $? & 127 ) {
+          croak( sprintf( "Command died with signal %d, %s coredump\n",
                           ( $? & 127 ),
-                          ( $? & 128 ) ? 'with' : 'without'
-                 ) );
-        } else {
+                          ( $? & 128 ) ? 'with' : 'without' ) );
+        }
+        else {
           croak( sprintf( "Command exited with value %d\n", $? >> 8 ) );
         }
       }
 
     }
-  } ## end if ( !defined($meta_tm...
+  } ## end if ( !defined($meta_tm...))
   return $metadata_file;
-}
+} ## end sub prepare_metadata_file
 
 sub recreate_database {
-  my ($self,$force, $drop_db) = @_;
+  my ( $self, $force, $drop_db ) = @_;
   my $user   = $self->user;
   my $dbname = $self->dbname;
   my $host   = $self->host;
   my $pass   = $self->pass;
-  my $port = $self->port;
-  my $dbh = DBI->connect( "DBI:mysql:host=$host:port=$port", $user, $pass,
-                          {'RaiseError' => 1});
+  my $port   = $self->port;
+  my $dbh    = DBI->connect( "DBI:mysql:host=$host:port=$port",
+                          $user, $pass, { 'RaiseError' => 1 } );
   # check to see if the database already exists
-  my %dbs = map {$_->[0] => 1} @{$dbh->selectall_arrayref('SHOW DATABASES')};
+  my %dbs = map { $_->[0] => 1 }
+    @{ $dbh->selectall_arrayref('SHOW DATABASES') };
 
-  if ($dbs{$dbname}) {
+  if ( $dbs{$dbname} ) {
 
-    if ( $drop_db ) {
-	$dbh->do( "DROP DATABASE $dbname" );
-	print "Database $dbname dropped\n" if($self->verbose) ;
-    } else {
+    if ($drop_db) {
+      $dbh->do("DROP DATABASE $dbname");
+      print "Database $dbname dropped\n" if ( $self->verbose );
+    }
+    else {
 
       my $p;
-      if($force){
-	$p = 'yes';
+      if ($force) {
+        $p = 'yes';
       }
-      else{
-	print "WARNING: about to drop database $dbname on $host:$port; yes to confirm, otherwise exit: ";
-	$p = <ARGV>;
+      else {
+        print
+"WARNING: about to drop database $dbname on $host:$port; yes to confirm, otherwise exit: ";
+        $p = <ARGV>;
       }
       chomp $p;
-      if ($p eq 'yes') {
-	$dbh->do( "DROP DATABASE $dbname" );
-	print "Removed existing database $dbname\n" if($self->verbose);
-      } else {
-	print "$dbname NOT removed\n";
-	exit(1);
+      if ( $p eq 'yes' ) {
+        $dbh->do("DROP DATABASE $dbname");
+        print "Removed existing database $dbname\n"
+          if ( $self->verbose );
+      }
+      else {
+        print "$dbname NOT removed\n";
+        exit(1);
       }
 
     }
-  }
+  } ## end if ( $dbs{$dbname} )
 
   $dbh->do( 'CREATE DATABASE ' . $dbname );
-}
+} ## end sub recreate_database
 
 sub populate_with_file {
-  my ($self, $sql_file) = @_;
+  my ( $self, $sql_file ) = @_;
   my $previous_input_record_separator = $INPUT_RECORD_SEPARATOR;
   $INPUT_RECORD_SEPARATOR = ";";
-  open(my $sql_fh, "<", $sql_file) or die $sql_file;
-  while(<$sql_fh>){
+  open( my $sql_fh, "<", $sql_file ) or die $sql_file;
+  while (<$sql_fh>) {
     s/#(.*?)\n//g;
     next if /^\s+$/;
     $self->dbc->do($_);

--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -28,8 +28,7 @@ use File::Spec::Functions;
 use IO::File;
 use English;
 
-sub new
-{
+sub new {
   my ($proto, $arg_ref) = @_;
 
   my $class = ref $proto || $proto;
@@ -57,11 +56,21 @@ sub verbose {
 }
 
 sub dbc {
-  my ($self, $arg) = @_;
-  (defined $arg) &&
-    ($self->{_dbc} = $arg );
+  my $self = shift;
+
+  if(@_) {
+    my $arg = shift;
+
+    if(defined($arg)) {
+      croak "$arg is not a DBConnection" 
+	unless $arg->isa('Bio::EnsEMBL::DBSQL::DBConnection');
+      $self->{_dbc} = $arg;
+    }
+  }
+
   return $self->{_dbc};
 }
+
 sub host {
   my ($self, $arg) = @_;
   $self->dbc->host($arg) if defined $arg;
@@ -92,8 +101,7 @@ sub port {
   return $self->dbc->port;
 }
 
-sub dbi
-{
+sub dbi {
     my $self = shift;
     my $dbi;
 
@@ -111,15 +119,14 @@ sub dbi
     return $dbi;
 }
 
-
-# Create database if required. Assumes sql/table.sql and sql/populate_metadata.sql
-# are present.
-
+# Create database if required. 
+# Assumes sql/table.sql and sql/populate_metadata.sql are present.
 sub create {
   my ($self, $sql_dir, $force, $drop_db) = @_;
   $self->recreate_database($force,$drop_db);
   $self->populate($sql_dir, $force);
 }
+
 sub populate {
   my ($self, $sql_dir, $force) = @_;
   my $table_file = catfile( $sql_dir, 'sql', 'table.sql' );
@@ -127,6 +134,7 @@ sub populate {
   $self->populate_with_file($table_file);
   $self->populate_with_file($metadata_file);
 }
+
 sub prepare_metadata_file {
   my ($self, $sql_dir, $force) = @_;
   my $metadata_file =
@@ -178,6 +186,7 @@ sub prepare_metadata_file {
   } ## end if ( !defined($meta_tm...
   return $metadata_file;
 }
+
 sub recreate_database {
   my ($self,$force, $drop_db) = @_;
   my $user   = $self->user;
@@ -232,4 +241,5 @@ sub populate_with_file {
   }
   $INPUT_RECORD_SEPARATOR = $previous_input_record_separator;
 }
+
 1;

--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -62,8 +62,7 @@ sub dbc {
     my $arg = shift;
 
     if(defined($arg)) {
-      croak "$arg is not a DBConnection" 
-	unless $arg->isa('Bio::EnsEMBL::DBSQL::DBConnection');
+      croak "$arg is not a DBConnection" unless $arg->isa('Bio::EnsEMBL::DBSQL::DBConnection');
       $self->{_dbc} = $arg;
     }
   }

--- a/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
@@ -36,9 +36,9 @@ sub run {
   my $dbi          = $ref_arg->{dbi};
   $dbi = $self->dbi unless defined $dbi;
 
-  if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
-    croak "Need to pass source_id, species_id, files and rel_file as pairs";
-  }
+  croak "Need to pass source_id, species_id, files and rel_file as pairs"
+    unless defined $source_id and defined $species_id and defined $files;
+
   $verbose |=0;
 
   my $file = @{$files}[0];
@@ -50,40 +50,31 @@ sub run {
   
 
   my $eg_io = $self->get_filehandle($file);
-  if ( !defined $eg_io ) {
-    print STDERR "ERROR: Could not open $file\n";
-    return 1;    # 1 is an error
-  }
-
-  my %seen;
-
+  croak "ERROR: Could not open $file\n" unless defined $eg_io;
 
   my $head = $eg_io->getline(); # first record are the headers
   chomp $head;
-  my (@arr) = split(/\s+/,$head);
-  # process this to the correct indexes to use. (incase they change);
+
+  # process header to figure out correct indexes to use, in case they change
+  my (@arr) = split(/\s+/, $head);
 
   my $gene_id_index = -2;
   my $gene_symbol_index = -2;
   my $gene_desc_index = -2;
   my $gene_tax_id_index = -2;
   my $gene_synonyms_index = -2;
+
   foreach (my $i=0; $i<= $#arr; $i++){
-    # Format change by Entrez, first header
-    # element is #tax_id
-    if($arr[$i] eq "#tax_id"){
+    # Format change by Entrez, first header element is #tax_id
+    if($arr[$i] eq "#tax_id") {
       $gene_tax_id_index = $i;
-    }
-    elsif($arr[$i] eq "GeneID"){
+    } elsif($arr[$i] eq "GeneID") {
       $gene_id_index = $i;
-    }
-    elsif($arr[$i] eq "Symbol"){
+    } elsif($arr[$i] eq "Symbol") {
       $gene_symbol_index = $i;
-    }
-    elsif($arr[$i] eq "description"){
+    } elsif($arr[$i] eq "description") {
       $gene_desc_index = $i;
-    }
-    elsif($arr[$i] eq "Synonyms"){
+    } elsif($arr[$i] eq "Synonyms") {
       $gene_synonyms_index = $i;
     }
   }
@@ -91,31 +82,28 @@ sub run {
       $gene_symbol_index   == -2 ||
       $gene_desc_index     == -2 ||
       $gene_synonyms_index == -2 ||
-      $gene_tax_id_index == -2){
-    print "HEADER\n$head\n\n";
-    print "Unable to get all the indexes needed\n";
-    print "gene_id = $gene_id_index\n";
-    print "tax_id = $gene_tax_id_index\n";
-    print "symbol = $gene_symbol_index\n";
-    print "desc = $gene_desc_index\n";
-    print "synonyms = $gene_synonyms_index\n";
-    return 0; # this is an error
+      $gene_tax_id_index == -2) {
+    croak "HEADER\n$head\n\n" .
+	"Unable to get all the indexes needed\n" .
+	"gene_id = $gene_id_index\n" .
+	"tax_id = $gene_tax_id_index\n" .
+	"symbol = $gene_symbol_index\n" .
+	"desc = $gene_desc_index\n" .
+	"synonyms = $gene_synonyms_index";
   }
+
   my $xref_count = 0;
   my $syn_count  = 0;
+  my %seen; # record already processed xrefs
+
   while ( $_ = $eg_io->getline() ) {
     chomp;
-    my (@arr) = split(/\t/,$_);
-    if(!defined($species_tax_id{$arr[$gene_tax_id_index]})){
-      next;
-    }
-    my $acc    = $arr[$gene_id_index];
-    if($seen{$acc}){
-      next;
-    }
-    else{
-      $seen{$acc} = 1;
-    }
+    my (@arr) = split(/\t/, $_);
+    next unless defined $species_tax_id{$arr[$gene_tax_id_index]};
+
+    my $acc = $arr[$gene_id_index];
+    next if $seen{$acc};
+
     my $symbol = $arr[$gene_symbol_index];
     my $desc   = $arr[$gene_desc_index];
 
@@ -143,11 +131,14 @@ sub run {
 	$syn_count++;
       }
     }
+
+    $seen{$acc} = 1;
   }
 
   $eg_io->close();
 
-  print $xref_count." EntrezGene Xrefs added with $syn_count synonyms\n" if($verbose);
+  print $xref_count." EntrezGene Xrefs added with $syn_count synonyms\n" if $verbose;
+
   return 0; #successful
 }
 

--- a/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
@@ -50,12 +50,10 @@ sub run {
   
 
   my $eg_io = $self->get_filehandle($file);
-  croak "ERROR: Could not open $file\n" unless defined $eg_io;
+  croak "Could not open $file\n" unless defined $eg_io;
 
-  my $input_file = Text::CSV->new({ sep_char           => "\t",
-				    empty_is_undef     => 1,
-				    allow_loose_quotes => 1 # turns out file has unescaped quotes
-				  }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
+  my $input_file = Text::CSV->new({ sep_char => "\t", empty_is_undef => 1, allow_loose_quotes => 1 }) 
+    or croak "Cannot use file $file: " . Text::CSV->error_diag ();
 
   # process header
   $input_file->column_names( @{ $input_file->getline( $eg_io ) } );

--- a/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
@@ -1,3 +1,4 @@
+
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
@@ -20,51 +21,55 @@ limitations under the License.
 package XrefParser::EntrezGeneParser;
 
 use strict;
+use warnings;
 
 use Carp;
-use POSIX qw(strftime);
-use File::Basename;
 use Text::CSV;
 
 use parent qw( XrefParser::BaseParser );
 
 sub run {
 
-  my ($self, $ref_arg) = @_;
+  my ( $self, $ref_arg ) = @_;
   my $source_id    = $ref_arg->{source_id};
   my $species_id   = $ref_arg->{species_id};
   my $species_name = $ref_arg->{species};
   my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose} || 0;
-  my $dbi          = $ref_arg->{dbi} || $self->dbi;
+  my $verbose      = $ref_arg->{verbose} // 0;
+  my $dbi          = $ref_arg->{dbi} // $self->dbi;
 
   croak "Need to pass source_id, species_id, files and rel_file as pairs"
-    unless defined $source_id and defined $species_id and defined $files;
+    unless defined $source_id and
+    defined $species_id and
+    defined $files;
 
   my $file = @{$files}[0];
 
-  my $wiki_source_id = $self->get_source_id_for_source_name("WikiGene", undef, $dbi);
+  my $wiki_source_id =
+    $self->get_source_id_for_source_name( "WikiGene", undef, $dbi );
 
-  my %species_tax_id = %{$self->get_taxonomy_from_species_id($species_id, $dbi)};
+  my %species_tax_id =
+    %{ $self->get_taxonomy_from_species_id( $species_id, $dbi ) };
   $species_tax_id{$species_id} = $species_id if defined $species_name;
-  
 
   my $eg_io = $self->get_filehandle($file);
   croak "Could not open $file\n" unless defined $eg_io;
 
-  my $input_file = Text::CSV->new({ sep_char => "\t", empty_is_undef => 1, allow_loose_quotes => 1 }) 
-    or croak "Cannot use file $file: " . Text::CSV->error_diag ();
+  my $input_file = Text::CSV->new(
+    { sep_char => "\t", empty_is_undef => 1, allow_loose_quotes => 1 } )
+    or
+    croak "Cannot use file $file: " . Text::CSV->error_diag();
 
   # process header
-  $input_file->column_names( @{ $input_file->getline( $eg_io ) } );
+  $input_file->column_names( @{ $input_file->getline($eg_io) } );
 
   # read data and load xrefs
   my $xref_count = 0;
   my $syn_count  = 0;
-  my %seen; # record already processed xrefs
+  my %seen;    # record already processed xrefs
 
-  while ( my $data = $input_file->getline_hr( $eg_io ) ) {
-    next unless exists $species_tax_id{$data->{'#tax_id'}};
+  while ( my $data = $input_file->getline_hr($eg_io) ) {
+    next unless exists $species_tax_id{ $data->{'#tax_id'} };
 
     my $acc = $data->{'GeneID'};
     next if $seen{$acc};
@@ -72,41 +77,47 @@ sub run {
     my $symbol = $data->{'Symbol'};
     my $desc   = $data->{'description'};
 
-    $self->add_xref({ acc        => $acc,
-		      label      => $symbol,
-		      desc       => $desc,
-		      source_id  => $source_id,
-		      species_id => $species_id,
-                      dbi        => $dbi,
-		      info_type  =>"DEPENDENT"} );
+    $self->add_xref(
+                     { acc        => $acc,
+                       label      => $symbol,
+                       desc       => $desc,
+                       source_id  => $source_id,
+                       species_id => $species_id,
+                       dbi        => $dbi,
+                       info_type  => "DEPENDENT" } );
 
-    $self->add_xref({ acc        => $acc,
-		      label      => $symbol,
-		      desc       => $desc,
-		      source_id  => $wiki_source_id,
-		      species_id => $species_id,
-                      dbi        => $dbi,
-		      info_type  => "DEPENDENT" } ); #,"From EntrezGene $acc");
+    $self->add_xref(
+                     { acc        => $acc,
+                       label      => $symbol,
+                       desc       => $desc,
+                       source_id  => $wiki_source_id,
+                       species_id => $species_id,
+                       dbi        => $dbi,
+                       info_type  => "DEPENDENT" }
+    );    #,"From EntrezGene $acc");
     $xref_count++;
 
-    my (@syn) = split(/\|/, $data->{'Synonyms'});
-    foreach my $synonym (@syn){
-      if($synonym ne "-"){
-	$self->add_to_syn($acc, $source_id, $synonym, $species_id, $dbi);
-	$syn_count++;
+    my (@syn) = split( /\|/, $data->{'Synonyms'} );
+    foreach my $synonym (@syn) {
+      if ( $synonym ne "-" ) {
+        $self->add_to_syn( $acc, $source_id, $synonym, $species_id,
+                           $dbi );
+        $syn_count++;
       }
     }
 
     $seen{$acc} = 1;
-  }
+  } ## end while ( my $data = $input_file...)
 
-  $input_file->eof or croak "Error parsing file $file: " . $input_file->error_diag();
+  $input_file->eof or
+    croak "Error parsing file $file: " . $input_file->error_diag();
   $eg_io->close();
 
-  print $xref_count." EntrezGene Xrefs added with $syn_count synonyms\n" if $verbose;
+  print $xref_count.
+    " EntrezGene Xrefs added with $syn_count synonyms\n"
+    if $verbose;
 
-  return 0; # success
-}
+  return 0;    # success
+} ## end sub run
 
- 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/HPAParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HPAParser.pm
@@ -1,3 +1,4 @@
+
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
@@ -28,7 +29,7 @@ use Text::CSV;
 use parent qw( XrefParser::BaseParser);
 
 # This parser will read direct xrefs from a simple comma-delimited file downloaded from the Human Protein Atlas (HPA) database.
-# The database contains two types of antibody, their own HPA antibodies and Collaborator antibody (CAB) commercial antibodies. 
+# The database contains two types of antibody, their own HPA antibodies and Collaborator antibody (CAB) commercial antibodies.
 # The columns of the file should be the following:
 #
 # 1)    Antibody
@@ -36,67 +37,79 @@ use parent qw( XrefParser::BaseParser);
 # 3)    Ensembl Peptide ID
 # 4)	Link (URL)
 
-
 sub run {
-  my ($self, $ref_arg) = @_;
-  my $source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose} || 0;
-  my $dbi          = $ref_arg->{dbi} || $self->dbi;
+  my ( $self, $ref_arg ) = @_;
+  my $source_id  = $ref_arg->{source_id};
+  my $species_id = $ref_arg->{species_id};
+  my $files      = $ref_arg->{files};
+  my $verbose    = $ref_arg->{verbose} // 0;
+  my $dbi        = $ref_arg->{dbi} // $self->dbi;
 
-  croak "Need to pass source_id, species_id, files and rel_file as pairs"
-    unless defined $source_id and defined $species_id and defined $files;
+  croak
+    "Need to pass source_id, species_id, files and rel_file as pairs"
+    unless defined $source_id and
+    defined $species_id and
+    defined $files;
 
   my $file = @{$files}[0];
 
   my $file_io = $self->get_filehandle($file);
   croak "Could not open $file\n" unless defined $file_io;
 
-  my $input_file = Text::CSV->new({ sep_char           => ",",
-				    empty_is_undef     => 1
-				  }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
-  
-  $file_io->getline(); # skip header # Antibody,antibody_id,ensembl_peptide_id,link
+  my $input_file =
+    Text::CSV->new( { sep_char => ",", empty_is_undef => 1 } ) or
+    croak "Cannot use file $file: " . Text::CSV->error_diag();
+
+  $file_io->getline()
+    ;    # skip header # Antibody,antibody_id,ensembl_peptide_id,link
 
   my $parsed_count = 0;
-  while ( my $row = $input_file->getline( $file_io ) ) {
+  while ( my $row = $input_file->getline($file_io) ) {
     my ( $antibody, $antibody_id, $ensembl_peptide_id, $link );
-    ( $antibody = $row->[0] ) =~ s/\s*$//;
-    ( $antibody_id = $row->[1] ) =~ s/\s*$//;
+    ( $antibody           = $row->[0] ) =~ s/\s*$//;
+    ( $antibody_id        = $row->[1] ) =~ s/\s*$//;
     ( $ensembl_peptide_id = $row->[2] ) =~ s/\s*$//;
-    ( $link = $row->[3] ) =~ s/\s*$//;
+    ( $link               = $row->[3] ) =~ s/\s*$//;
 
-    croak sprintf("Line %d contains has less than two columns.\nParsing failed", 1 + $parsed_count)
-      unless defined $antibody and defined $ensembl_peptide_id;
-	
+    croak
+      sprintf(
+          "Line %d contains has less than two columns.\nParsing failed",
+          1 + $parsed_count )
+      unless defined $antibody and
+      defined $ensembl_peptide_id;
+
     my $label   = $antibody;
     my $type    = 'translation';
     my $version = '1';
 
-    my $xref_id = $self->get_xref( $antibody_id, $source_id, $species_id, $dbi );
+    my $xref_id =
+      $self->get_xref( $antibody_id, $source_id, $species_id, $dbi );
 
-    unless(defined $xref_id or $xref_id ne '') {
-	$xref_id = $self->add_xref({ acc        => $antibody_id,
-				     version    => $version,
-				     label      => $label,
-				     source_id  => $source_id,
-				     species_id => $species_id,
-				     dbi        => $dbi,
-				     info_type  => "DIRECT"} )
+    if ( !defined($xref_id) || $xref_id eq q{} ) {
+      $xref_id = $self->add_xref(
+                                  { acc        => $antibody_id,
+                                    version    => $version,
+                                    label      => $label,
+                                    source_id  => $source_id,
+                                    species_id => $species_id,
+                                    dbi        => $dbi,
+                                    info_type  => "DIRECT" } );
     }
 
-    $self->add_direct_xref( $xref_id, $ensembl_peptide_id, $type, undef, $dbi);
+    $self->add_direct_xref( $xref_id, $ensembl_peptide_id, $type,
+                            undef, $dbi );
 
     ++$parsed_count;
-  }
+  } ## end while ( my $row = $input_file...)
 
-  $input_file->eof or croak "Error parsing file $file: " . $input_file->error_diag();
+  $input_file->eof or
+    croak "Error parsing file $file: " . $input_file->error_diag();
   $file_io->close();
 
-  printf( "%d direct xrefs succesfully parsed\n", $parsed_count ) if $verbose;
+  printf( "%d direct xrefs succesfully parsed\n", $parsed_count )
+    if $verbose;
 
-  return 0; # success
-}
+  return 0;    # success
+} ## end sub run
 
 1;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Refactoring the parsers to consider:
- consistent error handling
- code compression, clarity
- NULL fields where applicable without touching BaseParser at the moment, i.e. forcing NULL description when adding xrefs in HPA parser

## Use case

Xref pipeline for species with EntrezGene/HPA sources

## Benefits

Code quality improvement

## Possible Drawbacks

According to the guidelines, not fully there yet. Need to change the BaseParser and schema to force NULL info_text instead of empty string.

## Testing

No unit tests at the moment I'm afraid. Run the xref_parser script with the current version and proposed update and found no difference except attribute description is now NULL for xrefs from HPA (formerly '').

