### PR TITLE
Use seq_region_start and seq_region_end when updating gene coordinate…

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -1655,8 +1655,8 @@ sub update_coords {
        WHERE gene_id = ?
     );
   my $sth = $self->prepare($update_sql);
-  $sth->bind_param(1, $gene->start);
-  $sth->bind_param(2, $gene->end);
+  $sth->bind_param(1, $gene->seq_region_start);
+  $sth->bind_param(2, $gene->seq_region_end);
   $sth->bind_param(3, $gene->dbID);
   $sth->execute();
 }

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -474,15 +474,18 @@ cmp_ok($new_gene->start(), '==', 30735607, 'Updated gene start');
 cmp_ok($new_gene->end(), '==', 30815178, 'Updated gene end');
 
 # test update_coords method when working on sub Slice
-my $update_slice = $db->get_SliceAdaptor()->fetch_by_region('chromosome', '20', 30730000, 30815178);
+# to avoid setting the start and end relative to a sub Slice
+# correct coords: 30735607 - 30815178
+# wrong coords: 1 - 79572
+my $update_slice = $db->get_SliceAdaptor()->fetch_by_gene_stable_id('ENSG00000171456');
+# Make sure that the slice of the gene is a sub Slice
 my $update_genes = $update_slice->get_all_Genes();
-cmp_ok(scalar(@$update_genes), '>=', 1, 'Check the region has at least one gene');
+# Update the coordinates of the gene in the database
 foreach my $gene_to_update (@$update_genes) {
-  if ($gene_to_update->stable_id() eq 'ENSG00000171456') {
-    $ga->update_coords($gene_to_update);
-  }
+  $ga->update_coords($gene_to_update);
 }
 
+# Fetch the gene again to check the coordinates
 my $updated_gene = $ga->fetch_by_stable_id("ENSG00000171456");
 cmp_ok($updated_gene->start(), '==', 30735607, 'Updated gene start');
 cmp_ok($updated_gene->end(), '==', 30815178, 'Updated gene end');

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -473,6 +473,20 @@ my $new_gene = $ga->fetch_by_stable_id("ENSG00000171456");
 cmp_ok($new_gene->start(), '==', 30735607, 'Updated gene start');
 cmp_ok($new_gene->end(), '==', 30815178, 'Updated gene end');
 
+# test update_coords method when working on sub Slice
+my $update_slice = $db->get_SliceAdaptor()->fetch_by_region('chromosome', '20', 30730000, 30815178);
+my $update_genes = $update_slice->get_all_Genes();
+cmp_ok(scalar(@$update_genes), '>=', 1, 'Check the region has at least one gene');
+foreach my $gene_to_update (@$update_genes) {
+  if ($gene_to_update->stable_id() eq 'ENSG00000171456') {
+    $ga->update_coords($gene_to_update);
+  }
+}
+
+my $updated_gene = $ga->fetch_by_stable_id("ENSG00000171456");
+cmp_ok($updated_gene->start(), '==', 30735607, 'Updated gene start');
+cmp_ok($updated_gene->end(), '==', 30815178, 'Updated gene end');
+
 #
 # test GeneAdaptor::fetch_all_by_domain
 #


### PR DESCRIPTION
…oordinates in the database

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Use seq_region_start and seq_region_end when updating the coordinates of a gene in a database.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
If the gene is on a sub Slice and start and end are called, they return the start and end relative to the slice. When start and end are used in update_coords, it will then insert the wrong coordinates of the gene in the database.

## Benefits

_If applicable, describe the advantages the changes will have._
It will store the correct coordinates of a gene when updating the coordinates in the database.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
Yes
_If so, do the tests pass/fail?_
Pass
_Have you run the entire test suite and no regression was detected?_

