### PR TITLE
Bugfix/delint Mim2Gene parser

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -172,6 +172,7 @@ sub run {
                                        'source_id'      => $mim_gene_source_id,
                                        'species_id'     => $species_id,
                                        'linkage'        => $entrez_source_id,
+                                       'dbi'            => $dbi,
                                      });
           }
         }
@@ -186,6 +187,7 @@ sub run {
                                        'source_id'      => $mim_morbid_source_id,
                                        'species_id'     => $species_id,
                                        'linkage'        => $entrez_source_id,
+                                       'dbi'            => $dbi,
                                      });
           }
         }
@@ -201,6 +203,7 @@ sub run {
                                        'source_id'      => $mim_morbid_source_id,
                                        'species_id'     => $species_id,
                                        'linkage'        => $entrez_source_id,
+                                       'dbi'            => $dbi,
                                      });
           }
         }
@@ -215,6 +218,7 @@ sub run {
                                        'source_id'      => $mim_gene_source_id,
                                        'species_id'     => $species_id,
                                        'linkage'        => $entrez_source_id,
+                                       'dbi'            => $dbi,
                                      });
           }
         }

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -27,6 +27,7 @@ use warnings;
 
 use Carp;
 use File::Basename;
+use List::Util;
 use POSIX qw(strftime);
 use Readonly;
 use Text::CSV;
