### PR TITLE
Bugfix/delint MIM parser

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -255,7 +255,8 @@ sub run {
 
   if ($verbose) {
     print "$gene genemap and $phenotype phenotype MIM xrefs added\n"
-      . "added $syn_count synonyms (defined by MOVED TO)\n";
+      . "added $syn_count synonyms (defined by MOVED TO)\n"
+      . "$removed_count entries removed\n";
   }
 
   return 0;

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -194,12 +194,10 @@ sub run {
                              info_type  => "DEPENDENT" } );
         }
         elsif ( $type eq q{^} ) {
-          if ( $_ =~ m{
-                        [*]FIELD[*]\sTI\n
-                        \N{CARET}
-                        \d+\sMOVED\sTO\s
-                        (\d+)
-                    }msx ) {
+          if ( $long_desc =~ m{
+                                MOVED\sTO\s
+                                (\d+)
+                            }msx ) {
             if ( $1 eq $number ) { next; }
             $old_to_new{$number} = $1;
           }

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -81,7 +81,6 @@ sub run {
 
   my %old_to_new;
   my %removed;
-  my $source_id;
   my @sources;
 
   push @sources, $general_source_id;
@@ -113,13 +112,11 @@ sub run {
 
   while ( $_ = $mim_io->getline() ) {
     #get the MIM number
-    my $is_morbid = 0;
     my ( $number ) = ( $_ =~ m{
                                 [*]FIELD[*]\s+NO\n
                                 (\d+)
                             }msx );
     if ( defined $number ) {
-      $source_id = $gene_source_id;
 
       my ( $ti ) = ( $_ =~ m{
                               [*]FIELD[*]\sTI\n

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -64,7 +64,7 @@ sub run {
 
   print "sources are:- " . join( ", ", @sources ) . "\n" if ($verbose);
 
-  local $/ = "*RECORD*";
+  IO::Handle->input_record_separator('*RECORD*');
 
   my $mim_io = $self->get_filehandle($file);
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -23,9 +23,7 @@ use strict;
 use warnings;
 
 use Carp;
-use File::Basename;
 use Readonly;
-use POSIX qw(strftime);
 
 use parent qw( XrefParser::BaseParser );
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -96,7 +96,9 @@ sub run {
     croak 'Failed to retrieve MIM source IDs';
   }
 
-  print "sources are:- " . join( ", ", @sources ) . "\n" if ($verbose);
+  if ($verbose) {
+    print "sources are:- " . join( ", ", @sources ) . "\n";
+  }
 
   IO::Handle->input_record_separator('*RECORD*');
 
@@ -239,10 +241,10 @@ sub run {
     }
   }
 
-  print "$gene genemap and $phenotype phenotype MIM xrefs added\n"
-    if ($verbose);
-  print "added $syn_count synonyms (defined by MOVED TO)\n"
-    if ($verbose);
+  if ($verbose) {
+    print "$gene genemap and $phenotype phenotype MIM xrefs added\n"
+      . "added $syn_count synonyms (defined by MOVED TO)\n";
+  }
 
   return 0;
 } ## end sub run

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -24,6 +24,7 @@ use warnings;
 
 use Carp;
 use File::Basename;
+use Readonly;
 use POSIX qw(strftime);
 
 use parent qw( XrefParser::BaseParser );
@@ -60,6 +61,10 @@ use parent qw( XrefParser::BaseParser );
 # All the data relevant to the parser can be found in the TI field.
 
 
+# FIXME: this belongs in BaseParser
+Readonly my $ERR_SOURCE_ID_NOT_FOUND => -1;
+
+
 sub run {
 
   my ( $self, $ref_arg ) = @_;
@@ -92,7 +97,8 @@ sub run {
   my $morbid_source_id =
     $self->get_source_id_for_source_name( "MIM_MORBID", undef, $dbi );
   push @sources, $morbid_source_id;
-  if ( ( $gene_source_id == -1 ) || ( $morbid_source_id == -1 ) ) {
+  if ( ( $gene_source_id == $ERR_SOURCE_ID_NOT_FOUND )
+       || ( $morbid_source_id == $ERR_SOURCE_ID_NOT_FOUND ) ) {
     croak 'Failed to retrieve MIM source IDs';
   }
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -105,12 +105,12 @@ sub run {
           return 1;
         }
         $long_desc =~ s/^\s//;    # Remove white space at the start
-        my @fields = split( ";;", $long_desc );
+        my @fields = split( qr{;;}msx, $long_desc );
 
         # Use the first block of text as description
         my $label = $fields[0] . " [" . $type . $number . "]";
 
-        if ( $type eq "*" ) {     # gene only
+        if ( $type eq q{*} ) {     # gene only
           $gene++;
           $self->add_xref(
                            { acc        => $number,
@@ -122,9 +122,9 @@ sub run {
                              info_type  => "DEPENDENT" } );
         }
         elsif ( ( !defined $type ) or
-                ( $type eq "" )  or
-                ( $type eq "#" ) or
-                ( $type eq "%" ) )
+                ( $type eq q{} )  or
+                ( $type eq q{#} ) or
+                ( $type eq q{%} ) )
         {    #phenotype only
           $phenotype++;
           $self->add_xref(
@@ -136,7 +136,7 @@ sub run {
                              dbi        => $dbi,
                              info_type  => "DEPENDENT" } );
         }
-        elsif ( $type eq "+" ) {    # both
+        elsif ( $type eq q{+} ) {    # both
           $gene++;
           $phenotype++;
           $self->add_xref(
@@ -157,7 +157,7 @@ sub run {
                              dbi        => $dbi,
                              info_type  => "DEPENDENT" } );
         }
-        elsif ( $type eq "^" ) {
+        elsif ( $type eq q{^} ) {
           if (/[*]FIELD[*]\sTI\n\N{CARET}\d+ MOVED TO (\d+)/) {
             if ( $1 eq $number ) { next; }
             $old_to_new{$number} = $1;

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -25,7 +25,8 @@ use Carp;
 use POSIX qw(strftime);
 use File::Basename;
 
-use base qw( XrefParser::BaseParser );
+use parent qw( XrefParser::BaseParser );
+
 
 sub run {
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -127,8 +127,8 @@ sub run {
  RECORD:
   while ( my $input_record = $mim_io->getline() ) {
 
-    my ( $number, $ti ) = extract_number_and_ti( $input_record );
-    if ( ( ! defined $number ) || ( ! defined $ti ) ) {
+    my $ti = extract_ti( $input_record );
+    if ( ! defined $ti ) {
       next RECORD;
     }
 
@@ -142,10 +142,10 @@ sub run {
     $ti =~ s{\n}{ }gmsx;
 
     # Extract the 'type' and the whole description
-    my ( $type, $long_desc ) =
+    my ( $type, $number, $long_desc ) =
       ( $ti =~ m{
                   ([#%+*^]*)  # type of entry
-                  \d+         # number (should be the same as from NO)
+                  (\d+)       # accession number, same as in NO
                   \s+         # normally just one space
                   (.+)        # description of entry
               }msx );
@@ -235,14 +235,8 @@ sub run {
 } ## end sub run
 
 
-sub extract_number_and_ti {
+sub extract_ti {
   my ( $input_record ) = @_;
-
-  my ( $number )
-    = ( $input_record =~ m{
-                            [*]FIELD[*]\s+NO\n
-                            (\d+)
-                        }msx );
 
   my ( $ti )
     = ( $input_record =~ m{
@@ -255,7 +249,7 @@ sub extract_number_and_ti {
                             )
                         }msx );
 
-  return ( $number, $ti );
+  return $ti;
 }
 
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -30,21 +30,23 @@ use parent qw( XrefParser::BaseParser );
 
 sub run {
 
-  my ($self, $ref_arg) = @_;
-  my $general_source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
+  my ( $self, $ref_arg ) = @_;
+  my $general_source_id = $ref_arg->{source_id};
+  my $species_id        = $ref_arg->{species_id};
+  my $files             = $ref_arg->{files};
+  my $verbose           = $ref_arg->{verbose};
+  my $dbi               = $ref_arg->{dbi};
   $dbi = $self->dbi unless defined $dbi;
 
-  if((!defined $general_source_id) or (!defined $species_id) or (!defined $files) ){
+  if ( ( !defined $general_source_id ) or
+       ( !defined $species_id ) or
+       ( !defined $files ) )
+  {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |=0;
+  $verbose |= 0;
 
   my $file = @{$files}[0];
-
 
   my %old_to_new;
   my %removed;
@@ -53,12 +55,14 @@ sub run {
 
   push @sources, $general_source_id;
 
-  my $gene_source_id = $self->get_source_id_for_source_name("MIM_GENE", undef, $dbi);
+  my $gene_source_id =
+    $self->get_source_id_for_source_name( "MIM_GENE", undef, $dbi );
   push @sources, $gene_source_id;
-  my $morbid_source_id =  $self->get_source_id_for_source_name("MIM_MORBID", undef, $dbi);
+  my $morbid_source_id =
+    $self->get_source_id_for_source_name( "MIM_MORBID", undef, $dbi );
   push @sources, $morbid_source_id;
 
-  print "sources are:- ".join(", ",@sources)."\n" if($verbose);
+  print "sources are:- " . join( ", ", @sources ) . "\n" if ($verbose);
 
   local $/ = "*RECORD*";
 
@@ -69,9 +73,9 @@ sub run {
     return 1;    # 1 is an error
   }
 
-  my $gene = 0;
-  my $phenotype = 0;
-  my $removed_count =0;
+  my $gene          = 0;
+  my $phenotype     = 0;
+  my $removed_count = 0;
 
   $mim_io->getline();    # first record is empty with *RECORD* as the
                          # record seperator
@@ -79,13 +83,13 @@ sub run {
   while ( $_ = $mim_io->getline() ) {
     #get the MIM number
     my $number = 0;
-    my $label = undef;
+    my $label  = undef;
     my $long_desc;
     my $is_morbid = 0;
-    my $type =undef;
-    if(/\*FIELD\*\s+NO\n(\d+)/){
-      $number = $1;
-      $source_id = $gene_source_id;      
+    my $type      = undef;
+    if (/\*FIELD\*\s+NO\n(\d+)/) {
+      $number    = $1;
+      $source_id = $gene_source_id;
       # if(/\*FIELD\*\sTI\n([\^\#\%\+\*]*)\d+(.*)\n(.*)\n\*/){
       # 	$label =$2; # taken from description as acc is meaning less
       # 	$long_desc = $2;
@@ -94,90 +98,102 @@ sub run {
       # 	$label =~ s/\;\s[A-Z0-9]+$//; # strip gene name at end
       # 	$label = substr($label,0,35)." [".$type.$number."]";
 
-      if(/\*FIELD\*\sTI(.+)\*FIELD\*\sTX/s) { # grab the whole TI field
-	my $ti = $1;
-        $ti =~ s/\n//g; # Remove return carriages
-        # extract the 'type' and the whole description
-	$ti =~ /([\^\#\%\+\*]*)\d+(.+)/s;
-	my $type = $1;
-	my $long_desc = $2;
-        $long_desc =~ s/^\s//; # Remove white space at the start
-        my @fields = split(";;", $long_desc);
+      if (/\*FIELD\*\sTI(.+)\*FIELD\*\sTX/s) { # grab the whole TI field
+        my $ti = $1;
+        $ti =~ s/\n//g;   # Remove return carriages
+                          # extract the 'type' and the whole description
+        $ti =~ /([\^\#\%\+\*]*)\d+(.+)/s;
+        my $type      = $1;
+        my $long_desc = $2;
+        $long_desc =~ s/^\s//;    # Remove white space at the start
+        my @fields = split( ";;", $long_desc );
 
         # Use the first block of text as description
-	my $label = $fields[0] . " [" . $type . $number . "]";
+        my $label = $fields[0] . " [" . $type . $number . "]";
 
-	if($type eq "*"){ # gene only
-	  $gene++;
-	  $self->add_xref({ acc        => $number,
-			    label      => $label,
-			    desc       => $long_desc,
-			    source_id  => $gene_source_id,
-			    species_id => $species_id,
-                            dbi        => $dbi,
-			    info_type  => "DEPENDENT"} );
-	}
-	elsif((!defined $type) or ($type eq "") or ($type eq "#") or ($type eq "%")){ #phenotype only
-	  $phenotype++;
-	  $self->add_xref({ acc        => $number,
-			    label      => $label,
-			    desc       => $long_desc,
-			    source_id  => $morbid_source_id,
-			    species_id => $species_id,
-                            dbi        => $dbi,
-			    info_type  => "DEPENDENT"} );
-	}
-	elsif($type eq "+"){ # both
-	  $gene++;
- 	  $phenotype++;
-	  $self->add_xref({ acc        => $number,
-			    label      => $label,
-			    desc       => $long_desc,
-			    source_id  => $gene_source_id,
-			    species_id => $species_id,
-                            dbi        => $dbi,
-			    info_type  => "DEPENDENT"} );
+        if ( $type eq "*" ) {     # gene only
+          $gene++;
+          $self->add_xref(
+                           { acc        => $number,
+                             label      => $label,
+                             desc       => $long_desc,
+                             source_id  => $gene_source_id,
+                             species_id => $species_id,
+                             dbi        => $dbi,
+                             info_type  => "DEPENDENT" } );
+        }
+        elsif ( ( !defined $type ) or
+                ( $type eq "" )  or
+                ( $type eq "#" ) or
+                ( $type eq "%" ) )
+        {    #phenotype only
+          $phenotype++;
+          $self->add_xref(
+                           { acc        => $number,
+                             label      => $label,
+                             desc       => $long_desc,
+                             source_id  => $morbid_source_id,
+                             species_id => $species_id,
+                             dbi        => $dbi,
+                             info_type  => "DEPENDENT" } );
+        }
+        elsif ( $type eq "+" ) {    # both
+          $gene++;
+          $phenotype++;
+          $self->add_xref(
+                           { acc        => $number,
+                             label      => $label,
+                             desc       => $long_desc,
+                             source_id  => $gene_source_id,
+                             species_id => $species_id,
+                             dbi        => $dbi,
+                             info_type  => "DEPENDENT" } );
 
-	  $self->add_xref({ acc        => $number,
-			    label      => $label,
-			    desc       => $long_desc,
-			    source_id  => $morbid_source_id,
-			    species_id => $species_id,
-                            dbi        => $dbi,
-			    info_type  => "DEPENDENT"} );
-	}
-	elsif($type eq "^"){
-	  if(/\*FIELD\*\sTI\n[\^]\d+ MOVED TO (\d+)/){
-            if ($1 eq $number) { next; }
-	    $old_to_new{$number} = $1;
-	  }
-	  else{
-	    $removed{$number} = 1;
-	    $removed_count++;
-	  }
-	
-	}
-      }
-    }
-  }
+          $self->add_xref(
+                           { acc        => $number,
+                             label      => $label,
+                             desc       => $long_desc,
+                             source_id  => $morbid_source_id,
+                             species_id => $species_id,
+                             dbi        => $dbi,
+                             info_type  => "DEPENDENT" } );
+        }
+        elsif ( $type eq "^" ) {
+          if (/\*FIELD\*\sTI\n[\^]\d+ MOVED TO (\d+)/) {
+            if ( $1 eq $number ) { next; }
+            $old_to_new{$number} = $1;
+          }
+          else {
+            $removed{$number} = 1;
+            $removed_count++;
+          }
+
+        }
+      } ## end if (/\*FIELD\*\sTI(.+)\*FIELD\*\sTX/s)
+    } ## end if (/\*FIELD\*\s+NO\n(\d+)/)
+  } ## end while ( $_ = $mim_io->getline...)
 
   $mim_io->close();
 
-  my $syn_count =0;
-  foreach my $mim (keys %old_to_new){
-    my $old= $mim;
-    my $new= $old_to_new{$old};
-    while(defined($old_to_new{$new})){
+  my $syn_count = 0;
+  foreach my $mim ( keys %old_to_new ) {
+    my $old = $mim;
+    my $new = $old_to_new{$old};
+    while ( defined( $old_to_new{$new} ) ) {
       $new = $old_to_new{$new};
     }
-    if(!defined($removed{$new})){
-      $self->add_to_syn_for_mult_sources($new, \@sources, $old, $species_id, $dbi);
+    if ( !defined( $removed{$new} ) ) {
+      $self->add_to_syn_for_mult_sources( $new, \@sources, $old,
+                                          $species_id, $dbi );
       $syn_count++;
     }
   }
-  print "$gene genemap and $phenotype phenotype MIM xrefs added\n" if($verbose);
-  print "added $syn_count synonyms (defined by MOVED TO)\n" if($verbose);
-  return 0; #successful
-}
+  print "$gene genemap and $phenotype phenotype MIM xrefs added\n"
+    if ($verbose);
+  print "added $syn_count synonyms (defined by MOVED TO)\n"
+    if ($verbose);
+  return 0;    #successful
+} ## end sub run
+
 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -33,7 +33,7 @@ use parent qw( XrefParser::BaseParser );
 # OMIM Web site. They should be assigned to two different xref
 # sources: MIM_GENE and MIM_MORBID. MIM xrefs are linked to EntrezGene
 # entries so the parser does not match them to Ensembl; this will be
-# taken care of when EntrezGene antries are matched.
+# taken care of when EntrezGene entries are matched.
 #
 # OMIM records are multiline. Each record begins with a specific tag
 # line and consists of a number of fields. Each field starts with its

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -83,10 +83,7 @@ sub run {
   while ( $_ = $mim_io->getline() ) {
     #get the MIM number
     my $number = 0;
-    my $label  = undef;
-    my $long_desc;
     my $is_morbid = 0;
-    my $type      = undef;
     if (/[*]FIELD[*]\s+NO\n(\d+)/) {
       $number    = $1;
       $source_id = $gene_source_id;

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -21,9 +21,10 @@ package XrefParser::MIMParser;
 
 use strict;
 use warnings;
+
 use Carp;
-use POSIX qw(strftime);
 use File::Basename;
+use POSIX qw(strftime);
 
 use parent qw( XrefParser::BaseParser );
 
@@ -77,7 +78,7 @@ sub run {
   }
   $verbose |= 0;
 
-  my $file = @{$files}[0];
+  my $filename = @{$files}[0];
 
   my %old_to_new;
   my %removed;
@@ -99,11 +100,9 @@ sub run {
 
   IO::Handle->input_record_separator('*RECORD*');
 
-  my $mim_io = $self->get_filehandle($file);
-
+  my $mim_io = $self->get_filehandle($filename);
   if ( !defined $mim_io ) {
-    print {*STDERR} "ERROR: Could not open $file\n";
-    return 1;    # 1 is an error
+    croak "Failed to acquire a file handle for '${filename}'";
   }
 
   my $gene          = 0;
@@ -145,8 +144,7 @@ sub run {
                       (.+)        # description of entry
                   }msx );
         if ( !defined( $type ) ) {
-          print {*STDERR} 'Failed to extract record type and description from TI field';
-          return 1;
+          croak 'Failed to extract record type and description from TI field';
         }
 
         # Use the first block of text as description
@@ -217,8 +215,7 @@ sub run {
             $removed_count++;
           }
           else {
-            print {*STDERR} "Unsupported type of a '^' record: '${long_desc}'\n";
-            return 1;
+            croak "Unsupported type of a '^' record: '${long_desc}'\n";
           }
 
         }
@@ -241,11 +238,13 @@ sub run {
       $syn_count++;
     }
   }
+
   print "$gene genemap and $phenotype phenotype MIM xrefs added\n"
     if ($verbose);
   print "added $syn_count synonyms (defined by MOVED TO)\n"
     if ($verbose);
-  return 0;    #successful
+
+  return 0;
 } ## end sub run
 
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -69,7 +69,7 @@ sub run {
   my $mim_io = $self->get_filehandle($file);
 
   if ( !defined $mim_io ) {
-    print "ERROR: Could not open $file\n";
+    print {*STDERR} "ERROR: Could not open $file\n";
     return 1;    # 1 is an error
   }
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -97,11 +97,13 @@ sub run {
 
       if (/[*]FIELD[*]\sTI(.+)[*]FIELD[*]\sTX/s) { # grab the whole TI field
         my $ti = $1;
-        $ti =~ s/\n//g;   # Remove return carriages
-                          # extract the 'type' and the whole description
-        $ti =~ /([#%+*^]*)\d+(.+)/s;
-        my $type      = $1;
-        my $long_desc = $2;
+        $ti =~ s/\n//g;   # Remove line feeds
+        # Extract the 'type' and the whole description
+        my ($type, $long_desc) = ( $ti =~ /([#%+*^]*)\d+(.+)/s );
+        if ( !defined( $type ) ) {
+          print {*STDERR} 'Failed to extract record type and description from TI field';
+          return 1;
+        }
         $long_desc =~ s/^\s//;    # Remove white space at the start
         my @fields = split( ";;", $long_desc );
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -110,19 +110,21 @@ sub run {
   $mim_io->getline();    # first record is empty with *RECORD* as the
                          # record seperator
 
-  while ( $_ = $mim_io->getline() ) {
-    #get the MIM number
-    my ( $number ) = ( $_ =~ m{
-                                [*]FIELD[*]\s+NO\n
-                                (\d+)
-                            }msx );
+  while ( my $input_record = $mim_io->getline() ) {
+
+    my ( $number )
+      = ( $input_record =~ m{
+                              [*]FIELD[*]\s+NO\n
+                              (\d+)
+                          }msx );
     if ( defined $number ) {
 
-      my ( $ti ) = ( $_ =~ m{
-                              [*]FIELD[*]\sTI\n
-                              (.+)\n             # Grab the whole TI field
-                              [*]FIELD[*]\sTX
-                          }msx );
+      my ( $ti )
+        = ( $input_record =~ m{
+                                [*]FIELD[*]\sTI\n
+                                (.+)\n             # Grab the whole TI field
+                                [*]FIELD[*]\sTX
+                            }msx );
       if ( defined $ti ) {
         # Remove line breaks. FIXME: in some places it will result in words being concatenated
         $ti =~ s{\n}{}gmsx;

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -204,9 +204,15 @@ sub run {
               $old_to_new{$number} = $new_number;
             }
           }
-          else {
+          # Both leading and trailing whitespace has been removed
+          # so don't bother with another regex match, just compare.
+          elsif ( $long_desc eq 'REMOVED FROM DATABASE' ) {
             $removed{$number} = 1;
             $removed_count++;
+          }
+          else {
+            print {*STDERR} "Unsupported type of a '^' record: '${long_desc}'\n";
+            return 1;
           }
 
         }

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -91,6 +91,9 @@ sub run {
   my $morbid_source_id =
     $self->get_source_id_for_source_name( "MIM_MORBID", undef, $dbi );
   push @sources, $morbid_source_id;
+  if ( ( $gene_source_id == -1 ) || ( $morbid_source_id == -1 ) ) {
+    croak 'Failed to retrieve MIM source IDs';
+  }
 
   print "sources are:- " . join( ", ", @sources ) . "\n" if ($verbose);
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -129,7 +129,7 @@ sub run {
 
     my $ti = extract_ti( $input_record );
     if ( ! defined $ti ) {
-      next RECORD;
+      croak 'Failed to extract TI field from record';
     }
 
     # Remove line breaks, making sure we do not accidentally concatenate words

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -27,6 +27,37 @@ use File::Basename;
 
 use parent qw( XrefParser::BaseParser );
 
+# This parser will read xrefs from a record file downloaded from the
+# OMIM Web site. They should be assigned to two different xref
+# sources: MIM_GENE and MIM_MORBID. MIM xrefs are linked to EntrezGene
+# entries so the parser does not match them to Ensembl; this will be
+# taken care of when EntrezGene antries are matched.
+#
+# OMIM records are multiline. Each record begins with a specific tag
+# line and consists of a number of fields. Each field starts with its
+# own start-tag line (i.e. the data proper only appears after a
+# newline) and continues until the beginning of either the next field
+# in the same record, the next record, or the end-of-input tag. The
+# fields are expected to appear IN FIXED, SPECIFIC ORDER. The overall
+# structure looks as follows:
+#
+#   *RECORD*
+#   *FIELD* NO
+#   *FIELD* TI
+#   *FIELD* TX
+#   *FIELD* RF
+#   *FIELD* CD
+#   *FIELD* ED
+#   *RECORD*
+#   *FIELD* NO
+#   *FIELD* TI
+#   ...
+#   *FIELD* CD
+#   *FIELD* ED
+#   *THEEND*
+#
+# All the data relevant to the parser can be found in the TI field.
+
 
 sub run {
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -132,23 +132,7 @@ sub run {
       croak 'Failed to extract TI field from record';
     }
 
-    # Remove line breaks, making sure we do not accidentally concatenate words
-    $ti =~ s{
-              (?:
-                ;;\n
-              | \n;;
-              )
-          }{;;}gmsx;
-    $ti =~ s{\n}{ }gmsx;
-
-    # Extract the 'type' and the whole description
-    my ( $type, $number, $long_desc ) =
-      ( $ti =~ m{
-                  ([#%+*^]*)  # type of entry
-                  (\d+)       # accession number, same as in NO
-                  \s+         # normally just one space
-                  (.+)        # description of entry
-              }msx );
+    my ( $type, $number, $long_desc ) = parse_ti( $ti );
     if ( !defined( $type ) ) {
       croak 'Failed to extract record type and description from TI field';
     }
@@ -250,6 +234,30 @@ sub extract_ti {
                         }msx );
 
   return $ti;
+}
+
+
+sub parse_ti {
+  my ( $ti ) = @_;
+
+  # Remove line breaks, making sure we do not accidentally concatenate words
+  $ti =~ s{
+            (?:
+              ;;\n
+            | \n;;
+            )
+        }{;;}gmsx;
+  $ti =~ s{\n}{ }gmsx;
+
+  # Extract the 'type' and the whole description
+  my @captures = ( $ti =~ m{
+                             ([#%+*^]*)  # type of entry
+                             (\d+)       # accession number, same as in NO
+                             \s+         # normally just one space
+                             (.+)        # description of entry
+                         }msx );
+
+  return @captures;
 }
 
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -68,7 +68,6 @@ sub run {
   my $files             = $ref_arg->{files};
   my $verbose           = $ref_arg->{verbose};
   my $dbi               = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
 
   if ( ( !defined $general_source_id ) or
        ( !defined $species_id ) or
@@ -76,7 +75,8 @@ sub run {
   {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |= 0;
+  $verbose //= 0;
+  $dbi //= $self->dbi;
 
   my $filename = @{$files}[0];
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -134,8 +134,14 @@ sub run {
                                 )
                             }msx );
       if ( defined $ti ) {
-        # Remove line breaks. FIXME: in some places it will result in words being concatenated
-        $ti =~ s{\n}{}gmsx;
+        # Remove line breaks, making sure we do not accidentally concatenate words
+        $ti =~ s{
+                  (?:
+                    ;;\n
+                  | \n;;
+                  )
+              }{;;}gmsx;
+        $ti =~ s{\n}{ }gmsx;
 
         # Extract the 'type' and the whole description
         my ( $type, $long_desc ) =

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -69,8 +69,8 @@ sub run {
   my $general_source_id = $ref_arg->{source_id};
   my $species_id        = $ref_arg->{species_id};
   my $files             = $ref_arg->{files};
-  my $verbose           = $ref_arg->{verbose};
-  my $dbi               = $ref_arg->{dbi};
+  my $verbose           = $ref_arg->{verbose} // 0;
+  my $dbi               = $ref_arg->{dbi} // $self->dbi;
 
   if ( ( !defined $general_source_id ) or
        ( !defined $species_id ) or
@@ -78,8 +78,6 @@ sub run {
   {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose //= 0;
-  $dbi //= $self->dbi;
 
   my $filename = @{$files}[0];
 

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -87,22 +87,22 @@ sub run {
     my $long_desc;
     my $is_morbid = 0;
     my $type      = undef;
-    if (/\*FIELD\*\s+NO\n(\d+)/) {
+    if (/[*]FIELD[*]\s+NO\n(\d+)/) {
       $number    = $1;
       $source_id = $gene_source_id;
-      # if(/\*FIELD\*\sTI\n([\^\#\%\+\*]*)\d+(.*)\n(.*)\n\*/){
+      # if(/[*]FIELD[*]\sTI\n([#%+*^]*)\d+(.*)\n(.*)\n[*]/){
       # 	$label =$2; # taken from description as acc is meaning less
       # 	$long_desc = $2;
       # 	$long_desc .= $3 if defined $3;
       # 	$type = $1;
-      # 	$label =~ s/\;\s[A-Z0-9]+$//; # strip gene name at end
+      # 	$label =~ s/;\s[A-Z0-9]+$//; # strip gene name at end
       # 	$label = substr($label,0,35)." [".$type.$number."]";
 
-      if (/\*FIELD\*\sTI(.+)\*FIELD\*\sTX/s) { # grab the whole TI field
+      if (/[*]FIELD[*]\sTI(.+)[*]FIELD[*]\sTX/s) { # grab the whole TI field
         my $ti = $1;
         $ti =~ s/\n//g;   # Remove return carriages
                           # extract the 'type' and the whole description
-        $ti =~ /([\^\#\%\+\*]*)\d+(.+)/s;
+        $ti =~ /([#%+*^]*)\d+(.+)/s;
         my $type      = $1;
         my $long_desc = $2;
         $long_desc =~ s/^\s//;    # Remove white space at the start
@@ -159,7 +159,7 @@ sub run {
                              info_type  => "DEPENDENT" } );
         }
         elsif ( $type eq "^" ) {
-          if (/\*FIELD\*\sTI\n[\^]\d+ MOVED TO (\d+)/) {
+          if (/[*]FIELD[*]\sTI\n\N{CARET}\d+ MOVED TO (\d+)/) {
             if ( $1 eq $number ) { next; }
             $old_to_new{$number} = $1;
           }
@@ -169,8 +169,8 @@ sub run {
           }
 
         }
-      } ## end if (/\*FIELD\*\sTI(.+)\*FIELD\*\sTX/s)
-    } ## end if (/\*FIELD\*\s+NO\n(\d+)/)
+      } ## end if (/[*]FIELD[*]\sTI(.+)[*]FIELD[*]\sTX/s)
+    } ## end if (/[*]FIELD[*]\s+NO\n(\d+)/)
   } ## end while ( $_ = $mim_io->getline...)
 
   $mim_io->close();


### PR DESCRIPTION
## Description

Fixes bugs observed (so far) in MIMParser during the xref sprint, add additional checks, and delint the code to facilitate further refactoring. See ENSCORESW-2880.

## Use case

Part of the efforts to improve the xref pipeline.

## Benefits

Multi-line descriptions no longer end up with words adjacent to line breaks erronenously concatenated. Improved performance thanks to reduced amount of redundant text processing. Partly generalised xref-insertion code. Some future-proofing. Code (hopefully) easier to maintain. PerlCritic at level 3 complains only about still rather high complexity of run() and the only additional complaints introduced by level 2 are missing certain POD sections and $VERSION.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_
No.

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
N/A. However, I have run the parser itself on current MIM data set and it appears to work correctly.