### PR TITLE
Fixes in BaseParser::upload_xref_object_graphs()

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -931,11 +931,11 @@ sub add_xref {
   my $acc         = $arg_ref->{acc}        || croak 'add_xref needs aa acc';
   my $source_id   = $arg_ref->{source_id}  || croak 'add_xref needs a source_id';
   my $species_id  = $arg_ref->{species_id} || croak 'add_xref needs a species_id';
-  my $label       = $arg_ref->{label}      || $acc;
+  my $label       = $arg_ref->{label}      // $acc;
   my $description = $arg_ref->{desc};
-  my $version     = $arg_ref->{version}    || 0;
-  my $info_type   = $arg_ref->{info_type}  || 'MISC';
-  my $info_text   = $arg_ref->{info_text}  || '';
+  my $version     = $arg_ref->{version}    // 0;
+  my $info_type   = $arg_ref->{info_type}  // 'MISC';
+  my $info_text   = $arg_ref->{info_text}  // q{};
   my $dbi         = $arg_ref->{dbi};
 
   $dbi = $self->dbi unless defined $dbi;
@@ -1058,11 +1058,11 @@ sub add_to_direct_xrefs{
   my $acc         = $arg_ref->{acc}         || croak ('Need an accession of this direct xref' );
   my $source_id   = $arg_ref->{source_id}   || croak ('Need a source_id for this direct xref' );
   my $species_id  = $arg_ref->{species_id}  || croak ('Need a species_id for this direct xref' );
-  my $version     = $arg_ref->{version}     || 0;
-  my $label       = $arg_ref->{label}       || $acc;
+  my $version     = $arg_ref->{version}     // 0;
+  my $label       = $arg_ref->{label}       // $acc;
   my $description = $arg_ref->{desc};
   my $linkage     = $arg_ref->{linkage};
-  my $info_text   = $arg_ref->{info_text}  || '';
+  my $info_text   = $arg_ref->{info_text}   // q{};
   my $dbi         = $arg_ref->{dbi};
 
   $dbi = $self->dbi unless defined $dbi;
@@ -1145,11 +1145,11 @@ sub add_dependent_xref{
   my $acc         = $arg_ref->{acc}            || croak( 'Need an accession of this dependent xref' );
   my $source_id   = $arg_ref->{source_id}      || croak( 'Need a source_id for this dependent xref' );
   my $species_id  = $arg_ref->{species_id}     || croak( 'Need a species_id for this dependent xref' );
-  my $version     = $arg_ref->{version}        ||  0;
-  my $label       = $arg_ref->{label}          || $acc;
+  my $version     = $arg_ref->{version}        // 0;
+  my $label       = $arg_ref->{label}          // $acc;
   my $description = $arg_ref->{desc};
   my $linkage     = $arg_ref->{linkage};
-  my $info_text   = $arg_ref->{info_text} || '';
+  my $info_text   = $arg_ref->{info_text}      // q{};
   my $dbi         = $arg_ref->{dbi};
 
   $dbi = $self->dbi unless defined $dbi;

--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -585,23 +585,23 @@ sub upload_xref_object_graphs {
                                           });
          if( ! $dep_xref_id ) {
            next DEPENDENT_XREF;
-	 }
+         }
 
-	 #
-	 # Add the linkage_annotation and source id it came from
-	 #
+         #
+         # Add the linkage_annotation and source id it came from
+         #
          $self->add_dependent_xref_maponly( $dep_xref_id,
                                             $dep{LINKAGE_SOURCE_ID},
                                             $xref_id,
                                             $dep{LINKAGE_ANNOTATION} // $dep{SOURCE_ID} );
 
-	 #########################################################
-	 # if there are synonyms, add entries in the synonym table
-	 #########################################################
-	 foreach my $syn ( @{ $dep{SYNONYMS} } ) {
-	   $syn_sth->execute( $dep_xref_id, $syn )
-	     or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
-	 } # foreach syn
+         #########################################################
+         # if there are synonyms, add entries in the synonym table
+         #########################################################
+         foreach my $syn ( @{ $dep{SYNONYMS} } ) {
+           $syn_sth->execute( $dep_xref_id, $syn )
+             or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+         } # foreach syn
 
        } # foreach dep
 


### PR DESCRIPTION
## Description

BaseParser::upload_xref_object_graphs() can insert duplicate dependent xrefs on subsequent reruns of parsers using it on the same input, and inserted empty strings rather than NULLs as descriptions of dependent xrefs unless explicitly overridden by arguments.

## Use case

_BaseParser::upload_xref_object_graphs()_ is used by (at least) UniProtParser.

## Benefits

Calls to upload_xref_object_graphs() should now be replay-safe. Fewer empty strings.

## Possible Drawbacks

Parser output will likely change a lot, mostly due to the empty-space-to-null transition - which will make validation challenging.

## Testing

_Have you added/modified unit tests to test the changes?_
No.

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
I have run _xref_parser.t_, which AFAIK is the only part of the test suite dealing with xref parsers. All tests still pass.
Moreover, I have run the new UniProtParser (with a small subset of input extracted from the middle of current Swiss-Prot file) before and after the change to compare results and they have changed as expected.