@@ -211,8 +212,29 @@ sub run {
 sub is_header_file_valid {
   my ( $header ) = @_;
 
-  # FIXME: actually validate the header
-  return 1;
+  my @fields_ok;
+
+  # FIXME: we should probably use a loop + a lookup list for the code
+  # below to avoid using hard-coded field indices
+
+  # This one will likely have a hash prepended to it
+  my $mim_number_ok = ( $header->[0] =~ m{ \A [#]? \s* MIM[ ]Number }msx );
+  push @fields_ok, $mim_number_ok;
+
+  my $mim_type_ok = ( $header->[1] =~ m{ MIM[ ]Entry[ ]Type }msx );
+  push @fields_ok, $mim_type_ok;
+
+  my $entrez_id_ok = ( $header->[2] =~ m{ Entrez[ ]Gene[ ]ID }msx );
+  push @fields_ok, $entrez_id_ok;
+
+  my $hgnc_id_ok = ( $header->[3] =~ m{ Approved[ ]Gene[ ]Symbol }msx );
+  push @fields_ok, $hgnc_id_ok;
+
+  my $ensembl_id_ok = ( $header->[4] =~ m{ Ensembl[ ]Gene[ ]ID }msx );
+  push @fields_ok, $ensembl_id_ok;
+
+  # All fields must be in order
+  return List::Util::all { $_ } @fields_ok;
 }
 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -139,7 +139,9 @@ sub run {
       next RECORD;
     }
 
-    if ( $type eq "gene" || $type eq 'gene/phenotype' ) {
+    if ( $type eq "gene"
+         || $type eq 'gene/phenotype'
+         || $type eq 'predominantly phenotypes' ) {
       if ( defined( $mim_gene{$omim_id} ) ) {
         foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
           foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -99,8 +99,6 @@ sub run {
                   'all_entries'                          => 0,
                   'dependent_on_entrez'                  => 0,
                   'direct_ensembl'                       => 0,
-                  'expected_in_mim_gene_but_not_there'   => 0,
-                  'expected_in_mim_morbid_but_not_there' => 0,
                   'missed_master'                        => 0,
                   'missed_omim'                          => 0,
                 );
@@ -164,69 +162,32 @@ sub run {
       croak "Unknown type $type";
     }
 
-    if ( $type eq 'phenotype' ) {
-      # The only type with a different source order
-
-      if ( defined( $mim_morbid{$omim_id} ) ) {
-        foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
-          $self->process_xref_entry({
-            'mim_id'           => $mim_id,
-            'mim_source_id'    => $mim_morbid_source_id,
-            'species_id'       => $species_id,
-            'ensembl_id'       => $ensembl_id,
-            'entrez_xrefs'     => $entrez{$entrez_id},
-            'entrez_source_id' => $entrez_source_id,
-            'dbi'              => $dbi,
-            'counters'         => \%counters
-          });
-        }
-      }
-      else {
-        $counters{'expected_in_mim_morbid_but_not_there'}++;
-        foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
-          $self->process_xref_entry({
-            'mim_id'           => $mim_id,
-            'mim_source_id'    => $mim_gene_source_id,
-            'species_id'       => $species_id,
-            'ensembl_id'       => $ensembl_id,
-            'entrez_xrefs'     => $entrez{$entrez_id},
-            'entrez_source_id' => $entrez_source_id,
-            'dbi'              => $dbi,
-            'counters'         => \%counters
-          });
-        }
-      }
+    # With all the checks taken care of, insert the mappings. We check
+    # both MIM_GENE and MIM_MORBID every time because some MIM entries
+    # can appear in both.
+    foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+      $self->process_xref_entry({
+        'mim_id'           => $mim_id,
+        'mim_source_id'    => $mim_gene_source_id,
+        'species_id'       => $species_id,
+        'ensembl_id'       => $ensembl_id,
+        'entrez_xrefs'     => $entrez{$entrez_id},
+        'entrez_source_id' => $entrez_source_id,
+        'dbi'              => $dbi,
+        'counters'         => \%counters
+      });
     }
-    else {
-      if ( defined( $mim_gene{$omim_id} ) ) {
-        foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
-          $self->process_xref_entry({
-            'mim_id'           => $mim_id,
-            'mim_source_id'    => $mim_gene_source_id,
-            'species_id'       => $species_id,
-            'ensembl_id'       => $ensembl_id,
-            'entrez_xrefs'     => $entrez{$entrez_id},
-            'entrez_source_id' => $entrez_source_id,
-            'dbi'              => $dbi,
-            'counters'         => \%counters
-          });
-        }
-      }
-      else {
-        $counters{'expected_in_mim_gene_but_not_there'}++;
-        foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
-          $self->process_xref_entry({
-            'mim_id'           => $mim_id,
-            'mim_source_id'    => $mim_morbid_source_id,
-            'species_id'       => $species_id,
-            'ensembl_id'       => $ensembl_id,
-            'entrez_xrefs'     => $entrez{$entrez_id},
-            'entrez_source_id' => $entrez_source_id,
-            'dbi'              => $dbi,
-            'counters'         => \%counters
-          });
-        }
-      }
+    foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+      $self->process_xref_entry({
+        'mim_id'           => $mim_id,
+        'mim_source_id'    => $mim_morbid_source_id,
+        'species_id'       => $species_id,
+        'ensembl_id'       => $ensembl_id,
+        'entrez_xrefs'     => $entrez{$entrez_id},
+        'entrez_source_id' => $entrez_source_id,
+        'dbi'              => $dbi,
+        'counters'         => \%counters
+      });
     }
 
   } ## end record loop
@@ -239,12 +200,7 @@ sub run {
       . "\t" . $counters{'missed_omim'} . " had missing OMIM entries,\n"
       . "\t" . $counters{'direct_ensembl'} . " were direct gene xrefs,\n"
       . "\t" . $counters{'dependent_on_entrez'} . " were dependent EntrezGene xrefs,\n"
-      . "\t" . $counters{'missed_master'} . " had missing master entries.\n"
-      . "\t * * *\n"
-      . "\t" . $counters{'expected_in_mim_gene_but_not_there'}
-      . " were expected in MIM_GENE but were not found there,\n"
-      . "\t" . $counters{'expected_in_mim_morbid_but_not_there'}
-      . " were expected in MIM_MORBID but were not found there.\n";
+      . "\t" . $counters{'missed_master'} . " had missing master entries.\n";
   }
 
   return 0;

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -25,8 +25,13 @@ use warnings;
 use Carp;
 use File::Basename;
 use POSIX qw(strftime);
+use Readonly;
 
 use parent qw( XrefParser::BaseParser );
+
+
+# FIXME: this belongs in BaseParser
+Readonly my $ERR_SOURCE_ID_NOT_FOUND => -1;
 
 
 sub run {
@@ -56,7 +61,11 @@ sub run {
 
   my $entrez_source_id =
     $self->get_source_id_for_source_name( 'EntrezGene', undef, $dbi );
+  if ( $entrez_source_id == $ERR_SOURCE_ID_NOT_FOUND ) {
+    croak 'Failed to retrieve EntrezGene source ID';
+  }
 
+  # FIXME: should we abort if any of these comes back empty?
   my (%mim_gene) =
     %{ $self->get_valid_codes( "MIM_GENE", $species_id, $dbi ) };
   my (%mim_morbid) =

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -172,118 +172,62 @@ sub run {
 
       if ( defined( $mim_morbid{$omim_id} ) ) {
         foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
-          if ( $ensembl_id ) {
-            $counters{'direct_ensembl'}++;
-            $self->add_to_direct_xrefs({
-                                        'stable_id'  => $ensembl_id,
-                                        'type'       => 'gene',
-                                        'acc'        => $mim_id,
-                                        'source_id'  => $mim_morbid_source_id,
-                                        'species_id' => $species_id,
-                                        'dbi'        => $dbi,
-                                      });
-          }
-          else {
-            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            $counters{'dependent_on_entrez'}++;
-            $self->add_dependent_xref({
-                                         'master_xref_id' => $ent_id,
-                                         'acc'            => $mim_id,
-                                         'source_id'      => $mim_morbid_source_id,
-                                         'species_id'     => $species_id,
-                                         'linkage'        => $entrez_source_id,
-                                         'dbi'            => $dbi,
-                                       });
-            }
-          }
+          $self->process_xref_entry({
+            'mim_id'           => $mim_id,
+            'mim_source_id'    => $mim_morbid_source_id,
+            'species_id'       => $species_id,
+            'ensembl_id'       => $ensembl_id,
+            'entrez_xrefs'     => $entrez{$entrez_id},
+            'entrez_source_id' => $entrez_source_id,
+            'dbi'              => $dbi,
+            'counters'         => \%counters
+          });
         }
       }
       else {
         $counters{'expected_in_mim_morbid_but_not_there'}++;
         foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
-          if ( $ensembl_id ) {
-            $counters{'direct_ensembl'}++;
-            $self->add_to_direct_xrefs({
-                                        'stable_id'  => $ensembl_id,
-                                        'type'       => 'gene',
-                                        'acc'        => $mim_id,
-                                        'source_id'  => $mim_gene_source_id,
-                                        'species_id' => $species_id,
-                                        'dbi'        => $dbi,
-                                      });
-          }
-          else {
-            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-              $counters{'dependent_on_entrez'}++;
-              $self->add_dependent_xref({
-                                         'master_xref_id' => $ent_id,
-                                         'acc'            => $mim_id,
-                                         'source_id'      => $mim_gene_source_id,
-                                         'species_id'     => $species_id,
-                                         'linkage'        => $entrez_source_id,
-                                         'dbi'            => $dbi,
-                                       });
-            }
-          }
+          $self->process_xref_entry({
+            'mim_id'           => $mim_id,
+            'mim_source_id'    => $mim_gene_source_id,
+            'species_id'       => $species_id,
+            'ensembl_id'       => $ensembl_id,
+            'entrez_xrefs'     => $entrez{$entrez_id},
+            'entrez_source_id' => $entrez_source_id,
+            'dbi'              => $dbi,
+            'counters'         => \%counters
+          });
         }
       }
     }
     else {
       if ( defined( $mim_gene{$omim_id} ) ) {
         foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
-          if ( $ensembl_id ) {
-            $counters{'direct_ensembl'}++;
-            $self->add_to_direct_xrefs({
-                                        'stable_id'  => $ensembl_id,
-                                        'type'       => 'gene',
-                                        'acc'        => $mim_id,
-                                        'source_id'  => $mim_gene_source_id,
-                                        'species_id' => $species_id,
-                                        'dbi'        => $dbi,
-                                      });
-          }
-          else {
-            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-              $counters{'dependent_on_entrez'}++;
-              $self->add_dependent_xref({
-                                         'master_xref_id' => $ent_id,
-                                         'acc'            => $mim_id,
-                                         'source_id'      => $mim_gene_source_id,
-                                         'species_id'     => $species_id,
-                                         'linkage'        => $entrez_source_id,
-                                         'dbi'            => $dbi,
-                                       });
-            }
-          }
+          $self->process_xref_entry({
+            'mim_id'           => $mim_id,
+            'mim_source_id'    => $mim_gene_source_id,
+            'species_id'       => $species_id,
+            'ensembl_id'       => $ensembl_id,
+            'entrez_xrefs'     => $entrez{$entrez_id},
+            'entrez_source_id' => $entrez_source_id,
+            'dbi'              => $dbi,
+            'counters'         => \%counters
+          });
         }
       }
       else {
         $counters{'expected_in_mim_gene_but_not_there'}++;
         foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
-          if ( $ensembl_id ) {
-            $counters{'direct_ensembl'}++;
-            $self->add_to_direct_xrefs({
-                                        'stable_id'  => $ensembl_id,
-                                        'type'       => 'gene',
-                                        'acc'        => $mim_id,
-                                        'source_id'  => $mim_morbid_source_id,
-                                        'species_id' => $species_id,
-                                        'dbi'        => $dbi,
-                                      });
-          }
-          else {
-            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-              $counters{'dependent_on_entrez'}++;
-              $self->add_dependent_xref({
-                                         'master_xref_id' => $ent_id,
-                                         'acc'            => $mim_id,
-                                         'source_id'      => $mim_morbid_source_id,
-                                         'species_id'     => $species_id,
-                                         'linkage'        => $entrez_source_id,
-                                         'dbi'            => $dbi,
-                                       });
-            }
-          }
+          $self->process_xref_entry({
+            'mim_id'           => $mim_id,
+            'mim_source_id'    => $mim_morbid_source_id,
+            'species_id'       => $species_id,
+            'ensembl_id'       => $ensembl_id,
+            'entrez_xrefs'     => $entrez{$entrez_id},
+            'entrez_source_id' => $entrez_source_id,
+            'dbi'              => $dbi,
+            'counters'         => \%counters
+          });
         }
       }
     }
