### PR TITLE
VGNC parser update

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -62,7 +62,27 @@ sub run {
     empty_is_undef => 1
   }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
 
-  $input_file->column_names( @{ $input_file->getline( $file_io ) } );
+  # header must contain these columns
+  my @required_columns = qw(
+    taxon_id
+    ensembl_gene_id
+    vgnc_id symbol
+    name
+    alias_symbol
+    prev_symbol
+  );
+
+  # get header columns
+  my @columns = @{ $input_file->getline( $file_io ) };
+
+  # die if some required_column is not in columns
+  foreach my $colname (@required_columns) {
+    if ( !grep { /$colname/xms } @columns ) {
+      croak "ERROR: Can't find required column \"$colname\" in VGNC file $file\n";
+    }
+  }
+
+  $input_file->column_names( @columns );
 
   while ( my $data = $input_file->getline_hr( $file_io ) ) {
 

--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -37,7 +37,7 @@ sub run {
 
 
   if ( (!defined $source_id) or (!defined $species_id) or (!defined $files) ) {
-    croak 'Need to pass source_id, species_id and files';
+    croak "Need to pass source_id, species_id and files as pairs";
   }
 
   my $file = shift @{$files};
@@ -47,7 +47,7 @@ sub run {
   my $file_io = $self->get_filehandle($file);
 
   if ( !defined $file_io ) {
-    croak "ERROR: Can't open VGNC file $file\n";
+    croak "Can't open VGNC file $file\n";
   }
 
   my $source_name = $self->get_source_name_for_source_id($source_id, $dbi);
@@ -79,7 +79,7 @@ sub run {
   # die if some required_column is not in columns
   foreach my $colname (@required_columns) {
     if ( !grep { /$colname/xms } @columns ) {
-      croak "ERROR: Can't find required column \"$colname\" in VGNC file $file\n";
+      croak "Can't find required column $colname in VGNC file $file\n";
     }
   }
 

--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -66,7 +66,8 @@ sub run {
   my @required_columns = qw(
     taxon_id
     ensembl_gene_id
-    vgnc_id symbol
+    vgnc_id
+    symbol
     name
     alias_symbol
     prev_symbol

--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -21,93 +21,88 @@ package XrefParser::VGNCParser;
 
 use strict;
 use warnings;
-use File::Basename;
 use Carp;
-use base qw( XrefParser::HGNCParser);
+use Text::CSV;
+
+use parent qw( XrefParser::HGNCParser );
 
 sub run {
-
   my ($self, $ref_arg) = @_;
+
   my $source_id    = $ref_arg->{source_id};
   my $species_id   = $ref_arg->{species_id};
   my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
+  my $verbose      = $ref_arg->{verbose} // 0;
+  my $dbi          = $ref_arg->{dbi} // $self->dbi;
 
-  if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
-    croak "Need to pass source_id, species_id, files and rel_file as pairs";
+
+  if ( (!defined $source_id) or (!defined $species_id) or (!defined $files) ) {
+    croak 'Need to pass source_id, species_id and files';
   }
-  $verbose |=0;
 
-  my $file = @{$files}[0];
+  my $file = shift @{$files};
 
   my $count = 0;
 
   my $file_io = $self->get_filehandle($file);
 
   if ( !defined $file_io ) {
-    print "ERROR: Can't open VGNC file $file\n";
-    return 1;
+    croak "ERROR: Can't open VGNC file $file\n";
   }
 
   my $source_name = $self->get_source_name_for_source_id($source_id, $dbi);
+
   # Create a hash of all valid taxon_ids for this species
   my %species2tax = $self->species_id2taxonomy($dbi);
   my @tax_ids = @{$species2tax{$species_id}};
   my %taxonomy2species_id = map{ $_=>$species_id } @tax_ids;
 
-  # Skip header
-  $file_io->getline();
+  my $input_file = Text::CSV->new({
+    sep_char       => "\t",
+    empty_is_undef => 1
+  }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
 
-  while ( $_ = $file_io->getline() ) {
-    chomp;
-    my @array = split /\t/x, $_;
+  $input_file->column_names( @{ $input_file->getline( $file_io ) } );
 
-    my $taxon_id         = $array[0];
-    my $acc              = $array[1];
-    my $symbol           = $array[2];
-    my $name             = $array[3];
-    my $id               = $array[20];
-    my $previous_symbols = $array[9];
-    my $synonyms         = $array[11];
+  while ( my $data = $input_file->getline_hr( $file_io ) ) {
 
-    $previous_symbols =~ s/"//g;
-    $synonyms =~ s/"//g;
+    # skip data for other species
+    next if ( !exists $taxonomy2species_id{$data->{'taxon_id'}} );
 
-    unless (exists ($taxonomy2species_id{$taxon_id})) { next; }
+    if ( $data->{'ensembl_gene_id'} ) {              # Ensembl direct xref
+      $self->add_to_direct_xrefs({
+        stable_id  => $data->{'ensembl_gene_id'},
+        type       => 'gene',
+        acc        => $data->{'vgnc_id'},
+        label      => $data->{'symbol'},
+        desc       => $data->{'name'},
+        dbi        => $dbi,
+        source_id  => $source_id,
+        species_id => $species_id
+      });
 
-    if ($id){              # Ensembl direct xref
-      $self->add_to_direct_xrefs({ stable_id  => $id,
-				   type       => 'gene',
-				   acc        => $acc,
-				   label      => $symbol,
-				   desc       => $name,
-                                   dbi        => $dbi,
-				   source_id  => $source_id,
-				   species_id => $species_id} );
-
-      $self->add_synonyms_for_hgnc( {source_id  => $source_id,
-                                     name       => $acc,
-                                     species_id => $species_id,
-                                     dbi        => $dbi,
-                                     dead       => $previous_symbols,
-                                     alias      => $synonyms});
+      $self->add_synonyms_for_hgnc({
+        source_id  => $source_id,
+        name       => $data->{'vgnc_id'},
+        species_id => $species_id,
+        dbi        => $dbi,
+        dead       => $data->{'alias_symbol'},
+        alias      => $data->{'prev_symbol'}
+      });
 
       $count++;
     }
+
   }
 
-
+  $input_file->eof or croak "Error parsing file $file: " . $input_file->error_diag();
   $file_io->close();
 
   if($verbose){
     print "Loaded a total of $count xrefs\n";
   }
+
   return 0; # successful
 }
 
-
 1;
-
-


### PR DESCRIPTION
## Description

Update to the VGNC parser during the first stage of the xref sprint. See ENSCORESW-2886.
Updates were as agreed... no $_ variable handling, croak on error, null instead of '', linting in general...
Parser now using Text::CSV.
UPDATED: ENSCORESW-2835 also dealt with.

## Testing

no unit tests.
Manually tested with chimpanzee.
UPDATED:
Results are consistent.

OUTDATED:
I have got 16101 xrefs with old code and 16105 with new...
Xtra Xrefs are 
'9556', 'VGNC:57780', '0', 'VIPR1', 'vasoactive intestinal peptide receptor 1', '146', '9598', 'DIRECT', '', NULL
'9564', 'VGNC:57781', '0', 'WDR82', 'WD repeat domain 82', '146', '9598', 'DIRECT', '', NULL
'9566', 'VGNC:57782', '0', 'WNT7A', 'Wnt family member 7A', '146', '9598', 'DIRECT', '', NULL
'9540', 'VGNC:57783', '0', 'UBXN7', 'UBX domain protein 7', '146', '9598', 'DIRECT', '', NULL



