### PR TITLE
Feature/rgd

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -372,10 +372,14 @@ sub label_to_acc{
 ####################################################
 # get_valid_codes
 #
-# hash of accession to array of xrefs.
+# hash of accessions to array of xref dbIDs.
 # This is an array becouse more than one entry can
 # exist. i.e. for uniprot and refseq we have direct
 # and sequence match sets and we need to give both.
+#
+# This list is a cache of acceptable IDs in order to
+# reduce querying when attaching external accessions
+# to xrefs.
 ####################################################
 sub get_valid_codes{
 

--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -1213,7 +1213,8 @@ sub add_synonym{
   my ($self, $xref_id, $syn, $dbi) = @_;
 
   $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
+  my $add_synonym_sth = $dbi->prepare_cached('INSERT IGNORE INTO synonym VALUES(?,?)');
+  
   $add_synonym_sth->execute( $xref_id, $syn ) 
     or croak( $dbi->errstr()."\n $xref_id\n $syn\n\n" );
 

--- a/misc-scripts/xref_mapping/XrefParser/ProcessData.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ProcessData.pm
@@ -101,8 +101,9 @@ DSS
   my $dep_sth = $dbi->prepare($sql);
 
   # validate species names
-  my $species_id = $self->validate_species($species, $verbose) if defined $species;
-  my $division_id = $self->validate_species($division, $verbose) if defined $division;
+  my ($species_id,$division_id);
+  $species_id = $self->validate_species($species, $verbose) if defined $species;
+  $division_id = $self->validate_species($division, $verbose) if defined $division;
   my @species_sources = ($species_id);
   push @species_sources, $division_id if defined $division_id;
   push @species_sources, $taxon_id if defined $taxon_id;
@@ -733,7 +734,7 @@ sub sanitise {
 
 
 #######################################################
-# Print to stanadrd error the list of species available
+# Print to standard error the list of species available
 #######################################################
 sub show_valid_species {
   my ($self) =shift;
@@ -768,7 +769,7 @@ sub validate_sources {
     } else {
       print "\nSource $source is not valid; valid sources are:\n";
       foreach my $sp (@{$speciesref}){
-	show_valid_sources($sp);
+        $self->show_valid_sources($sp);
       }
       return 0;
     }

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -87,7 +87,7 @@ sub run {
   my $syn_count = 0;
   my $cols; # Digested columns from CSV
   while ( $cols = $csv->getline_hr($rgd_io) ) {
-    next if $csv->is_missing (0) || (exists $cols->{GENE_RGD_ID} && $cols->{GENE_RGD_ID} eq '' || !defined $cols->{GENE_RGD_ID});
+    next if exists $cols->{GENE_RGD_ID} && ($cols->{GENE_RGD_ID} eq '' || !defined $cols->{GENE_RGD_ID});
 
     my @nucs;
     @nucs = split(/\;/,$cols->{GENBANK_NUCLEOTIDE}) if defined $cols->{GENBANK_NUCLEOTIDE};

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -48,7 +48,7 @@ sub run {
   if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
     confess "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |=0;
+  $verbose //= 0;
 
   my $source_sql = "select source_id from source where name = 'RGD' and priority_description = 'direct_xref'";
   my $sth = $dbi->prepare($source_sql);

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -31,8 +31,6 @@ package XrefParser::RGDParser;
 use strict;
 use warnings;
 use Carp;
-use POSIX qw(strftime);
-use File::Basename;
 use Text::CSV;
 
 use parent qw( XrefParser::BaseParser );

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -185,25 +185,15 @@ sub sort_refseq_accessions {
   return @accessions;
 }
 
-
 # Process the synonym column into potentially many items, add them to the synonym table
 sub add_synonyms {
   my ($self,$synonym_string,$xref_id,$dbi) = @_;
   my $syn_count = 0;
   return $syn_count if (!defined $synonym_string || !defined $xref_id || !defined $dbi);
-  my $add_syn_sth;
 
-  if (! $self->{_syn_dbh_cache}) {
-    my $sql = "insert ignore into synonym (xref_id, synonym) values (?, ?)";
-    $add_syn_sth = $dbi->prepare($sql);
-    $self->{_syn_dbh_cache} = $add_syn_sth;
-  }
-  $add_syn_sth = $self->{_syn_dbh_cache};
-
-  my @syns;
-  @syns = split(/\;/,$synonym_string);
+  my @syns = split(/\;/,$synonym_string);
   foreach my $syn(@syns){
-    $add_syn_sth->execute($xref_id, $syn);
+    $self->add_synonym($xref_id,$syn,$dbi);
     $syn_count++;
   }
   return $syn_count;

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -58,8 +58,8 @@ sub run {
   my $rgd_io = $self->get_filehandle($file);
 
   if ( !defined $rgd_io ) {
-    print "ERROR: Could not open $file\n";
-    return 1;
+    print STDERR "ERROR: Could not open $file\n";
+    croak "Could not open $file when trying to parse RGD";
   }
   my $line;
   my $found =0;
@@ -82,7 +82,7 @@ sub run {
   # Detect format deviations
   foreach my $name (keys %columns) {
     if($linearr[$columns{$name}] ne $name) {
-      die "$name is not element $columns{$name} in the RGD header:\n$line\n";
+      croak "$name is not element $columns{$name} in the RGD header:\n$line\n";
     }
   }
 

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -75,7 +75,7 @@ sub run {
   # strict is turned off to prevent failure on a blank line at the end
 
   my $line = '#';
-  until (substr($line,0,1) ne '#') {
+  while (substr($line,0,1) eq '#') {
     $line = $rgd_io->getline;
   }
   $csv->parse($line);

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -15,6 +15,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+=head1 DESCRIPTION
+
+Designed to parse the Rat Genome Database download file, historically hosted at
+ftp://ftp.rgd.mcw.edu/pub/data_release/GENES_RAT.txt . It comprises 40+ columns in a 
+tab-separated format
+
+It contains RGD IDs (which are numeric), and associates them either with Ensembl genes or
+RefSeq records (mainly transcripts).
+
 =cut
 
 package XrefParser::RGDParser;
@@ -92,7 +101,7 @@ sub run {
     my @nucs;
     @nucs = split(/\;/,$cols->{GENBANK_NUCLEOTIDE}) if defined $cols->{GENBANK_NUCLEOTIDE};
     my $done = 0;
-    # @nucs are sorted in the file in alphabetical order. Filter them to down
+    # @nucs are sorted in the file in alphabetical order. Filter them down
     # to a higher quality subset, then add dependent Xrefs where possible
     foreach my $nuc ($self->sort_refseq_accessions(@nucs)){
       if(!$done && exists $preloaded_refseq{$nuc}){
@@ -177,6 +186,7 @@ sub sort_refseq_accessions {
 }
 
 
+# Process the synonym column into potentially many items, add them to the synonym table
 sub add_synonyms {
   my ($self,$synonym_string,$xref_id,$dbi) = @_;
   my $syn_count = 0;

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -107,8 +107,8 @@ sub run {
     my @nucs = split(/\;/,$refseq); # nucs = nucleotides
     my $done = 0;
 
-    # @nucs are sorted in the file in alphabetical order. Reverse order might be
-    # an efficiency hack for getting the better accessions done first, e.g. XM_, NM_
+    # @nucs are sorted in the file in alphabetical order. Filter them to down
+    # to a higher quality subset, then add dependent Xrefs where possible
     foreach my $nuc ($self->sort_refseq_accessions(@nucs)){
       if(!$done){
         if(exists $preloaded_refseq{$nuc}){

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -39,7 +39,7 @@ sub run {
   $dbi = $self->dbi unless defined $dbi;
 
   if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
-    croak "Need to pass source_id, species_id and files as pairs";
+    confess "Need to pass source_id, species_id and files as pairs";
   }
   $verbose |=0;
 
@@ -59,10 +59,10 @@ sub run {
   my $rgd_io = $self->get_filehandle($file);
 
   if ( !defined $rgd_io ) {
-    carp "Could not open $file when trying to parse RGD";
+    confess "Could not open $file when trying to parse RGD";
   }
   my $csv = Text::CSV->new({ sep => "\t", blank_is_undef => 1, strict => 0, auto_diag => 1, binary => 1, allow_loose_quotes => 1})
-    or carp "Cannot use CSV: ".Text::CSV->error_diag ();
+    or confess "Cannot use CSV: ".Text::CSV->error_diag ();
   # WARNING - Text::CSV does not like the GENES-RAT.txt file. It is improperly formatted and contains a non-ASCII character
   # Make sure binary is turned on or it silently fails and you get 1/3rd of the records.
   # strict is turned off to prevent failure on a blank line at the end

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -109,7 +109,7 @@ sub run {
 
     # @nucs are sorted in the file in alphabetical order. Reverse order might be
     # an efficiency hack for getting the better accessions done first, e.g. XM_, NM_
-    foreach my $nuc (reverse @nucs){
+    foreach my $nuc ($self->sort_refseq_accessions(@nucs)){
       if(!$done){
         if(exists $preloaded_refseq{$nuc}){
           foreach my $xref (@{$preloaded_refseq{$nuc}}){
@@ -176,6 +176,26 @@ sub run {
     print "added $syn_count synonyms\n";
   }
   return 0;
+}
+
+# Predefined importance levels for the most valued RefSeq accession types
+my %refseq_priorities = (
+  NM => 1,
+  NP => 1,
+  NR => 1,
+  XM => 2,
+  XP => 2,
+  XR => 2,
+);
+
+# Filter out any accessions which are not in the "normal" set of genomic features
+# The column in question contains EMBL accessions as well as other things, and we don't 
+# have the ability to make Xrefs to those. It wouldn't be useful to do so in any case
+sub sort_refseq_accessions {
+  my ($self,@accessions) = @_;
+  @accessions = sort { $refseq_priorities{substr $a, 0,2} <=> $refseq_priorities{substr $b, 0,2} } 
+                grep { exists $refseq_priorities{substr $_, 0,2} } @accessions;
+  return @accessions;
 }
 
 1;

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -72,7 +72,7 @@ sub run {
   my @linearr = split(/\t/,$line);
 
   my %columns = (
-    GENE_RDB_ID => 0,
+    GENE_RGD_ID => 0,
     SYMBOL => 1,
     NAME => 2,
     GENBANK_NUCLEOTIDE => 23,
@@ -97,7 +97,7 @@ sub run {
     chomp $line;
     my ($rgd, $symbol, $name, $refseq ,$old_name, $ensembl_id) = 
       (split (/\t/,$line))
-      [ $columns{GENE_RDB_ID},
+      [ $columns{GENE_RGD_ID},
         $columns{SYMBOL},
         $columns{NAME},
         $columns{GENBANK_NUCLEOTIDE},


### PR DESCRIPTION
## Description

Update RGD parser to use Text::CSV, delint, and a few logical improvents

## Use case

Xref pipeline

## Benefits

Selection of RefSeq dependent xrefs changed from pseudo-random reverse alphabetical order to one based on evidence inferred via RefSeq accession.

## Possible Drawbacks

Text::CSV has undesirable behaviours when it encounters strange things in files. Fragile to content changes. Change in RefSeq dependent logic may have unforeseen consequences

## Testing

No test suite. Pipeline works end to end, but it's not especially easy to tell if it's really an improvement.