@@ -311,6 +255,7 @@ sub run {
 
 
 =head2 is_file_header_valid
+
   Arg [1]    : String file header line
   Example    : if (!is_file_header_valid($header_line)) {
                  croak 'Bad header';
@@ -353,5 +298,54 @@ sub is_header_file_valid {
   # All fields must be in order
   return List::Util::all { $_ } @fields_ok;
 }
+
+
+=head2 process_xref_entry
+
+  Arg [1]    : HashRef list of named arguments: FIXME
+  Example    : $self->process_xref_entry({...});
+  Description: Wrapper around the most frequently repeated bit of
+               run(): if $ensembl_id is defined insert a direct MIM
+               xref, otherwise loop over the list of matching
+               EntrezGene xrefs and insert dependent MIM xrefs.
+               In either case increment the correct counter.
+  Return type: none
+  Exceptions : none
+  Caller     : internal
+  Status     : Stable
+
+=cut
+
+sub process_xref_entry {
+  my ( $self, $arg_ref ) = @_;
+
+  if ( $arg_ref->{'ensembl_id'} ) {
+    $arg_ref->{'counters'}->{'direct_ensembl'}++;
+    $self->add_to_direct_xrefs({
+      'stable_id'  => $arg_ref->{'ensembl_id'},
+      'type'       => 'gene',
+      'acc'        => $arg_ref->{'mim_id'},
+      'source_id'  => $arg_ref->{'mim_source_id'},
+      'species_id' => $arg_ref->{'species_id'},
+      'dbi'        => $arg_ref->{'dbi'},
+    });
+  }
+  else {
+    foreach my $ent_id ( @{ $arg_ref->{'entrez_xrefs'} } ) {
+      $arg_ref->{'counters'}->{'dependent_on_entrez'}++;
+      $self->add_dependent_xref({
+        'master_xref_id' => $ent_id,
+        'acc'            => $arg_ref->{'mim_id'},
+        'source_id'      => $arg_ref->{'mim_source_id'},
+        'species_id'     => $arg_ref->{'species_id'},
+        'linkage'        => $arg_ref->{'entrez_source_id'},
+        'dbi'            => $arg_ref->{'dbi'},
+      });
+    }
+  }
+
+  return;
+}
+
 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -37,7 +37,6 @@ sub run {
   my $files             = $ref_arg->{files};
   my $verbose           = $ref_arg->{verbose};
   my $dbi               = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
 
   if ( ( !defined $general_source_id ) or
        ( !defined $species_id ) or
@@ -45,7 +44,8 @@ sub run {
   {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |= 0;
+  $dbi //= $self->dbi;
+  $verbose //= 0;
 
   my $filename = @{$files}[0];
 

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -145,6 +145,8 @@ sub run {
   } ## end while ( $_ = $eg_io->getline...)
   $add_dependent_xref_sth->finish;
 
+  $eg_io->close();
+
   if ( $verbose ) {
     print $missed_entrez . " EntrezGene entries could not be found.\n"
       . $missed_omim . " Omim entries could not be found.\n"

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -230,8 +230,8 @@ sub run {
         # The only type with a different source order
 
         if ( defined( $mim_morbid{$omim_id} ) ) {
-          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+          foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
               $self->add_dependent_xref({
                                          'master_xref_id' => $ent_id,
                                          'acc'            => $mim_id,
@@ -245,8 +245,8 @@ sub run {
         }
         else {
           $counters{'expected_in_mim_morbid_but_not_there'}++;
-          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+          foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
               $self->add_dependent_xref({
                                          'master_xref_id' => $ent_id,
                                          'acc'            => $mim_id,
@@ -261,8 +261,8 @@ sub run {
       }
       else {
         if ( defined( $mim_gene{$omim_id} ) ) {
-          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+          foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
               $self->add_dependent_xref({
                                          'master_xref_id' => $ent_id,
                                          'acc'            => $mim_id,
@@ -276,8 +276,8 @@ sub run {
         }
         else {
           $counters{'expected_in_mim_gene_but_not_there'}++;
-          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+          foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+            foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
               $self->add_dependent_xref({
                                          'master_xref_id' => $ent_id,
                                          'acc'            => $mim_id,

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -159,7 +159,8 @@ sub run {
          && ( $type ne 'gene/phenotype' )
          && ( $type ne 'predominantly phenotypes' )
          && ( $type ne 'phenotype' ) ) {
-      croak "Unknown type $type";
+      croak "Unknown type $type for MIM Number '${omim_acc}' "
+        . "(${filename}:" . $csv->record_number() . ")";
     }
 
     # With all the checks taken care of, insert the mappings. We check

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -128,14 +128,14 @@ sub run {
     }
 
     # Do not modify the contents of @{$line}, only the output - hence the /r.
-    my ( $omim_id, $type, $entrez_id, $hgnc_symbol, $ensembl_id )
+    my ( $omim_acc, $type, $entrez_id, $hgnc_symbol, $ensembl_id )
       = map { s{\s+\z}{}rmsx } @{ $line };
 
     $counters{'all_entries'}++;
 
     # No point in doing anything if we have no matching MIM xref...
-    if ( ( !defined $mim_gene{$omim_id} ) and
-         ( !defined $mim_morbid{$omim_id} ) )
+    if ( ( !defined $mim_gene{$omim_acc} ) &&
+         ( !defined $mim_morbid{$omim_acc} ) )
     {
       $counters{'missed_omim'}++;
       next RECORD;
@@ -165,9 +165,9 @@ sub run {
     # With all the checks taken care of, insert the mappings. We check
     # both MIM_GENE and MIM_MORBID every time because some MIM entries
     # can appear in both.
-    foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+    foreach my $mim_xref_id ( @{ $mim_gene{$omim_acc} } ) {
       $self->process_xref_entry({
-        'mim_id'           => $omim_id,
+        'mim_acc'          => $omim_acc,
         'mim_source_id'    => $mim_gene_source_id,
         'species_id'       => $species_id,
         'ensembl_id'       => $ensembl_id,
@@ -177,9 +177,9 @@ sub run {
         'counters'         => \%counters
       });
     }
-    foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+    foreach my $mim_xref_id ( @{ $mim_morbid{$omim_acc} } ) {
       $self->process_xref_entry({
-        'mim_id'           => $omim_id,
+        'mim_acc'          => $omim_acc,
         'mim_source_id'    => $mim_morbid_source_id,
         'species_id'       => $species_id,
         'ensembl_id'       => $ensembl_id,
@@ -274,7 +274,7 @@ sub process_xref_entry {
     $self->add_to_direct_xrefs({
       'stable_id'  => $arg_ref->{'ensembl_id'},
       'type'       => 'gene',
-      'acc'        => $arg_ref->{'mim_id'},
+      'acc'        => $arg_ref->{'mim_acc'},
       'source_id'  => $arg_ref->{'mim_source_id'},
       'species_id' => $arg_ref->{'species_id'},
       'dbi'        => $arg_ref->{'dbi'},
@@ -285,7 +285,7 @@ sub process_xref_entry {
       $arg_ref->{'counters'}->{'dependent_on_entrez'}++;
       $self->add_dependent_xref({
         'master_xref_id' => $ent_id,
-        'acc'            => $arg_ref->{'mim_id'},
+        'acc'            => $arg_ref->{'mim_acc'},
         'source_id'      => $arg_ref->{'mim_source_id'},
         'species_id'     => $arg_ref->{'species_id'},
         'linkage'        => $arg_ref->{'entrez_source_id'},

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -167,7 +167,7 @@ sub run {
     # can appear in both.
     foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
       $self->process_xref_entry({
-        'mim_id'           => $mim_id,
+        'mim_id'           => $omim_id,
         'mim_source_id'    => $mim_gene_source_id,
         'species_id'       => $species_id,
         'ensembl_id'       => $ensembl_id,
@@ -179,7 +179,7 @@ sub run {
     }
     foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
       $self->process_xref_entry({
-        'mim_id'           => $mim_id,
+        'mim_id'           => $omim_id,
         'mim_source_id'    => $mim_morbid_source_id,
         'species_id'       => $species_id,
         'ensembl_id'       => $ensembl_id,

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -25,7 +25,7 @@ use Carp;
 use POSIX qw(strftime);
 use File::Basename;
 
-use base qw( XrefParser::BaseParser );
+use parent qw( XrefParser::BaseParser );
 
 sub run {
 

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -276,26 +276,23 @@ sub is_header_file_valid {
 
   my @fields_ok;
 
-  # FIXME: we should probably use a loop + a lookup list for the code
-  # below to avoid using hard-coded field indices
+  Readonly my @field_patterns
+    => (
+        qr{ \A [#]? \s* MIM[ ]Number }msx,
+        qr{ MIM[ ]Entry[ ]Type }msx,
+        qr{ Entrez[ ]Gene[ ]ID }msx,
+        qr{ Approved[ ]Gene[ ]Symbol }msx,
+        qr{ Ensembl[ ]Gene[ ]ID }msx,
+      );
 
-  # This one will likely have a hash prepended to it
-  my $mim_number_ok = ( $header->[0] =~ m{ \A [#]? \s* MIM[ ]Number }msx );
-  push @fields_ok, $mim_number_ok;
+  my $header_field;
+  foreach my $pattern (@field_patterns) {
+    $header_field = shift @{ $header };
+    # Make sure we run the regex match in scalar context
+    push @fields_ok, scalar ( $header_field =~ m{ $pattern }msx );
+  }
 
-  my $mim_type_ok = ( $header->[1] =~ m{ MIM[ ]Entry[ ]Type }msx );
-  push @fields_ok, $mim_type_ok;
-
-  my $entrez_id_ok = ( $header->[2] =~ m{ Entrez[ ]Gene[ ]ID }msx );
-  push @fields_ok, $entrez_id_ok;
-
-  my $hgnc_id_ok = ( $header->[3] =~ m{ Approved[ ]Gene[ ]Symbol }msx );
-  push @fields_ok, $hgnc_id_ok;
-
-  my $ensembl_id_ok = ( $header->[4] =~ m{ Ensembl[ ]Gene[ ]ID }msx );
-  push @fields_ok, $ensembl_id_ok;
-
-  # All fields must be in order
+  # All fields must have matched
   return List::Util::all { $_ } @fields_ok;
 }
 

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -136,9 +136,11 @@ sub run {
   } ## end while ( $_ = $eg_io->getline...)
   $add_dependent_xref_sth->finish;
 
-  print $missed_entrez. " EntrezGene entries could not be found.\n";
-  print $missed_omim. " Omim entries could not be found.\n";
-  print $diff_type. " had different types out of $count Entries.\n";
+  if ( $verbose ) {
+    print $missed_entrez . " EntrezGene entries could not be found.\n"
+      . $missed_omim . " Omim entries could not be found.\n"
+      . $diff_type . " had different types out of $count Entries.\n";
+  }
 
   return 0;
 } ## end sub run

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -47,8 +47,8 @@ sub run {
   my $general_source_id = $ref_arg->{source_id};
   my $species_id        = $ref_arg->{species_id};
   my $files             = $ref_arg->{files};
-  my $verbose           = $ref_arg->{verbose};
-  my $dbi               = $ref_arg->{dbi};
+  my $verbose           = $ref_arg->{verbose} // 0;
+  my $dbi               = $ref_arg->{dbi} // $self->dbi;
 
   if ( ( !defined $general_source_id ) or
        ( !defined $species_id ) or
@@ -56,9 +56,6 @@ sub run {
   {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $dbi //= $self->dbi;
-  $verbose //= 0;
-
 
   my $csv = Text::CSV->new({
                             sep_char => "\t",

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -21,27 +21,31 @@ package XrefParser::Mim2GeneParser;
 
 use strict;
 use warnings;
+
 use Carp;
-use POSIX qw(strftime);
 use File::Basename;
+use POSIX qw(strftime);
 
 use parent qw( XrefParser::BaseParser );
 
+
 sub run {
 
- my ($self, $ref_arg) = @_;
-  my $general_source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
+  my ( $self, $ref_arg ) = @_;
+  my $general_source_id = $ref_arg->{source_id};
+  my $species_id        = $ref_arg->{species_id};
+  my $files             = $ref_arg->{files};
+  my $verbose           = $ref_arg->{verbose};
+  my $dbi               = $ref_arg->{dbi};
   $dbi = $self->dbi unless defined $dbi;
 
-  if((!defined $general_source_id) or (!defined $species_id) or (!defined $files) ){
+  if ( ( !defined $general_source_id ) or
+       ( !defined $species_id ) or
+       ( !defined $files ) )
+  {
     croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |=0;
-
+  $verbose |= 0;
 
   my $file = @{$files}[0];
 
@@ -52,87 +56,94 @@ sub run {
   }
 
   my $entrez_source_id =
-      $self->get_source_id_for_source_name(
-        'EntrezGene', undef, $dbi);
+    $self->get_source_id_for_source_name( 'EntrezGene', undef, $dbi );
 
-  my (%mim_gene)   = %{$self->get_valid_codes("MIM_GENE",$species_id, $dbi)};
-  my (%mim_morbid) = %{$self->get_valid_codes("MIM_MORBID",$species_id, $dbi)};
-  my (%entrez)     = %{$self->get_valid_codes("EntrezGene",$species_id, $dbi)};
- 
-  my $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)");
+  my (%mim_gene) =
+    %{ $self->get_valid_codes( "MIM_GENE", $species_id, $dbi ) };
+  my (%mim_morbid) =
+    %{ $self->get_valid_codes( "MIM_MORBID", $species_id, $dbi ) };
+  my (%entrez) =
+    %{ $self->get_valid_codes( "EntrezGene", $species_id, $dbi ) };
+
+  my $add_dependent_xref_sth = $dbi->prepare(
+"INSERT INTO dependent_xref (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)"
+  );
 
   my $missed_entrez = 0;
   my $missed_omim   = 0;
   my $diff_type     = 0;
   my $count;
 
-  $eg_io->getline(); # do not need header
+  $eg_io->getline();    # do not need header
   while ( $_ = $eg_io->getline() ) {
     $count++;
     chomp;
-    my ($omim_id, $entrez_id, $type, $other) = split;
+    my ( $omim_id, $entrez_id, $type, $other ) = split;
 
-    if(!defined($entrez{$entrez_id})){
+    if ( !defined( $entrez{$entrez_id} ) ) {
       $missed_entrez++;
       next;
     }
-    
-    if((!defined $mim_gene{$omim_id} ) and (!defined $mim_morbid{$omim_id} ) ){
+
+    if ( ( !defined $mim_gene{$omim_id} ) and
+         ( !defined $mim_morbid{$omim_id} ) )
+    {
       $missed_omim++;
       next;
     }
 
-    if($type eq "gene" || $type eq 'gene/phenotype'){
-      if(defined($mim_gene{$omim_id})){
-	foreach my $ent_id (@{$entrez{$entrez_id}}){
-	  foreach my $mim_id (@{$mim_gene{$omim_id}}){
-	    $add_dependent_xref_sth->execute($ent_id, $mim_id);
-	  }
-	}
-	# $add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_gene{$omim_id});
+    if ( $type eq "gene" || $type eq 'gene/phenotype' ) {
+      if ( defined( $mim_gene{$omim_id} ) ) {
+        foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
+          foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+            $add_dependent_xref_sth->execute( $ent_id, $mim_id );
+          }
+        }
+#        $add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_gene{$omim_id});
       }
-      else{
-	$diff_type++;
-	foreach my $ent_id (@{$entrez{$entrez_id}}){
-	  foreach my $mim_id (@{$mim_morbid{$omim_id}}){
-	    $add_dependent_xref_sth->execute($ent_id, $mim_id);
-	  }
-	}
-	# $add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_morbid{$omim_id});	
-      }
-    }
-    elsif($type eq "phenotype"){
-      if(defined($mim_morbid{$omim_id})){
-	foreach my $ent_id (@{$entrez{$entrez_id}}){
-	  foreach my $mim_id (@{$mim_morbid{$omim_id}}){
-	    $add_dependent_xref_sth->execute($ent_id, $mim_id);
-	  }
-	}
-	#	$add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_morbid{$omim_id});
-      }
-      else{
-	$diff_type++;
-	foreach my $ent_id (@{$entrez{$entrez_id}}){
-	  foreach my $mim_id (@{$mim_gene{$omim_id}}){
-	    $add_dependent_xref_sth->execute($ent_id, $mim_id);
-	  }
-	}
-	#	$add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_gene{$omim_id});	
+      else {
+        $diff_type++;
+        foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
+          foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+            $add_dependent_xref_sth->execute( $ent_id, $mim_id );
+          }
+        }
+#        $add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_morbid{$omim_id});
       }
     }
-    else{
+    elsif ( $type eq "phenotype" ) {
+      if ( defined( $mim_morbid{$omim_id} ) ) {
+        foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
+          foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+            $add_dependent_xref_sth->execute( $ent_id, $mim_id );
+          }
+        }
+#        $add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_morbid{$omim_id});
+      }
+      else {
+        $diff_type++;
+        foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
+          foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+            $add_dependent_xref_sth->execute( $ent_id, $mim_id );
+          }
+        }
+#        $add_dependent_xref_sth->execute($entrez{$entrez_id}, $mim_gene{$omim_id});
+      }
+    }
+    else {
       print "WARNING unknown type $type\n";
       next;
     }
 
-  }
+  } ## end while ( $_ = $eg_io->getline...)
   $add_dependent_xref_sth->finish;
 
-  print $missed_entrez." EntrezGene entries could not be found.\n";
-  print $missed_omim." Omim entries could not be found.\n";
-  print $diff_type." had different types out of $count Entries.\n";
+  print $missed_entrez. " EntrezGene entries could not be found.\n";
+  print $missed_omim. " Omim entries could not be found.\n";
+  print $diff_type. " had different types out of $count Entries.\n";
 
   return 0;
-}
+} ## end sub run
+
 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -273,10 +273,9 @@ sub process_xref_entry {
                             $arg_ref->{'ensembl_id'},
                             'gene',
                             undef,
-                            $arg_ref->{'dbi'}
+                            $arg_ref->{'dbi'},
+                            1
                          );
-    # FIXME: update info_type in the xref from DEPENDENT to DIRECT as
-    # well, unless MIMParser starts inserting something else.
   }
   else {
     foreach my $ent_id ( @{ $arg_ref->{'entrez_xrefs'} } ) {
@@ -285,7 +284,8 @@ sub process_xref_entry {
                                          $arg_ref->{'mim_source_id'},
                                          $ent_id,
                                          $arg_ref->{'entrez_source_id'},
-                                         $arg_ref->{'dbi'}
+                                         $arg_ref->{'dbi'},
+                                         1
                                       );
     }
   }

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -146,40 +146,26 @@ sub run {
       next RECORD;
     }
 
+    # An unknown type might indicate the change of input format,
+    # therefore make sure the user notices it. That said, do not
+    # bother we do not have an xref this entry would operate on anyway
+    # - which is why we only check this AFTER the missed_omim block
+    # above.
+    if ( ( $type ne 'gene')
+         && ( $type ne 'gene/phenotype' )
+         && ( $type ne 'predominantly phenotypes' )
+         && ( $type ne 'phenotype' ) ) {
+      croak "Unknown type $type";
+    }
+
     if ( $ensembl_id ) {
       $counters{'direct_ensembl'}++;
 
       # FIXME: *lots* of duplication wrt dependent xrefs
-      if ( $type eq "gene"
-           || $type eq 'gene/phenotype'
-           || $type eq 'predominantly phenotypes' ) {
-        if ( defined( $mim_gene{$omim_id} ) ) {
-          foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
-            $self->add_to_direct_xrefs({
-                                        'stable_id'  => $ensembl_id,
-                                        'type'       => 'gene',
-                                        'acc'        => $mim_id,
-                                        'source_id'  => $mim_gene_source_id,
-                                        'species_id' => $species_id,
-                                        'dbi'        => $dbi,
-                                      });
-          }
-        }
-        else {
-          $counters{'expected_in_mim_gene_but_not_there'}++;
-          foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
-            $self->add_to_direct_xrefs({
-                                        'stable_id'  => $ensembl_id,
-                                        'type'       => 'gene',
-                                        'acc'        => $mim_id,
-                                        'source_id'  => $mim_morbid_source_id,
-                                        'species_id' => $species_id,
-                                        'dbi'        => $dbi,
-                                      });
-          }
-        }
-      }
-      elsif ( $type eq "phenotype" ) {
+
+      if ( $type eq 'phenotype' ) {
+        # The only type with a different source order
+
         if ( defined( $mim_morbid{$omim_id} ) ) {
           foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
             $self->add_to_direct_xrefs({
@@ -207,7 +193,31 @@ sub run {
         }
       }
       else {
-        croak "Unknown type $type";
+        if ( defined( $mim_gene{$omim_id} ) ) {
+          foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+            $self->add_to_direct_xrefs({
+                                        'stable_id'  => $ensembl_id,
+                                        'type'       => 'gene',
+                                        'acc'        => $mim_id,
+                                        'source_id'  => $mim_gene_source_id,
+                                        'species_id' => $species_id,
+                                        'dbi'        => $dbi,
+                                      });
+          }
+        }
+        else {
+          $counters{'expected_in_mim_gene_but_not_there'}++;
+          foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+            $self->add_to_direct_xrefs({
+                                        'stable_id'  => $ensembl_id,
+                                        'type'       => 'gene',
+                                        'acc'        => $mim_id,
+                                        'source_id'  => $mim_morbid_source_id,
+                                        'species_id' => $species_id,
+                                        'dbi'        => $dbi,
+                                      });
+          }
+        }
       }
 
     }
@@ -215,40 +225,10 @@ sub run {
       $counters{'dependent_on_entrez'}++;
 
       # FIXME: *lots* of duplication wrt direct xrefs
-      if ( $type eq "gene"
-           || $type eq 'gene/phenotype'
-           || $type eq 'predominantly phenotypes' ) {
-        if ( defined( $mim_gene{$omim_id} ) ) {
-          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
-              $self->add_dependent_xref({
-                                         'master_xref_id' => $ent_id,
-                                         'acc'            => $mim_id,
-                                         'source_id'      => $mim_gene_source_id,
-                                         'species_id'     => $species_id,
-                                         'linkage'        => $entrez_source_id,
-                                         'dbi'            => $dbi,
-                                       });
-            }
-          }
-        }
-        else {
-          $counters{'expected_in_mim_gene_but_not_there'}++;
-          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
-            foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
-              $self->add_dependent_xref({
-                                         'master_xref_id' => $ent_id,
-                                         'acc'            => $mim_id,
-                                         'source_id'      => $mim_morbid_source_id,
-                                         'species_id'     => $species_id,
-                                         'linkage'        => $entrez_source_id,
-                                         'dbi'            => $dbi,
-                                       });
-            }
-          }
-        }
-      }
-      elsif ( $type eq "phenotype" ) {
+
+      if ( $type eq 'phenotype' ) {
+        # The only type with a different source order
+
         if ( defined( $mim_morbid{$omim_id} ) ) {
           foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
             foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
@@ -280,7 +260,35 @@ sub run {
         }
       }
       else {
-        croak "Unknown type $type";
+        if ( defined( $mim_gene{$omim_id} ) ) {
+          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
+            foreach my $mim_id ( @{ $mim_gene{$omim_id} } ) {
+              $self->add_dependent_xref({
+                                         'master_xref_id' => $ent_id,
+                                         'acc'            => $mim_id,
+                                         'source_id'      => $mim_gene_source_id,
+                                         'species_id'     => $species_id,
+                                         'linkage'        => $entrez_source_id,
+                                         'dbi'            => $dbi,
+                                       });
+            }
+          }
+        }
+        else {
+          $counters{'expected_in_mim_gene_but_not_there'}++;
+          foreach my $ent_id ( @{ $entrez{$entrez_id} } ) {
+            foreach my $mim_id ( @{ $mim_morbid{$omim_id} } ) {
+              $self->add_dependent_xref({
+                                         'master_xref_id' => $ent_id,
+                                         'acc'            => $mim_id,
+                                         'source_id'      => $mim_morbid_source_id,
+                                         'species_id'     => $species_id,
+                                         'linkage'        => $entrez_source_id,
+                                         'dbi'            => $dbi,
+                                       });
+            }
+          }
+        }
       }
 
     }

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -83,10 +83,10 @@ sub run {
   my $count;
 
   $eg_io->getline();    # do not need header
-  while ( $_ = $eg_io->getline() ) {
+  while ( my $line = $eg_io->getline() ) {
     $count++;
-    chomp;
-    my ( $omim_id, $entrez_id, $type, $other ) = split;
+    chomp $line;
+    my ( $omim_id, $entrez_id, $type, $other ) = split qr{\t}msx, $line;
 
     if ( !defined( $entrez{$entrez_id} ) ) {
       $missed_entrez++;

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -165,6 +165,12 @@ sub run {
     # With all the checks taken care of, insert the mappings. We check
     # both MIM_GENE and MIM_MORBID every time because some MIM entries
     # can appear in both.
+    # FIXME: the underlying BaseParser code does NOT support having
+    # multiple xref_ids matching a single accession - and to make
+    # things worse, instead of failing should that be the case it
+    # quietly assigns such mappings to whichever xref for the given
+    # accession the database returns as first. Fortunately this
+    # doesn't seem to ever happen for current MIM input.
     foreach my $mim_xref_id ( @{ $mim_gene{$omim_acc} } ) {
       $self->process_xref_entry({
         'mim_acc'          => $omim_acc,
@@ -279,6 +285,8 @@ sub process_xref_entry {
       'species_id' => $arg_ref->{'species_id'},
       'dbi'        => $arg_ref->{'dbi'},
     });
+    # FIXME: update info_type in the xref from DEPENDENT to DIRECT as
+    # well, unless MIMParser starts inserting something else.
   }
   else {
     foreach my $ent_id ( @{ $arg_ref->{'entrez_xrefs'} } ) {

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -130,8 +130,7 @@ sub run {
       }
     }
     else {
-      print "WARNING unknown type $type\n";
-      next;
+      croak "Unknown type $type";
     }
 
   } ## end while ( $_ = $eg_io->getline...)

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -47,12 +47,11 @@ sub run {
   }
   $verbose |= 0;
 
-  my $file = @{$files}[0];
+  my $filename = @{$files}[0];
 
-  my $eg_io = $self->get_filehandle($file);
+  my $eg_io = $self->get_filehandle($filename);
   if ( !defined $eg_io ) {
-    print STDERR "ERROR: Could not open $file\n";
-    return 1;    # 1 is an error
+    croak "Could not open file '${filename}'";
   }
 
   my $entrez_source_id =


### PR DESCRIPTION
**Warning:** as of 2018-10-30, this PR is expected to fail Travis builds due to being dependent on #323 and #324 . 

## Description

Fixes bugs observed (so far) in Mim2GeneParser during the xref sprint, implements support for direct MIM xrefs, add additional checks, and delint the code to facilitate further refactoring. See ENSCORESW-2891.

## Use case

Part of the efforts to improve the xref pipeline. Moreover, one of the observed bugs actually prevents current versions of mim2gene data from being parsed at all.

## Benefits

The parser can now handle recent versions of mim2gene input. Direct xrefs are now produced wherever possible, with dependent ones only used for entries lacking Ensembl ID but with EntrezGene ID present. Use BaseParser methods for inserting dependent xrefs into the database, which in addition to avoiding hand-rolled DBI code will, once pull request #314 has been approved, prevent Mim2GeneParser from inserting duplicate entries upon re-runs with the same input. Some future-proofing. Code (hopefully) easier to maintain. Most complaints of PerlCritic levels 3 and 2 taken care of. Use a standardised rather than hand-rolled CSV parser, with potential for a performance increase if compiled rather than native-Perl version of the parser is used.

## Possible Drawbacks

Output is less straightforward than it used to be because it now includes both direct (the vast majority) and dependent (around 10 percent as of today) xrefs.

## Testing

_Have you added/modified unit tests to test the changes?_
No.

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
N/A. However, I have run the parser itself on both current DBASS data and some intentionally malformed input, and it appears to work correctly.