### PR TITLE
Bugfix/delint DBASS parser

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -72,14 +72,19 @@ sub run {
     # assumes actual column values will never contain commas, which while
     # true at present brings into question why bother quoting them in the
     # first place.
-    # FIXME: add a sanity check for that
     $line =~ s/"//gx;
 
-    my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id ) =
+    my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id, @split_overflow ) =
       split( /,/x, $line );
 
     if ( !defined($dbass_gene_id) || !defined($ensembl_id) ) {
       printf STDERR ( "Line %d has fewer than three columns.\n",
+                      1 + $parsed_count );
+      print STDERR ("The parsing failed\n");
+      return 1;
+    }
+    elsif ( scalar @split_overflow > 0 ) {
+      printf STDERR ( "Line %d has more than three columns.\n",
                       1 + $parsed_count );
       print STDERR ("The parsing failed\n");
       return 1;

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -65,12 +65,12 @@ sub run {
 
   while ( defined( my $line = $file_io->getline() ) ) {
 
-    $line =~ s/\s*$//;
+    $line =~ s/\s*$//x;
     # csv format can come with quoted columns, remove them
-    $line =~ s/"//g;
+    $line =~ s/"//gx;
 
     my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id ) =
-      split( /,/, $line );
+      split( /,/x, $line );
 
     if ( !defined($dbass_gene_id) || !defined($ensembl_id) ) {
       printf STDERR ( "Line %d contains  has less than two columns.\n",
@@ -82,12 +82,12 @@ sub run {
     my $first_gene_name = $dbass_gene_name;
     my $second_gene_name;
 
-    if ( $dbass_gene_name =~ /.\/./ ) {
+    if ( $dbass_gene_name =~ /.\/./x ) {
       ( $first_gene_name, $second_gene_name ) =
-        split( /\//, $dbass_gene_name );
+        split( /\//x, $dbass_gene_name );
     }
 
-    if ( $dbass_gene_name =~ /(.*)\((.*)\)/ ) {
+    if ( $dbass_gene_name =~ /(.*)\((.*)\)/x ) {
       $first_gene_name  = $1;
       $second_gene_name = $2;
 #      print $first_gene_name, "\n", $second_gene_name, "\n" if($verbose);
@@ -120,7 +120,7 @@ sub run {
     if ( defined($synonym) ) {
       $self->add_synonym( $xref_id, $synonym, $dbi );
     }
-    elsif ( $synonym =~ /^\s/ ) {
+    elsif ( $synonym =~ /^\s/x ) {
       print "There is white space! \n" if ($verbose);
     }
     else {

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -78,15 +78,15 @@ sub run {
       split( /,/x, $line );
 
     if ( !defined($dbass_gene_id) || !defined($ensembl_id) ) {
-      printf STDERR ( "Line %d has fewer than three columns.\n",
+      printf {*STDERR} ( "Line %d has fewer than three columns.\n",
                       1 + $parsed_count );
-      print STDERR ("The parsing failed\n");
+      print {*STDERR} ("The parsing failed\n");
       return 1;
     }
     elsif ( scalar @split_overflow > 0 ) {
-      printf STDERR ( "Line %d has more than three columns.\n",
+      printf {*STDERR} ( "Line %d has more than three columns.\n",
                       1 + $parsed_count );
-      print STDERR ("The parsing failed\n");
+      print {*STDERR} ("The parsing failed\n");
       return 1;
     }
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -27,12 +27,15 @@ use Carp;
 
 use parent qw( XrefParser::BaseParser );
 
-# This parser will read direct xrefs from a simple comma-delimited file downloaded from the DBASS database.
+# This parser will read direct xrefs from a comma-delimited file downloaded from the DBASS Web site.
 # The columns of the file should be the following:
 #
 # 1)    DBASS Gene ID
 # 2)    DBASS Gene Name
 # 3)    Ensembl Gene ID
+#
+# where 2) can be either a single name, a 'name/synonym' pair, or a 'name (synonym)' pair.
+# Column values, including empty strings, can be surrounded by pairs of double quotes.
 
 
 sub run {
@@ -90,10 +93,6 @@ sub run {
       return 1;
     }
 
-    # Three options here:
-    #  1. gene has only one name;
-    #  2. synonyms are slash-separated;
-    #  3. the second name follows the first one in brackets.
     # FIXME: .* is seriously inefficient because here it results in massive
     # amounts of backtracking. Could we be more specific, i.e. assume
     # some specific format of DBASS names?

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -157,8 +157,9 @@ sub run {
 
   } ## end while ( defined( my $line...))
 
-  printf( "%d direct xrefs succesfully parsed\n", $parsed_count )
-    if ($verbose);
+  if ($verbose) {
+    printf( "%d direct xrefs succesfully parsed\n", $parsed_count );
+  }
 
   $file_io->close();
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -93,6 +93,8 @@ sub run {
     # not a valid Ensembl stable ID.
     if ( $ensembl_id ) {
 
+      # DBASS files list synonyms in two ways: either "FOO (BAR)" (with or
+      # without space) or "FOO/BAR". Both forms are relevant to us.
       my ( $first_gene_name, $second_gene_name );
       if ( ( $dbass_gene_name =~ m{
                                     (.*)
@@ -101,7 +103,7 @@ sub run {
                                   }msx ) ||
            ( $dbass_gene_name =~ m{
                                     (.*)
-                                    \s?  # typically there IS a space before the ( here
+                                    \s?  # there are entries both with and without ws
                                     [(] (.*) [)]
                                   }msx ) ) {
         $first_gene_name  = $1;

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -20,6 +20,7 @@ limitations under the License.
 package XrefParser::DBASSParser;
 
 use strict;
+use warnings;
 
 use base qw( XrefParser::BaseParser);
 use DBI;

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -24,6 +24,7 @@ use warnings;
 
 use Carp;
 use List::Util;
+use Readonly;
 use Text::CSV;
 
 use parent qw( XrefParser::BaseParser );
@@ -37,6 +38,9 @@ use parent qw( XrefParser::BaseParser );
 #
 # where 2) can be either a single name, a 'name/synonym' pair, or a 'name (synonym)' pair.
 # Column values, including empty strings, can be surrounded by pairs of double quotes.
+
+
+Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 3;
 
 
 sub run {
@@ -75,7 +79,7 @@ sub run {
 
   while ( defined( my $line = $csv->getline ( $file_io ) ) ) {
 
-    if ( scalar @{ $line } != 3 ) {
+    if ( scalar @{ $line } != $EXPECTED_NUMBER_OF_COLUMNS ) {
       croak 'Line ' . (2 + $processed_count + $unmapped_count)
         . " of input file '${filename}' has an incorrect number of columns";
     }
@@ -175,7 +179,7 @@ sub is_file_header_valid {
 
   # Don't bother with parsing column names if their number does not
   # match to begin with
-  if ( scalar @{ $header } != 3 ) {
+  if ( scalar @{ $header } != $EXPECTED_NUMBER_OF_COLUMNS ) {
     return 0;
   }
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -22,9 +22,10 @@ package XrefParser::DBASSParser;
 use strict;
 use warnings;
 
-use base qw( XrefParser::BaseParser);
 use DBI;
 use Carp;
+
+use parent qw( XrefParser::BaseParser );
 
 # This parser will read direct xrefs from a simple comma-delimited file downloaded from the DBASS database.
 # The columns of the file should be the following:

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -120,12 +120,6 @@ sub run {
     if ( defined($synonym) ) {
       $self->add_synonym( $xref_id, $synonym, $dbi );
     }
-    elsif ( $synonym =~ /^\s/x ) {
-      print "There is white space! \n" if ($verbose);
-    }
-    else {
-      next;
-    }
 
   } ## end while ( defined( my $line...))
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -51,8 +51,8 @@ sub run {
   my $source_id  = $ref_arg->{source_id};
   my $species_id = $ref_arg->{species_id};
   my $files      = $ref_arg->{files};
-  my $verbose    = $ref_arg->{verbose};
-  my $dbi        = $ref_arg->{dbi};
+  my $verbose    = $ref_arg->{verbose} // 0;
+  my $dbi        = $ref_arg->{dbi} // $self->dbi;
 
   if ( ( !defined $source_id ) or
        ( !defined $species_id ) or
@@ -60,9 +60,6 @@ sub run {
   {
     croak 'Need to pass source_id, species_id and files as pairs';
   }
-  $verbose //= 0;
-  $dbi //= $self->dbi;
-
   my $csv = Text::CSV->new()
     || croak 'Failed to initialise CSV parser: ' . Text::CSV->error_diag();
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -22,6 +22,9 @@ package XrefParser::DBASSParser;
 use strict;
 use warnings;
 
+# For non-destructive substitutions in regexps (/r flag)
+require 5.014_000;
+
 use Carp;
 use List::Util;
 use Readonly;
@@ -84,10 +87,9 @@ sub run {
         . " of input file '${filename}' has an incorrect number of columns";
     }
 
-    # strip trailing whitespace
-    map { s{\s+\z}{}msx } @{ $line };
-
-    my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id ) = @{ $line };
+    # Do not modify the contents of @{$line}, only the output - hence the /r.
+    my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id )
+      = map { s{\s+\z}{}rmsx } @{ $line };
 
     # Do not attempt to create unmapped xrefs. Checking truthiness is good
     # enough here because the only non-empty string evaluating as false is

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -59,7 +59,7 @@ sub run {
 
   my $file_io = $self->get_filehandle($filename);
   if ( !defined($file_io) ) {
-    return 1;
+    croak "Failed to acquire a file handle for '${filename}'";
   }
 
   my $parsed_count = 0;
@@ -87,16 +87,10 @@ sub run {
     # $ensembl_id to an empty string for unmapped entries and correctly
     # assigns further tokens to the overflow array.
     if ( !defined($dbass_gene_id) || !defined($dbass_gene_name) ) {
-      printf {*STDERR} ( "Line %d has fewer than two columns.\n",
-                      1 + $parsed_count );
-      print {*STDERR} ("The parsing failed\n");
-      return 1;
+      croak 'Line ' . (1 + $parsed_count) . ' has fewer than two columns';
     }
     elsif ( scalar @split_overflow > 0 ) {
-      printf {*STDERR} ( "Line %d has more than three columns.\n",
-                      1 + $parsed_count );
-      print {*STDERR} ("The parsing failed\n");
-      return 1;
+      croak 'Line ' . (1 + $parsed_count) . ' has more than three columns';
     }
 
     # Do not attempt to create unmapped xrefs. Checking truthiness is good

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -94,14 +94,20 @@ sub run {
     #  1. gene has only one name;
     #  2. synonyms are slash-separated;
     #  3. the second name follows the first one in brackets.
+    # FIXME: .* is seriously inefficient because here it results in massive
+    # amounts of backtracking. Could we be more specific, i.e. assume
+    # some specific format of DBASS names?
     my ( $first_gene_name, $second_gene_name );
-    if ( $dbass_gene_name =~ /.\/./x ) {
-      # FIXME: feels wasteful to do a regex match AND a split
-      ( $first_gene_name, $second_gene_name ) =
-        split( /\//x, $dbass_gene_name );
-    }
-    elsif ( $dbass_gene_name =~ /(.*)\((.*)\)/x ) {
-      # FIXME: this may add a trailing space to the first name. Incorrect?
+    if ( ( $dbass_gene_name =~ m{
+                                  (.*)
+                                  \s?\/\s?  # typically no ws here but just in case
+                                  (.*)
+                                }x ) ||
+         ( $dbass_gene_name =~ m{
+                                  (.*)
+                                  \s?  # typically there IS a space before the ( here
+                                  [(] (.*) [)]
+                                }x ) ) {
       $first_gene_name  = $1;
       $second_gene_name = $2;
     }

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -34,9 +34,6 @@ use parent qw( XrefParser::BaseParser );
 # 2)    DBASS Gene Name
 # 3)    Ensembl Gene ID
 
-my $dbi;
-my $xref_id;
-my $source_id;
 
 sub run {
   my ( $self, $ref_arg ) = @_;

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -93,32 +93,33 @@ sub run {
       return 1;
     }
 
-    # FIXME: .* is seriously inefficient because here it results in massive
-    # amounts of backtracking. Could we be more specific, i.e. assume
-    # some specific format of DBASS names?
-    my ( $first_gene_name, $second_gene_name );
-    if ( ( $dbass_gene_name =~ m{
-                                  (.*)
-                                  \s?\/\s?  # typically no ws here but just in case
-                                  (.*)
-                                }x ) ||
-         ( $dbass_gene_name =~ m{
-                                  (.*)
-                                  \s?  # typically there IS a space before the ( here
-                                  [(] (.*) [)]
-                                }x ) ) {
-      $first_gene_name  = $1;
-      $second_gene_name = $2;
-    }
-    else {
-      $first_gene_name = $dbass_gene_name;
-      $second_gene_name = undef;
-    }
-
-    ++$parsed_count;
-
     # Do not attempt to create unmapped xrefs
     if ( $ensembl_id ne q{} ) {
+
+      # FIXME: .* is seriously inefficient because here it results in massive
+      # amounts of backtracking. Could we be more specific, i.e. assume
+      # some specific format of DBASS names?
+      my ( $first_gene_name, $second_gene_name );
+      if ( ( $dbass_gene_name =~ m{
+                                    (.*)
+                                    \s?\/\s?  # typically no ws here but just in case
+                                    (.*)
+                                  }x ) ||
+           ( $dbass_gene_name =~ m{
+                                    (.*)
+                                    \s?  # typically there IS a space before the ( here
+                                    [(] (.*) [)]
+                                  }x ) ) {
+        $first_gene_name  = $1;
+        $second_gene_name = $2;
+      }
+      else {
+        $first_gene_name = $dbass_gene_name;
+        $second_gene_name = undef;
+      }
+
+      ++$parsed_count;
+
       my $label       = $first_gene_name;
       my $synonym     = $second_gene_name;
       my $type        = 'gene';

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -95,7 +95,6 @@ sub run {
 
     my $label       = $first_gene_name;
     my $type        = 'gene';
-    my $description = '';
     my $version     = '1';
     my $synonym     = $second_gene_name;
 
@@ -109,14 +108,14 @@ sub run {
                                   { acc        => $dbass_gene_id,
                                     version    => $version,
                                     label      => $label,
-                                    desc       => $description,
+                                    desc       => undef,
                                     source_id  => $source_id,
                                     dbi        => $dbi,
                                     species_id => $species_id,
                                     info_type  => "DIRECT" } );
     }
 
-    $self->add_direct_xref( $xref_id, $ensembl_id, $type, '', $dbi );
+    $self->add_direct_xref( $xref_id, $ensembl_id, $type, undef, $dbi );
 
     if ( defined($synonym) ) {
       $self->add_synonym( $xref_id, $synonym, $dbi );

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -45,7 +45,6 @@ sub run {
   my $files      = $ref_arg->{files};
   my $verbose    = $ref_arg->{verbose};
   my $dbi        = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
 
   if ( ( !defined $source_id ) or
        ( !defined $species_id ) or
@@ -53,7 +52,8 @@ sub run {
   {
     croak 'Need to pass source_id, species_id and files as pairs';
   }
-  $verbose |= 0;
+  $verbose //= 0;
+  $dbi //= $self->dbi;
 
   my $filename = @{$files}[0];
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -73,7 +73,7 @@ sub run {
       split( /,/x, $line );
 
     if ( !defined($dbass_gene_id) || !defined($ensembl_id) ) {
-      printf STDERR ( "Line %d contains  has less than two columns.\n",
+      printf STDERR ( "Line %d has fewer than three columns.\n",
                       1 + $parsed_count );
       print STDERR ("The parsing failed\n");
       return 1;

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -48,7 +48,7 @@ sub run {
        ( !defined $species_id ) or
        ( !defined $files ) )
   {
-    croak "Need to pass source_id, species_id and files as pairs";
+    croak 'Need to pass source_id, species_id and files as pairs';
   }
   $verbose |= 0;
 
@@ -119,7 +119,7 @@ sub run {
     ++$parsed_count;
 
     # Do not attempt to create unmapped xrefs
-    if ( $ensembl_id ne '' ) {
+    if ( $ensembl_id ne q{} ) {
       my $label       = $first_gene_name;
       my $synonym     = $second_gene_name;
       my $type        = 'gene';
@@ -128,7 +128,7 @@ sub run {
       my $xref_id =
         $self->get_xref( $dbass_gene_id, $source_id, $species_id, $dbi );
 
-      if ( !defined($xref_id) || $xref_id eq '' ) {
+      if ( !defined($xref_id) || $xref_id eq q{} ) {
         $xref_id = $self->add_xref(
                                    { acc        => $dbass_gene_id,
                                      version    => $version,

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -34,111 +34,111 @@ use parent qw( XrefParser::BaseParser );
 # 2)    DBASS Gene Name
 # 3)    Ensembl Gene ID
 
-
 my $dbi;
 my $xref_id;
 my $source_id;
 
-
 sub run {
-  my ($self, $ref_arg) = @_;
-  my $source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
+  my ( $self, $ref_arg ) = @_;
+  my $source_id  = $ref_arg->{source_id};
+  my $species_id = $ref_arg->{species_id};
+  my $files      = $ref_arg->{files};
+  my $verbose    = $ref_arg->{verbose};
+  my $dbi        = $ref_arg->{dbi};
   $dbi = $self->dbi unless defined $dbi;
 
-  if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
+  if ( ( !defined $source_id ) or
+       ( !defined $species_id ) or
+       ( !defined $files ) )
+  {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |=0;
+  $verbose |= 0;
 
   my $filename = @{$files}[0];
 
+  my $file_io = $self->get_filehandle($filename);
+  if ( !defined($file_io) ) {
+    return 1;
+  }
 
-    my $file_io = $self->get_filehandle($filename);
-    if ( !defined($file_io) ) {
-        return 1;
+  my $parsed_count = 0;
+
+  $file_io->getline();
+
+  while ( defined( my $line = $file_io->getline() ) ) {
+
+    $line =~ s/\s*$//;
+    # csv format can come with quoted columns, remove them
+    $line =~ s/"//g;
+
+    my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id ) =
+      split( /,/, $line );
+
+    if ( !defined($dbass_gene_id) || !defined($ensembl_id) ) {
+      printf STDERR ( "Line %d contains  has less than two columns.\n",
+                      1 + $parsed_count );
+      print STDERR ("The parsing failed\n");
+      return 1;
     }
 
-     my $parsed_count = 0;
+    my $first_gene_name = $dbass_gene_name;
+    my $second_gene_name;
 
-     $file_io->getline();
-    
-    while ( defined( my $line = $file_io->getline() ) ) {
- 
-	$line =~ s/\s*$//;
-        # csv format can come with quoted columns, remove them
-        $line =~ s/"//g;
+    if ( $dbass_gene_name =~ /.\/./ ) {
+      ( $first_gene_name, $second_gene_name ) =
+        split( /\//, $dbass_gene_name );
+    }
 
-        my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id) = split( /,/, $line );
+    if ( $dbass_gene_name =~ /(.*)\((.*)\)/ ) {
+      $first_gene_name  = $1;
+      $second_gene_name = $2;
+#      print $first_gene_name, "\n", $second_gene_name, "\n" if($verbose);
+    }
 
-        if ( !defined($dbass_gene_id) || !defined($ensembl_id) ) {
-            printf STDERR ( "Line %d contains  has less than two columns.\n",
-                    1 + $parsed_count );
-            print STDERR ("The parsing failed\n");
-            return 1;
-        }
-	
-	
-	my $first_gene_name = $dbass_gene_name;
-	my $second_gene_name;
-	
-	
-	if ($dbass_gene_name =~ /.\/./){
-		($first_gene_name, $second_gene_name) = split( /\//, $dbass_gene_name );
-	}
-	
-	if ($dbass_gene_name =~ /(.*)\((.*)\)/){
-		$first_gene_name = $1;
-	 	$second_gene_name = $2;
-#		print $first_gene_name, "\n", $second_gene_name, "\n" if($verbose);
-	}
-       
-       
-        my $label       = $first_gene_name;
-	my $type        = 'gene';
-        my $description = '';
-        my $version     = '1';
-	my $synonym	= $second_gene_name;
+    my $label       = $first_gene_name;
+    my $type        = 'gene';
+    my $description = '';
+    my $version     = '1';
+    my $synonym     = $second_gene_name;
 
-        ++$parsed_count;
+    ++$parsed_count;
 
-        my $xref_id = $self->get_xref( $dbass_gene_id, $source_id, $species_id, $dbi );
+    my $xref_id =
+      $self->get_xref( $dbass_gene_id, $source_id, $species_id, $dbi );
 
-        if ( !defined($xref_id) || $xref_id eq '' ) {
-            $xref_id = $self->add_xref({ acc        => $dbass_gene_id,
-					 version    => $version,
-					 label      => $label,
-					 desc       => $description,
-					 source_id  => $source_id,
-                                         dbi        => $dbi,
-					 species_id => $species_id,
-					 info_type => "DIRECT"} );
-        }
-	
-	$self->add_direct_xref( $xref_id, $ensembl_id, $type, '', $dbi);
-	
-	if (defined ($synonym)) {
-		$self->add_synonym($xref_id, $synonym, $dbi);
-	}
-	elsif ($synonym =~ /^\s/){
-		print "There is white space! \n" if($verbose);	
-	}
-	else {
-		next;
-	}
-	
-	
-    } ## end while ( defined( my $line...
+    if ( !defined($xref_id) || $xref_id eq '' ) {
+      $xref_id = $self->add_xref(
+                                  { acc        => $dbass_gene_id,
+                                    version    => $version,
+                                    label      => $label,
+                                    desc       => $description,
+                                    source_id  => $source_id,
+                                    dbi        => $dbi,
+                                    species_id => $species_id,
+                                    info_type  => "DIRECT" } );
+    }
 
-    printf( "%d direct xrefs succesfully parsed\n", $parsed_count ) if($verbose);
+    $self->add_direct_xref( $xref_id, $ensembl_id, $type, '', $dbi );
 
-    $file_io->close();
+    if ( defined($synonym) ) {
+      $self->add_synonym( $xref_id, $synonym, $dbi );
+    }
+    elsif ( $synonym =~ /^\s/ ) {
+      print "There is white space! \n" if ($verbose);
+    }
+    else {
+      next;
+    }
 
+  } ## end while ( defined( my $line...))
 
-    return 0;
+  printf( "%d direct xrefs succesfully parsed\n", $parsed_count )
+    if ($verbose);
+
+  $file_io->close();
+
+  return 0;
 } ## end sub run
 
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -23,7 +23,6 @@ use strict;
 use warnings;
 
 use Carp;
-use DBI;
 use List::Util;
 use Text::CSV;
 

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -116,32 +116,35 @@ sub run {
       $second_gene_name = undef;
     }
 
-    my $label       = $first_gene_name;
-    my $type        = 'gene';
-    my $version     = '1';
-    my $synonym     = $second_gene_name;
-
     ++$parsed_count;
 
-    my $xref_id =
-      $self->get_xref( $dbass_gene_id, $source_id, $species_id, $dbi );
+    # Do not attempt to create unmapped xrefs
+    if ( $ensembl_id ne '' ) {
+      my $label       = $first_gene_name;
+      my $synonym     = $second_gene_name;
+      my $type        = 'gene';
+      my $version     = '1';
 
-    if ( !defined($xref_id) || $xref_id eq '' ) {
-      $xref_id = $self->add_xref(
-                                  { acc        => $dbass_gene_id,
-                                    version    => $version,
-                                    label      => $label,
-                                    desc       => undef,
-                                    source_id  => $source_id,
-                                    dbi        => $dbi,
-                                    species_id => $species_id,
-                                    info_type  => "DIRECT" } );
-    }
+      my $xref_id =
+        $self->get_xref( $dbass_gene_id, $source_id, $species_id, $dbi );
 
-    $self->add_direct_xref( $xref_id, $ensembl_id, $type, undef, $dbi );
+      if ( !defined($xref_id) || $xref_id eq '' ) {
+        $xref_id = $self->add_xref(
+                                   { acc        => $dbass_gene_id,
+                                     version    => $version,
+                                     label      => $label,
+                                     desc       => undef,
+                                     source_id  => $source_id,
+                                     dbi        => $dbi,
+                                     species_id => $species_id,
+                                     info_type  => "DIRECT" } );
+      }
 
-    if ( defined($synonym) ) {
-      $self->add_synonym( $xref_id, $synonym, $dbi );
+      if ( defined($synonym) ) {
+        $self->add_synonym( $xref_id, $synonym, $dbi );
+      }
+
+      $self->add_direct_xref( $xref_id, $ensembl_id, $type, undef, $dbi );
     }
 
   } ## end while ( defined( my $line...))

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -70,15 +70,15 @@ sub run {
   while ( defined( my $line = $file_io->getline() ) ) {
 
     # strip trailing whitespace
-    $line =~ s/\s*$//x;
+    $line =~ s{\s*\z}{}msx;
     # csv format can come with quoted columns, remove them. Note that this
     # assumes actual column values will never contain commas, which while
     # true at present brings into question why bother quoting them in the
     # first place.
-    $line =~ s/"//gx;
+    $line =~ s{"}{}gmsx;
 
     my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id, @split_overflow ) =
-      split( /,/x, $line );
+      split( qr{,}msx, $line );
 
     # If Ensembl ID is the last column and quotation marks have already
     # been stripped, split() will leave $ensembl_id undefined for unmapped
@@ -112,12 +112,12 @@ sub run {
                                     (.*)
                                     \s?\/\s?  # typically no ws here but just in case
                                     (.*)
-                                  }x ) ||
+                                  }msx ) ||
            ( $dbass_gene_name =~ m{
                                     (.*)
                                     \s?  # typically there IS a space before the ( here
                                     [(] (.*) [)]
-                                  }x ) ) {
+                                  }msx ) ) {
         $first_gene_name  = $1;
         $second_gene_name = $2;
       }


### PR DESCRIPTION
## Description

Fixes bugs observed (so far) in DBASSParser during the xref sprint, add additional checks, and delint the code to facilitate further refactoring. See ENSCORESW-2886.

## Use case

Part of the efforts to improve the xref pipeline. Moreover, one of the observed bugs actually prevents current versions of DBASS3 data from being fully parsed.

## Benefits

DBASS3 input can now be parsed properly. Some future-proofing. Code (hopefully) easier to maintain. Passes PerlCritic inspection at level 3 and the only complaints at level 2 are missing certain POD sections and $VERSION. Use a standardised rather than hand-rolled CSV parser, with potential for a performance increase if compiled rather than native-Perl version of the parser is used.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_
No.

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
N/A. However, I have run the parser itself on both current DBASS data and some intentionally malformed input, and it appears to work correctly.