### PR TITLE
BaseParser: fast path for insertion of dependent xrefs

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -1157,7 +1157,7 @@ IXR
 ##################################################################
 
 sub add_dependent_xref_maponly {
-  my ( $self, $dependent_id, $dependent_source_id, $master_id, $master_source_id, $dbi ) = @_;
+  my ( $self, $dependent_id, $dependent_source_id, $master_id, $master_source_id, $dbi, $update_info_type ) = @_;
 
   $dbi //= $self->dbi;
 
@@ -1181,6 +1181,11 @@ ADX
   }
 
   $add_dependent_xref_sth->finish();
+
+  if ( $update_info_type ) {
+    $self->_update_xref_info_type( $dependent_id, 'DEPENDENT', $dbi );
+  }
+
   return;
 }
 


### PR DESCRIPTION
**Warning:** this PR is now dependent on #326

## Description

Factor insertion of _dependent_xref_ entries out of add_dependent_xref() so that it can be used independently.

## Use case

Parsers inserting dependent-xref mappings which do not insert xrefs themselves, e.g. Mim2GeneParser.

## Benefits

Parsers which are not supposed to insert xrefs themselves will now no longer insert stub xrefs upon e.g. encountering a typo. In the event of a single accession pointing to multiple xref_ids dependent mappings can now be correctly assigned to those IDs, whereas using add_dependent_xref() would assign them all to the first matching xref_id returned by the database. Considerable performance gain thanks to fewer conversations with the database. API behaviour for inserting dependent xrefs is now consistent with that for inserting direct ones, albeit due to a name collision functions doing the same thing have different names for the two.

## Possible Drawbacks

When the fast path is used validation of xref IDs is left up to the programmer, therefore it may now be easier to insert mappings pointing to xrefs which do not exist.

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
N/A but I have tested the changes by running a parser which uses the relevant bits of code (i.e. my delinted version of Mim2GeneParser) and the changes seem to do what they should.
