### PR TITLE
BaseParser: new method for updating xref info_type

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -1515,6 +1515,23 @@ sub get_meta_value {
 }
 
 
+######################################
+# Update info_type of an existing xref
+######################################
+sub _update_xref_info_type {
+  my ($self, $xref_id, $info_type, $dbi) = @_;
+
+  $dbi //= $self->dbi;
+
+  my $sth =  $dbi->prepare('UPDATE xref SET info_type=? where xref_id=?');
+  if ( ! $sth->execute( $info_type, $xref_id ) ) {
+    croak $dbi->errstr() . "\n $xref_id\n $info_type\n\n";
+  }
+
+  $sth->finish();
+  return;
+}
+
 
 1;
 


### PR DESCRIPTION
## Description

There are xref parsers such as Mim2GeneParser which a) only insert mappings but not xrefs themselves, and b) can insert mappings of several different types. Under such circumstances it is necessary for the parser to update respective xrefs' info_type to reflect the type of mappings they use.

## Use case

For example, the MIMParser/Mim2GeneParser pair. The latter inserts both direct and dependent mappings but depends on the former to provide MIM xrefs, whereas the former has no way of knowing what value of info_type is the right one at the time it runs. Combining the two parsers into one is almost certainly out of the question because they are both complex as they are and they deal with input that is structured in completely different ways.

## Benefits

MIM xrefs directly mapped to Ensembl genes will have correct info_type.

## Possible Drawbacks

The new method might in theory be (ab)used by developers, even though it has been declared as private in order to discourage direct use.

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
No, I have however run the revised Mim2GeneParser and confirmed insertion of direct xrefs correctly updates MIM xrefs' info_type to DIRECT from the default DEPENDENT.
