### PR TITLE
Xref parser mgiparser

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/MGIParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGIParser.pm
@@ -1,3 +1,4 @@
+
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
@@ -29,14 +30,17 @@ use parent qw(XrefParser::BaseParser);
 
 sub run {
 
-  my ($self, $ref_arg) = @_;
-  my $source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose} || 0;
-  my $dbi          = $ref_arg->{dbi} || $self->dbi;
+  my ( $self, $ref_arg ) = @_;
+  my $source_id  = $ref_arg->{source_id};
+  my $species_id = $ref_arg->{species_id};
+  my $files      = $ref_arg->{files};
+  my $verbose    = $ref_arg->{verbose} // 0;
+  my $dbi        = $ref_arg->{dbi} // $self->dbi;
 
-  if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
+  if ( ( !defined $source_id )
+    or ( !defined $species_id )
+    or ( !defined $files ) )
+  {
     croak "Need to pass source_id, species_id and files as pairs";
   }
 
@@ -44,54 +48,62 @@ sub run {
 
   my $file_io = $self->get_filehandle($file);
   if ( !defined $file_io ) {
-    print STDERR "ERROR: Could not open $file\n";
-    return 1;    # 1 is an error
+    croak "Could not open $file\n";
   }
 
   #synonyms
-  my $sql = "insert ignore into synonym (xref_id, synonym) values (?, ?)";
-  my $add_syn_sth = $dbi->prepare($sql);    
-  my $syn_hash = $self->get_ext_synonyms("MGI", $dbi);
+  my $syn_hash = $self->get_ext_synonyms( "MGI", $dbi );
 
   #Init input file
-  my $input_file = Text::CSV->new({
-                                    sep_char           => "\t",
-				    empty_is_undef     => 1,
-                                    strict => 1,
-                                    allow_loose_quotes => 1,
-				   }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
+  my $input_file = Text::CSV->new(
+    {
+      sep_char           => "\t",
+      empty_is_undef     => 1,
+      strict             => 1,
+      allow_loose_quotes => 1,
+    }
+  ) or croak "Cannot use file $file: " . Text::CSV->error_diag();
 
-  # init headers
-  # MGI:1915941	1110028C15Rik	RIKEN cDNA 1110028C15 gene	33.61	1	ENSMUSG00000026004	ENSMUST00000042389 ENSMUST00000068168 ENSMUST00000113987 ENSMUST00000129190 ENSMUST00000132960	ENSMUSP00000036975 ENSMUSP00000063843 ENSMUSP00000109620 ENSMUSP00000118603
-  $input_file->column_names([qw(accession symbol name position chrom ens_gene_stableid)] ); #ignore last two columns EnsemblTranscriptIDs and EnsemblProteinIDs
-  my $count = 0;
+# init headers
+# MGI:1915941	1110028C15Rik	RIKEN cDNA 1110028C15 gene	33.61	1	ENSMUSG00000026004	ENSMUST00000042389 ENSMUST00000068168 ENSMUST00000113987 ENSMUST00000129190 ENSMUST00000132960	ENSMUSP00000036975 ENSMUSP00000063843 ENSMUSP00000109620 ENSMUSP00000118603
+  $input_file->column_names( [qw(accession symbol name position chrom ens_gene_stableid)] );    #ignore last two columns EnsemblTranscriptIDs and EnsemblProteinIDs
+  my $count     = 0;
   my $syn_count = 0;
-  while ( my $data = $input_file->getline_hr( $file_io ) ){
+  while ( my $data = $input_file->getline_hr($file_io) ) {
 
-      my $acc = $data->{'accession'};
-      my $ensid = $data->{'ens_gene_stableid'};
-      my $xref_id = $self->add_xref({ acc        => $acc,
-				      version    => 0,
-				      label      => $data->{'symbol'},
-				      desc       => $data->{'name'},
-				      source_id  => $source_id,
-                                      dbi        => $dbi,
-				      species_id => $species_id,
-				      info_type  => "DIRECT"} );
-
-      $self->add_direct_xref( $xref_id, $ensid, "Gene", '', $dbi);
-      if(defined($syn_hash->{$acc})){
-	foreach my $syn (@{$syn_hash->{$acc}}){
-	  $add_syn_sth->execute($xref_id, $syn);
-	}
+    my $acc     = $data->{'accession'};
+    my $ensid   = $data->{'ens_gene_stableid'};
+    my $xref_id = $self->add_xref(
+      {
+        acc        => $acc,
+        version    => 0,
+        label      => $data->{'symbol'},
+        desc       => $data->{'name'},
+        source_id  => $source_id,
+        dbi        => $dbi,
+        species_id => $species_id,
+        info_type  => "DIRECT"
       }
-      $count++;
+    );
+
+    $self->add_direct_xref( $xref_id, $ensid, "Gene", undef, $dbi );
+    if ( defined( $syn_hash->{$acc} ) ) {
+      foreach my $syn ( @{ $syn_hash->{$acc} } ) {
+        $self->add_to_syn( $acc, $source_id, $syn, $species_id, $dbi );
+        $syn_count++;
+      }
+    }
+    $count++;
 
   }
-  $input_file->eof or croak "Error parsing file $file: " . $input_file->error_diag();
+  $input_file->eof
+    or croak "Error parsing file $file: " . $input_file->error_diag();
   $file_io->close();
 
-  print "$count direct MGI xrefs added\n";
+  if ($verbose) {
+    print "$count direct MGI xrefs added\n";
+    print $syn_count. " synonyms added\n";
+  }
   return 0;
 
 }

--- a/misc-scripts/xref_mapping/XrefParser/MGIParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGIParser.pm
@@ -58,7 +58,6 @@ sub run {
                                     sep_char           => "\t",
 				    empty_is_undef     => 1,
                                     strict => 1,
-                                    auto_diag => 1,
                                     allow_loose_quotes => 1,
 				   }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
 

--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -23,9 +23,8 @@ use strict;
 use warnings;
 use Carp;
 use File::Basename;
-use Text::CSV;
 
-use parent qw( XrefParser::BaseParser );
+use base qw( XrefParser::BaseParser );
 
 use Bio::EnsEMBL::DBSQL::DBAdaptor;
 
@@ -36,14 +35,16 @@ sub run {
   my $source_id    = $ref_arg->{source_id};
   my $species_id   = $ref_arg->{species_id};
   my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose} || 0;
-  my $dbi          = $ref_arg->{dbi} || $self->dbi;
+  my $verbose      = $ref_arg->{verbose};
+  my $dbi          = $ref_arg->{dbi};
+  $dbi = $self->dbi unless defined $dbi;
 
   if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
     croak "Need to pass source_id, species_id and files as pairs";
   }
+  $verbose |=0;
 
-  my $file = shift @{$files};
+  my $file = @{$files}[0];
 
   my $mgi_io = $self->get_filehandle($file);
 
@@ -56,41 +57,53 @@ sub run {
   my $syn_count = 0;
   my %acc_to_xref;
 
-  my $input_file = Text::CSV->new({
-                                    sep_char           => "\t",
-				    empty_is_undef     => 1,
-                                    strict => 1,
-                                    auto_diag => 1,
-                                    allow_loose_quotes => 1,
-				   }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
 
-  # skip header
-  $input_file->getline($mgi_io);
-  $input_file->column_names([qw(accession chromosome position start end strand label status marker marker_type feature_type synonym_field)] );
-  while ( my $data = $input_file->getline_hr( $mgi_io ) ) {
-        my $accession = $data->{'accession'};
-        my $marker = defined($data->{'marker'}) ? $data->{'marker'} : undef;
+    my $header = $mgi_io->getline(); #discard header line
+
+    chomp($header);
+    # crude emergency check for potentially altered file format.
+    my $header_template = qq(MGI Accession ID\tChr\tcM Position\tgenome coordinate start\tgenome coordinate end\tstrand\tMarker Symbol\tStatus\tMarker Name\tMarker Type\tFeature Type\tMarker Synonyms (pipe-separated));
+    if ($header ne $header_template) {die "File header has altered from format parser expects. Check MGI "};
+      
+    while ( my $line = $mgi_io->getline() ) {
+
+        chomp($line);
+        my ($accession, $chromosome, $position, $start, $end, $strand,$label, 
+            $status, $marker, $marker_type, $feature_type, $synonym_field) = split(/\t/,$line);
+            
+        $position =~ s/^\s+// if ($position);
+
+        my @synonyms = split(/\|/,$synonym_field) if ($synonym_field);
+        
+	
+        my $desc;
+	if ($marker) {
+	    $desc = $marker;
+	}
+        
         $acc_to_xref{$accession} = $self->add_xref({ acc        => $accession,
-                                                     label      => $data->{'label'},
-                                                     desc       => $marker,
-                                                     source_id  => $source_id,
-                                                     species_id => $species_id,
-                                                     dbi        => $dbi,
-                                                     info_type  => "MISC"} );
-        if($verbose and !$marker){
+    	                           		             label      => $label,
+    					                             desc       => $desc,
+    					                             source_id  => $source_id,
+    					                             species_id => $species_id,
+                                                                     dbi        => $dbi,
+    					                             info_type  => "MISC"} );
+        if($verbose and !$desc){
     	   print "$accession has no description\n";
         }
         $xref_count++;
-        my @synonyms;
+            
         if(defined($acc_to_xref{$accession})){
-            @synonyms = split(/\|/,$data->{'synonym_field'}) if ($data->{'synonym_field'});
+           
             foreach my $syn (@synonyms) {
                 $self->add_synonym($acc_to_xref{$accession}, $syn, $dbi);
                 $syn_count++;
             }
+            
         }
+        
     }
-    $mgi_io->eof or croak "Error parsing file $file: " . $input_file->error_diag();
+      
     $mgi_io->close();
       
     print $xref_count." MGI Description Xrefs added\n" if($verbose);

--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -70,38 +70,27 @@ sub run {
         chomp($line);
         my ($accession, $chromosome, $position, $start, $end, $strand,$label, 
             $status, $marker, $marker_type, $feature_type, $synonym_field) = split(/\t/,$line);
-            
-        $position =~ s/^\s+// if ($position);
-
-        my @synonyms = split(/\|/,$synonym_field) if ($synonym_field);
-        
 	
-        my $desc;
-	if ($marker) {
-	    $desc = $marker;
-	}
-        
         $acc_to_xref{$accession} = $self->add_xref({ acc        => $accession,
     	                           		             label      => $label,
-    					                             desc       => $desc,
+                                                                     desc       => defined($marker) ? $marker : undef,
     					                             source_id  => $source_id,
     					                             species_id => $species_id,
                                                                      dbi        => $dbi,
     					                             info_type  => "MISC"} );
-        if($verbose and !$desc){
+        if($verbose and !$marker){
     	   print "$accession has no description\n";
         }
         $xref_count++;
-            
+
+        my @synonyms;
         if(defined($acc_to_xref{$accession})){
-           
+            @synonyms = split(/\|/,$synonym_field) if ($synonym_field);
             foreach my $syn (@synonyms) {
                 $self->add_synonym($acc_to_xref{$accession}, $syn, $dbi);
                 $syn_count++;
             }
-            
         }
-        
     }
       
     $mgi_io->close();


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Updates:

Used Text:CSV for parsing the file
Removed loading for mgi description from xref table
Updated to get the description from the same file being read (MRK_ENSEMBL.rpt)

## Use case

XrefParser for source MGI (MGI_official) for mouse (mus musculus)

## Benefits

Code quality improvements, removed dependency on previous loaded mgi description from xref table

## Possible Drawbacks

None

## Testing

No until test. However, have tested it by running the xref_parser script and checked the _xref database for row counts.


