### PR TITLE
XrefParser - XenopusJamboreeParser cleanup

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
@@ -53,13 +53,13 @@ sub run {
   }
 
   my $count = 0;
-  while ( $_ = $file_io->getline() ) {
-    chomp;
-    my ($acc, $label, $desc, $stable_id) = split /\t/;
-    # Remove some provenance information encoded in the description
-    $desc =~ s/\[.*\]//;
-    # Remove labels of type 5 of 14 from the description
-    $desc =~ s/ , [0-9]+ of [0-9]+//;
+  while ( my $line = $file_io->getline() ) {
+    chomp $line;
+    my ($acc, $label, $desc, $stable_id) = split /\t/, $line;
+
+    if(defined $desc){
+      $desc = $self->parse_description($desc);
+    }
 
     if($label eq "unnamed"){
       $label = $acc;
@@ -82,5 +82,25 @@ sub run {
 
   return 0;
 }
+
+
+=begin comment
+Regex handles lines in the following desc formats
+
+XB-GENE-940410	unnamed	Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14	ENSXETG00000007206
+XB-GENE-956173	hba4	alpha-T4 globin, Putative ortholog of hemoglobin alpha chain. [Source:Uniprot/SWISSPROT;Acc:P01922], 2 of 3	ENSXETG00000001141
+
+=end comment
+=cut
+sub parse_description{
+  my ($self, $desc) = @_;
+
+  # Remove some provenance information encoded in the description
+  $desc =~ s/\[.*\]//;
+  # Remove labels of type 5 of 14 from the description
+  $desc =~ s/ , [0-9]+ of [0-9]+//;
+  return $desc;
+}
+
 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
@@ -81,6 +81,7 @@ sub run {
     $count++;
   }
 
+  $input_file->eof or croak "Error parsing file $file: " . $input_file->error_diag();
   $file_io->close();
 
   print $count . " XenopusJamboreeParser xrefs succesfully parsed\n" if($verbose);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Refactored to:
 - Remove usage of $_
 - Move the parsing of description to a separate routine.

## Use case

XrefParser for source frog (xenopus_tropicalis)

## Benefits

Better code quality, readability.

## Possible Drawbacks

None.

## Testing

No unit testing. However, tested by running the xref_parser script.
