### PR TITLE
Remove mgi xref mappings via ccds and uniprot 

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -141,45 +141,6 @@ sub create_xrefs {
   my @tax_ids = @{$species2tax{$species_id}};
   my %taxonomy2species_id = map{ $_=>$species_id } @tax_ids;
 
-
-#
-# MGI data needed---------------------------------------------------------
-#
-  my %mgi_acc_to_desc;
-  my %mgi_acc_to_label;
-  my %mgi_label_to_desc;
-  my %mgi_label_to_acc;
-
-  my $sth = $dbi->prepare("SELECT x.accession, x.label, x.description from xref x, source s where x.source_id = s.source_id and s.name like 'MGI' and s.priority_description like 'descriptions'");
-  
-  $sth->execute() or croak( $dbi->errstr() );
-  while ( my @row = $sth->fetchrow_array() ) {
-    $mgi_acc_to_desc{$row[0]}   = $row[2];
-    $mgi_acc_to_label{$row[0]}  = $row[1];
-    $mgi_label_to_desc{$row[1]} = $row[2];
-    $mgi_label_to_acc{$row[1]}  = $row[0];
-  }
-  $sth->finish;
-
-
-  #
-  # Get the MGI synonyms
-  #
-
-  $sth = $dbi->prepare("SELECT sy.synonym, x.accession, x.description from xref x, source s, synonym sy where sy.xref_id = x.xref_id and x.source_id = s.source_id and s.name like 'MGI' and s.priority_description like 'descriptions'");
-  
-  $sth->execute() or croak( $dbi->errstr() );
-  while ( my @row = $sth->fetchrow_array() ) {
-    $mgi_label_to_desc{$row[0]} = $row[2];
-    $mgi_label_to_acc{$row[0]}  = $row[1];
-  }
-  $sth->finish;
-
-  #
-  # end MGI data needed -------------------------------------------------
-  #
-
-
   my %dependent_xrefs;
   my $ensembl_derived_protein_count = 0;
 
@@ -447,6 +408,10 @@ sub create_xrefs {
       	if($source =~ "HGNC"){
       	  next;
       	}
+        # We get the mappings directly from the source
+        if($source =~ "MGI"){
+          next;
+        }
         # Nomenclature data is imported directly from the source
         if($source =~ "VGNC"){
           next;
@@ -504,27 +469,6 @@ sub create_xrefs {
 	    $dep{LABEL} = $extra[0];
 	  }
 	  $dep{ACCESSION} = $acc;
-
-	  if($source =~ /MGI/){
-	    $extra[0] =~ s/[.]$//;
-            if($extra[0] =~ /ENSMUSG/ or $extra[0] =~ /OTTMUSG/ ){
-               next;  # no extra info gained and it could now link to different MGI
-            }
-	    $dep{LABEL} = $extra[0];
-	    if(defined($mgi_acc_to_label{$acc})){
-	      $dep{LABEL} = $mgi_acc_to_label{$acc};
-	    }
-	    if(defined($mgi_acc_to_desc{$acc})){
-	      $dep{DESCRIPTION} = $mgi_acc_to_desc{$acc};
-	    }
-	    elsif(defined($mgi_label_to_desc{$dep{LABEL}})){ # old mgi number ?? use label 
-              $dep{DESCRIPTION} = $mgi_label_to_desc{$dep{LABEL}};
-              $dep{ACCESSION}   = $mgi_label_to_acc{$dep{LABEL}};
-	    }
-            else{
-               print "Not found $acc, ".$extra[0]."\n" if($verbose);
-            }
-	  }
 
 #	  $dep{ACCESSION} = $acc;
 	  $dependent_xrefs{ $dep{SOURCE_NAME} }++; # get count of depenent xrefs.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -123,10 +123,6 @@ sub create_xrefs {
 
   my %dependent_sources = $self->get_xref_sources($dbi);
 
-  if(defined($dependent_sources{'MGI'})){
-    $dependent_sources{'MGI'} = $self->get_source_id_for_source_name("MGI","uniprot", $dbi);
-  }
-
     my (%genemap) =
       %{ $self->get_valid_codes( "mim_gene", $species_id, $dbi ) };
     my (%morbidmap) =

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -597,15 +597,6 @@ parser          = Mim2GeneParser
 dependent_on    = MIM,EntrezGene
 data_uri        = ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen
 
-[source MGI::mus_musculus#04]
-# Used by mus_musculus
-name            = MGI
-download        = N
-order           = 30
-priority        = 4
-prio_descr      = uniprot
-data_uri        = taken from uniprot files
-
 [source MGI::mus_musculus#01]
 # Used by mus_musculus
 name            = MGI
@@ -625,16 +616,6 @@ priority        = 10
 prio_descr      = descriptions
 parser          = MGI_Desc_Parser
 data_uri        = http://www.informatics.jax.org/downloads/reports/MRK_List2.rpt
-
-[source MGI::mus_musculus#03]
-# Used by mus_musculus
-name            = MGI
-download        = Y
-order           = 35
-priority        = 3
-prio_descr      = ccds
-parser          = MGI_CCDS_Parser
-data_uri        = ftp://ftp.ncbi.nlm.nih.gov/pub/CCDS/current_mouse/CCDS.current.txt
 
 [source Reactome::MULTI]
 # Used by all species
@@ -1861,7 +1842,6 @@ taxonomy_id     = 10090
 source          = CCDS::mus_musculus
 source          = EntrezGene::MULTI
 source          = MGI::mus_musculus#01
-source          = MGI::mus_musculus#03
 source          = MGI::mus_musculus#05
 source          = UCSC::mus_musculus
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Removed the sections from the ini file corresponding to MGI ccds and uniprot sources.
Removed the call to get the source id from 'MGI' source name and uniprot as it is not applicable anymore.

## Use case

For mouse, we use MGI symbols as the official naming source. To increase the coverage, we use third-party mappings to MGI, including CCDS and UniProt mappings. As of the latest update, we have 14 MGI xrefs obtained via CCDS mappings and another 52 via UniProt. These updates will  remove those additional mappings to get the mappings from a single source ie MGI.

## Benefits

We get the mappings only from single source (MGI)

## Possible Drawbacks

We may miss the mappings for the some minimal ids. (14-ccds, 52-uniprot)

## Testing

Tested it by running the xref_parser script and checked the _xref database for row counts. 
modules/t/xref_parser.t also passes
