### PR TITLE
MIMParser: change xref info_type to UNMAPPED

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -143,7 +143,7 @@ sub run {
                        desc       => $long_desc,
                        species_id => $species_id,
                        dbi        => $dbi,
-                       info_type  => "DEPENDENT",
+                       info_type  => 'UNMAPPED',
                      };
 
     if ( exists $TYPE_SINGLE_SOURCES{$type} ) {


### PR DESCRIPTION
## Description

MIMParser used to set info_type of all xrefs it crearted to DEPENDENT because all MIM xrefs were dependent on EntrezGene ones, now however many (most, for that matter) are direct. Therefore, set it to UNMAPPED to begin with and leave it to Mim2GeneParser to set the correct value when it inserts actual mappings.

## Use case

Running the MIMParser/Mim2GeneParser pair, in which the former creates actual xrefs without knowledge of how they will be mapped and the latter only handles mappings.

## Benefits

Easier to spot unmapped MIM xrefs because their info_type will not be updated by Mim2GeneParser.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
No, I have however run MIMParser and it seems to work fine.
