### PR TITLE
XrefParser sprint - MGI_Desc_Parser updates

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -68,35 +68,37 @@ sub run {
   $input_file->getline($mgi_io);
   $input_file->column_names([qw(accession chromosome position start end strand label status marker marker_type feature_type synonym_field)] );
   while ( my $data = $input_file->getline_hr( $mgi_io ) ) {
-        my $accession = $data->{'accession'};
-        my $marker = defined($data->{'marker'}) ? $data->{'marker'} : undef;
-        $acc_to_xref{$accession} = $self->add_xref({ acc        => $accession,
-                                                     label      => $data->{'label'},
-                                                     desc       => $marker,
-                                                     source_id  => $source_id,
-                                                     species_id => $species_id,
-                                                     dbi        => $dbi,
-                                                     info_type  => "MISC"} );
-        if($verbose and !$marker){
-    	   print "$accession has no description\n";
-        }
-        $xref_count++;
-        my @synonyms;
-        if(defined($acc_to_xref{$accession})){
-            @synonyms = split(/\|/,$data->{'synonym_field'}) if ($data->{'synonym_field'});
-            foreach my $syn (@synonyms) {
-                $self->add_synonym($acc_to_xref{$accession}, $syn, $dbi);
-                $syn_count++;
-            }
-        }
+    my $accession = $data->{'accession'};
+    my $marker = defined($data->{'marker'}) ? $data->{'marker'} : undef;
+    $acc_to_xref{$accession} = $self->add_xref({ acc        => $accession,
+                                                 label      => $data->{'label'},
+                                                 desc       => $marker,
+                                                 source_id  => $source_id,
+                                                 species_id => $species_id,
+                                                 dbi        => $dbi,
+                                                 info_type  => "MISC"} );
+    if($verbose and !$marker){
+      print "$accession has no description\n";
     }
-    $mgi_io->eof or croak "Error parsing file $file: " . $input_file->error_diag();
-    $mgi_io->close();
-      
-    print $xref_count." MGI Description Xrefs added\n" if($verbose);
-    print $syn_count." synonyms added\n" if($verbose);
+    $xref_count++;
+    my @synonyms;
+    if(defined($acc_to_xref{$accession})){
+      @synonyms = split(/\|/,$data->{'synonym_field'}) if ($data->{'synonym_field'});
+      foreach my $syn (@synonyms) {
+        $self->add_synonym($acc_to_xref{$accession}, $syn, $dbi);
+        $syn_count++;
+      }
+    }
+  }
+  $mgi_io->eof or croak "Error parsing file $file: " . $input_file->error_diag();
+  $mgi_io->close();
 
-    return 0; #successful
+  if ($verbose) {
+    print "$xref_count MGI Description Xrefs added\n";
+    print "$syn_count synonyms added\n";
+  }
+
+  return 0; #successful
 }
 	
 

--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -70,38 +70,27 @@ sub run {
         chomp($line);
         my ($accession, $chromosome, $position, $start, $end, $strand,$label, 
             $status, $marker, $marker_type, $feature_type, $synonym_field) = split(/\t/,$line);
-            
-        $position =~ s/^\s+// if ($position);
-
-        my @synonyms = split(/\|/,$synonym_field) if ($synonym_field);
-        
 	
-        my $desc;
-	if ($marker) {
-	    $desc = $marker;
-	}
-        
         $acc_to_xref{$accession} = $self->add_xref({ acc        => $accession,
     	                           		             label      => $label,
-    					                             desc       => $desc,
+                                                                     desc       => defined($marker) ? $marker : undef,
     					                             source_id  => $source_id,
     					                             species_id => $species_id,
                                                                      dbi        => $dbi,
     					                             info_type  => "MISC"} );
-        if($verbose and !$desc){
+        if($verbose and !$marker){
     	   print "$accession has no description\n";
         }
         $xref_count++;
-            
+
+        my @synonyms;
         if(defined($acc_to_xref{$accession})){
-           
+            @synonyms = split(/\|/,$synonym_field) if ($synonym_field);
             foreach my $syn (@synonyms) {
                 $self->add_synonym($acc_to_xref{$accession}, $syn, $dbi);
                 $syn_count++;
             }
-            
         }
-        
     }
       
     $mgi_io->close();


### PR DESCRIPTION
…ition, removed desc intialisation inside if block

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description
Updates:
  - Removed the unused variable ($position)
  - Moved the @synonms parsing inside if block where it is accessed.

## Use case

XrefParser for source MGI (MGI_desc) for mouse (mus musculus)


## Benefits

Improvement in code quality.

## Possible Drawbacks

None.

## Testing

No until test. But have tested it by running the xref_parser script and checked the _xref database.


