### PR TITLE
Feature/jgi

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/JGI_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/JGI_Parser.pm
@@ -79,7 +79,7 @@ sub run {
   my $file_io = $self->get_filehandle($file);
 
   if ( !defined $file_io ) {
-    croak "ERROR: Could not open $file\n";
+    confess "Could not open $file\n";
   }
 
   IO::Handle->input_record_separator( "\n>");
@@ -104,11 +104,11 @@ sub run {
     } elsif ($source_name=~m/cint_aniseed_.*v1/) {
       # header format is  >ci0100146277, we want this 
       # JGI 1.0
-
+      ($accession = $header) =~s/\w{6}//;
     } else {
-      croak "WARNING : The source-name specified ($source_name) in the populate_metatable.sql file is\n" .
-            "WARNING : not matching the different cases specified in JGI_Parser.pm - please\n".
-            "WARNING : edit the parser \n" ;
+      confess "The source-name specified ($source_name) in the populate_metatable.sql file is\n" .
+              "not matching the different cases specified in JGI_Parser.pm - please\n".
+              "edit the parser \n" ;
     }
 
     # make sequence into one long string

--- a/misc-scripts/xref_mapping/XrefParser/JGI_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/JGI_Parser.pm
@@ -24,7 +24,7 @@ use warnings;
 use Carp;
 use File::Basename;
 
-use base qw( XrefParser::BaseParser );
+use parent qw( XrefParser::BaseParser );
 
 # JGI protein file with gene predictons  - FASTA FORMAT
 #
@@ -82,7 +82,7 @@ sub run {
     croak "ERROR: Could not open $file\n";
   }
 
-  $file_io->input_record_separator( "\n>");
+  IO::Handle->input_record_separator( "\n>");
   
   while ( my $record = $file_io->getline() ) {
 
@@ -127,7 +127,7 @@ sub run {
   }
 
   $file_io->close();
-  $file_io->input_record_separator( "\n");
+  IO::Handle->input_record_separator( "\n");
   print scalar(@xrefs) . " JGI_ xrefs succesfully parsed\n" if($verbose);
 
   $self->upload_xref_object_graphs(\@xrefs, $dbi);

--- a/misc-scripts/xref_mapping/XrefParser/JGI_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/JGI_Parser.pm
@@ -26,10 +26,10 @@ use File::Basename;
 
 use base qw( XrefParser::BaseParser );
 
-# JGI protein file with gene predictons  - FASTA FORMAT  
+# JGI protein file with gene predictons  - FASTA FORMAT
 #
 #
-# This is the parser that provides most functionality, subclasses 
+# This is the parser that provides most functionality, subclasses
 # (JGI_ProteinParser) just set sequence type)
 
 sub run {
@@ -38,7 +38,6 @@ sub run {
   my $source_id    = $ref_arg->{source_id};
   my $species_id   = $ref_arg->{species_id};
   my $files        = $ref_arg->{files};
-  my $release_file = $ref_arg->{rel_file};
   my $verbose      = $ref_arg->{verbose};
   my $dbi          = $ref_arg->{dbi};
   $dbi = $self->dbi unless defined $dbi;
@@ -76,11 +75,7 @@ sub run {
   #  DEDDDL*
   #
 
-
-
   my @xrefs;
-
-  local $/ = "\n>";
 
   my $file_io = $self->get_filehandle($file);
 
@@ -89,76 +84,64 @@ sub run {
     return 1;    # 1 is an error
   }
 
-  while ( $_ = $file_io->getline() ) {
+  $file_io->input_record_separator( "\n>");
+  
+  while ( my $record = $file_io->getline() ) {
 
-    next if (/^File:/);   # skip header
+    next if ($record =~ /^File:/);   # skip header
 
     my $xref;
 
-    my ($header, $sequence) = $_ =~ /^>?(.+?)\n([^>]*)/s or warn("Can't parse FASTA entry: $_\n"); 
+    my ($header, $sequence) = $record =~ /^>?(.+?)\n([^>]*)/s or warn("Can't parse FASTA entry: $record\n");
 
-      my @attr = split/\|/, $header ; 
-      my $acession = $header ;
-    
+    my @attr = split/\|/, $header;
+    my $accession = $header;
+
     # split header in different ways according to source name : 
-    my ( $version,$label  ) ;      
-    if ($source_name=~m/cint_jgi_v1/) { 
+    my ( $version,$label );
+    if ($source_name=~m/cint_jgi_v1/) {
       # header format is  >ci0100146277
       # we want  146277
-      ($acession = $header)  =~s/\w{6}//;  
-      $version = "JGI 1.0" ;  
-    
-    } elsif ($source_name=~m/cint_aniseed_.*v1/) { 
+      ($accession = $header)  =~s/\w{6}//;
+      $version = "JGI 1.0" ;
+
+    } elsif ($source_name=~m/cint_aniseed_.*v1/) {
       # header format is  >ci0100146277, we want this 
-      $version = "JGI 1.0" ;  
+      $version = "JGI 1.0" ;
 
-
-    } elsif ($source_name=~m/cint_jgi_v2/) { 
-      $acession = $attr[2]  ; 
-      $version = "JGI 2.0" ;  
-      $label = $attr[3] ; 
-    } elsif ($source_name=~m/cint_aniseed_.*v2/) { 
+    } elsif ($source_name=~m/cint_jgi_v2/) {
+      $accession = $attr[2]  ;
+      $version = "JGI 2.0" ;
+      $label = $attr[3] ;
+    } elsif ($source_name=~m/cint_aniseed_.*v2/) {
       my $aniseed_prefix = "ci0200" ; 
-      $acession = $aniseed_prefix . $attr[2]  ; 
+      $accession = $aniseed_prefix . $attr[2]  ; 
       $version = "JGI 2.0" ;  
-
-    }else { 
+    } else {
       print STDERR "WARNING : The source-name specified ($source_name) in the populate_metatable.sql file is\n" .
-        "WARNING : not matching the differnt cases specified in JGI_Parser.pm - plese\n".
-          "WARNING : edit the parser \n" ; 
+        "WARNING : not matching the different cases specified in JGI_Parser.pm - please\n".
+          "WARNING : edit the parser \n" ;
       return 1;
-    } 
-    #print "ACCESSION $acession\n" ;  
+    }
 
     # make sequence into one long string
     $sequence =~ s/\n//g;
 
     # build the xref object and store it
-    $xref->{ACCESSION}     = $acession;
-    $xref->{LABEL}         = $acession;
+    $xref->{ACCESSION}     = $accession;
+    $xref->{LABEL}         = $accession;
     $xref->{SEQUENCE}      = $sequence;
     $xref->{SOURCE_ID}     = $source_id;
     $xref->{SPECIES_ID}    = $species_id;
     $xref->{SEQUENCE_TYPE} = $self->get_sequence_type();
     $xref->{STATUS}        = 'experimental';
 
-    # pull cg_name from peptide files as well and create dependent xrefs
-#    if ($self->get_sequence_type() =~ /peptide/) {
-#      my ($cg_name) = $cg =~ /cg_name=(.*)/;
-#      my %dep;
-#      $dep{SOURCE_NAME} = 'JGI__Gene';
-#      $dep{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-#      $dep{SOURCE_ID} = $celera_gene_source_id;
-#      $dep{ACCESSION} = $cg_name;
-#      push @{$xref->{DEPENDENT_XREFS}}, \%dep; # array of hashrefs
-#    }
-#
     push @xrefs, $xref;
 
   }
 
   $file_io->close();
-
+  $file_io->input_record_separator( "\n");
   print scalar(@xrefs) . " JGI_ xrefs succesfully parsed\n" if($verbose);
 
   $self->upload_xref_object_graphs(\@xrefs, $dbi);

--- a/misc-scripts/xref_mapping/XrefParser/JGI_ProteinParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/JGI_ProteinParser.pm
@@ -22,7 +22,7 @@ package XrefParser::JGI_ProteinParser;
 
 use strict;
 
-use base qw( XrefParser::JGI_Parser );
+use parent qw( XrefParser::JGI_Parser );
 
 # See JGI_Parser for details
 


### PR DESCRIPTION
## Description

Clean up of JGI parser, removing redundant version 2 content, and creating fatal errors instead of warnings

## Use case

Ciona xrefs

## Benefits

Errors will not be hidden, code is a little simpler

## Possible Drawbacks

Errors will not be hidden.

## Testing

No unit tests. Produces the same output statistics