### PR TITLE
Rewritten UniProtParser

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2018] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional
+information regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,521 +17,150 @@ limitations under the License.
 
 =cut
 
-# Parse UniProt (SwissProt & SPTrEMBL) files to create xrefs.
-#
-# Files actually contain both types of xref, distinguished by ID line;
-#
-# ID   CYC_PIG                 Reviewed;         104 AA.  Swissprot
-# ID   Q3ASY8_CHLCH            Unreviewed;     36805 AA.  SPTrEMBL
-
 
 
 package XrefParser::UniProtParser;
 
 use strict;
 use warnings;
+
 use Carp;
-use POSIX qw(strftime);
-use File::Basename;
+use Readonly;
 
-use base qw( XrefParser::BaseParser );
+use XrefParser::UniProtParser::Extractor;
+use XrefParser::UniProtParser::Transformer;
+use XrefParser::UniProtParser::Loader;
 
+use parent qw( XrefParser::BaseParser );
+
+
+Readonly my $DEFAULT_LOADER_BATCH_SIZE => 1000;
+
+Readonly my %source_name_for_section => (
+                                         'Swiss-Prot' => 'Uniprot/SWISSPROT',
+                                         'TrEMBL'     => 'Uniprot/SPTREMBL',
+                                       );
 
 
 sub run {
+  my ( $self, $ref_arg ) = @_;
 
-  my ($self, $ref_arg) = @_;
-  my $source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $species_name = $ref_arg->{species};
-  my $files        = $ref_arg->{files};
-  my $release_file = $ref_arg->{rel_file};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
+  my $general_source_id = $ref_arg->{source_id};
+  my $species_id        = $ref_arg->{species_id};
+  my $species_name      = $ref_arg->{species};
+  my $files             = $ref_arg->{files};
+  my $release_file      = $ref_arg->{rel_file};
+  my $verbose           = $ref_arg->{verbose} // 0;
+  my $dbh               = $ref_arg->{dbi} // $self->dbi;
 
-  if((!defined $source_id) or (!defined $species_id) or (!defined $files)){
-    croak "Need to pass source_id, species_id, files and rel_file as pairs";
+  my $loader_batch_size
+    = $ref_arg->{loader_batch_size} // $DEFAULT_LOADER_BATCH_SIZE;
+
+  if ( ( !defined $general_source_id ) or
+       ( !defined $species_id ) or
+       ( !defined $files ) )
+  {
+    croak "Need to pass source_id, species_id and files as pairs";
   }
-  $verbose |=0;
 
-  my $file = @{$files}[0];
+  my $extractor = XrefParser::UniProtParser::Extractor->new({
+    'file_names' => $files,
+  });
+  my $transformer = XrefParser::UniProtParser::Transformer->new({
+    'dbh'        => $dbh,
+    'species_id' => $species_id,
+  });
+  my $loader = XrefParser::UniProtParser::Loader->new({
+    'batch_size' => $loader_batch_size,
+    'dbh'        => $dbh,
+  });
 
-  my ( $sp_source_id, $sptr_source_id, $sp_release, $sptr_release, $sptr_non_display_source_id, $sp_direct_source_id, $sptr_direct_source_id );
-
-  $sp_source_id =
-    $self->get_source_id_for_source_name('Uniprot/SWISSPROT','sequence_mapped', $dbi);
-  $sptr_source_id =
-    $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'sequence_mapped', $dbi);
-
-  $sptr_non_display_source_id =
-    $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'protein_evidence_gt_2', $dbi);
-
-  $sp_direct_source_id = $self->get_source_id_for_source_name('Uniprot/SWISSPROT', 'direct', $dbi);
-  $sptr_direct_source_id = $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'direct', $dbi);
-
-  print "SwissProt source id for $file: $sp_source_id\n" if ($verbose);
-  print "SpTREMBL source id for $file: $sptr_source_id\n" if ($verbose);
-  print "SpTREMBL protein_evidence > 2 source id for $file: $sptr_non_display_source_id\n" if ($verbose);
-  print "SwissProt direct source id for $file: $sp_direct_source_id\n" if ($verbose);
-  print "SpTREMBL direct source id for $file: $sptr_direct_source_id\n" if ($verbose);
- 
-  $self->create_xrefs( $sp_source_id, $sptr_source_id, $sptr_non_display_source_id, $species_id,
-      $file, $verbose, $sp_direct_source_id, $sptr_direct_source_id, $dbi );
-
-    if ( defined $release_file ) {
-        # Parse Swiss-Prot and SpTrEMBL release info from
-        # $release_file.
-        my $release_io = $self->get_filehandle($release_file);
-        while ( defined( my $line = $release_io->getline() ) ) {
-            if ( $line =~ m#(UniProtKB/Swiss-Prot Release .*)# ) {
-                $sp_release = $1;
-                print "Swiss-Prot release is '$sp_release'\n" if($verbose);
-            } elsif ( $line =~ m#(UniProtKB/TrEMBL Release .*)# ) {
-                $sptr_release = $1;
-                print "SpTrEMBL release is '$sptr_release'\n" if($verbose);
-            }
-        }
-        $release_io->close();
-
-        # Set releases
-        $self->set_release( $sp_source_id,        $sp_release, $dbi );
-        $self->set_release( $sptr_source_id,      $sptr_release, $dbi );
-	$self->set_release( $sptr_non_display_source_id, $sptr_release, $dbi );
-        $self->set_release( $sp_direct_source_id, $sp_release, $dbi );
-        $self->set_release( $sptr_direct_source_id,$sptr_release, $dbi );
-    }
-
-
-  return 0; # successfull
-}
-
-
-# --------------------------------------------------------------------------------
-# Parse file into array of xref objects
-
-sub create_xrefs {
-  my ($self, $sp_source_id, $sptr_source_id, $sptr_non_display_source_id, $species_id, $file, $verbose, $sp_direct_source_id, $sptr_direct_source_id, $dbi ) = @_;
-
-  my $num_sp = 0;
-  my $num_sptr = 0;
-  my $num_sp_pred = 0;
-  my $num_sptr_pred = 0;
-  my $num_sptr_non_display = 0;
-  my $num_direct_sp = 0;
-  my $num_direct_sptr = 0;
-
-  my %dependent_sources = $self->get_xref_sources($dbi);
-
-    my (%genemap) =
-      %{ $self->get_valid_codes( "mim_gene", $species_id, $dbi ) };
-    my (%morbidmap) =
-      %{ $self->get_valid_codes( "mim_morbid", $species_id, $dbi ) };
-
-    my $uniprot_io = $self->get_filehandle($file);
-    if ( !defined $uniprot_io ) { return }
-
-  my @xrefs;
-
-  local $/ = "//\n";
-
-  # Create a hash of all valid taxon_ids for this species
-  my %species2tax = $self->species_id2taxonomy($dbi);
-  push @{$species2tax{$species_id}}, $species_id;
-  my @tax_ids = @{$species2tax{$species_id}};
-  my %taxonomy2species_id = map{ $_=>$species_id } @tax_ids;
-
-  my %dependent_xrefs;
-  my $ensembl_derived_protein_count = 0;
-
-  # Counter to process file in batches
-  my $count = 0;
-
-  while ( $_ = $uniprot_io->getline() ) {
-
-    # if an OX line exists, only store the xref if the taxonomy ID that the OX
-    # line refers to is in the species table
-    # due to some records having more than one tax_id, we need to check them 
-    # all and only proceed if one of them matches.
-    #OX   NCBI_TaxID=158878, 158879;
-    #OX   NCBI_TaxID=103690;
-
-    my ($ox) = $_ =~ /OX\s+[a-zA-Z_]+=([0-9 ,]+).*;/;
-    my @ox = ();
-    my $found = 0;
-
-    if ( defined $ox ) {
-        @ox = split /\, /, $ox;
-
-        # my %taxonomy2species_id = $self->taxonomy2species_id();
-
-        foreach my $taxon_id_from_file (@ox) {
-          $taxon_id_from_file =~ s/\s//;
-          if ( exists $taxonomy2species_id{$taxon_id_from_file} ){
-            $found = 1;
-            $count++;
-          }
-        }
-    }
-
-    next if (!$found); # no taxon_id's match, so skip to next record
-    my $xref;
-
-    # set accession (and synonyms if more than one)
-    # AC line may have primary accession and possibly several ; separated synonyms
-    # May also be more than one AC line
-    my ($acc) = $_ =~ /(\nAC\s+.+)/s; # will match first AC line and everything else
-
-    my @all_lines = split /\n/, $acc;
-
-    # Check for CC (caution) lines containing certain text
-    # If sequence is from Ensembl, do not use
-    my $ensembl_derived_protein = 0;
-    if ($_ =~ /CAUTION: The sequence shown here is derived from an Ensembl/) {
-      $ensembl_derived_protein = 1;
-      $ensembl_derived_protein_count++;
-    }
-
-    # extract ^AC lines only & build list of accessions
-    my @accessions;
-    foreach my $line (@all_lines) {
-      my ($accessions_only) = $line =~ /^AC\s+(.+)/;
-      push(@accessions, (split /;\s*/, $accessions_only)) if ($accessions_only);
-
-    }
-
-
-    if(lc($accessions[0]) eq "unreviewed"){
-      print "WARNING: entries with accession of $acc not allowed will be skipped\n";
-      next;
-    }
-    $xref->{INFO_TYPE} = "SEQUENCE_MATCH";
-    $xref->{ACCESSION} = $accessions[0];
-    for (my $a=1; $a <= $#accessions; $a++) {
-      push(@{$xref->{"SYNONYMS"} }, $accessions[$a]);
-    }
-
-    my ($label, $sp_type) = $_ =~ /ID\s+(\w+)\s+(\w+)/;
-    my ($protein_evidence_code) = $_ =~ /PE\s+(\d+)/; 
-
-    # SwissProt/SPTrEMBL are differentiated by having STANDARD/PRELIMINARY here
-    if ($sp_type =~ /^Reviewed/i) {
-
-      $xref->{SOURCE_ID} = $sp_source_id;
-      $num_sp++;
-    } elsif ($sp_type =~ /Unreviewed/i) {
-
-    #Use normal source only if it is PE levels 1 & 2
-      if (defined($protein_evidence_code) && $protein_evidence_code < 3) {
-          $xref->{SOURCE_ID} = $sptr_source_id;
-          $num_sptr++;
-      } else {
-          $xref->{SOURCE_ID} = $sptr_non_display_source_id;
-          $num_sptr_non_display++;	  
-      }
-
-    } else {
-
-      next; # ignore if it's neither one nor t'other
-
-    }
-
-
-
-    # some straightforward fields
-    # the previous $label flag of type BRCA2_HUMAN is not used in Uniprot any more, use accession instead
-    $xref->{LABEL} = $accessions[0];
-    $xref->{SPECIES_ID} = $species_id;
-    $xref->{SEQUENCE_TYPE} = 'peptide';
-    $xref->{STATUS} = 'experimental';
-
-    # May have multi-line descriptions
-    my ($description_and_rest) = $_ =~ /(DE\s+.*)/s;
-    @all_lines = split /\n/, $description_and_rest;
-
-    # extract ^DE lines only & build cumulative description string
-    my $description = "";
-    my $name        = "";
-    my $sub_description = "";
-
-    foreach my $line (@all_lines) {
-
-      next if(!($line =~ /^DE/));
-
-      # get the data
-      if($line =~ /^DE   RecName: Full=(.*);/){
-        $name .= '; ' if $name ne q{}; #separate multiple sub-names with a '; '
-        $name .= $1;
-      }
-      elsif($line =~ /RecName: Full=(.*);/){
-        $description .= ' ' if $description ne q{}; #separate the description bit with just a space
-        $description .= $1;
-      }
-      elsif($line =~ /SubName: Full=(.*);/){
-        $name .= '; ' if $name ne q{}; #separate multiple sub-names with a '; '
-        $name .= $1;
-      }
-
-
-      $description =~ s/^\s*//g;
-      $description =~ s/\s*$//g;
-
-      
-      my $desc = $name.' '.$description;
-      if(!length($desc)){
-	$desc = $sub_description;
-      }
-      
-      $desc =~ s/\s*\{ECO:.*?\}//g;
-      $xref->{DESCRIPTION} = $desc;
-
-      # Parse the EC_NUMBER line, only for S.cerevisiae for now
-      
-      if (($line =~ /EC=/) && ($species_id == 4932)) {
-
-	  #print STDERR "EC Number line: $line\n";
-	  
-	  $line =~ /^DE\s+EC=([^;]+);/;
-	  
-	  # Get the EC Number and make it an xref for S.cer if any
-	  
-	  my $EC = $1;
-	  
-	  #print STDERR "EC after processing: $EC\n";
-	  
-	  my %depe;
-	  $depe{LABEL} = $EC;
-	  $depe{ACCESSION} = $EC;
-	  
-	  $depe{SOURCE_NAME} = "EC_NUMBER";
-	  
-	  $depe{SOURCE_ID} = $dependent_sources{"EC_NUMBER"};
-	  $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-	  push @{$xref->{DEPENDENT_XREFS}}, \%depe;
-	  $dependent_xrefs{"EC_NUMBER"}++;
-      }
-
-    }
-
-    # extract sequence
-    my ($seq) = $_ =~ /SQ\s+(.+)/s; # /s allows . to match newline
-      my @seq_lines = split /\n/, $seq;
-    my $parsed_seq = "";
-    foreach my $x (@seq_lines) {
-      $parsed_seq .= $x;
-    }
-    $parsed_seq =~ s/\/\///g;   # remove trailing end-of-record character
-    $parsed_seq =~ s/\s//g;     # remove whitespace
-    $parsed_seq =~ s/^.*;//g;   # remove everything before last ;
-
-    $xref->{SEQUENCE} = $parsed_seq;
-    #print "Adding " . $xref->{ACCESSION} . " " . $xref->{LABEL} ."\n";
-
-    
-    my ($gns) = $_ =~ /(GN\s+.+)/s;
-    my @gn_lines = ();
-    if ( defined $gns ) { @gn_lines = split /;/, $gns }
-  
-    # Do not allow the addition of UniProt Gene Name dependent Xrefs
-    # if the protein was imported from Ensembl. Otherwise we will
-    # re-import previously set symbols
-    if(! $ensembl_derived_protein) {
-      my %depe;
-      foreach my $gn (@gn_lines){
-# Make sure these are still lines with Name or Synonyms
-        if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
-        my $gene_name = undef;
-
-        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s]+)/s) { #/s for multi-line entries ; is the delimiter
-# Example line 
-# GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
-          my $name = $1;
-          $name =~ s/\s+$//g; # Remove white spaces that are left over at the end if there was an evidence code
-          $depe{LABEL} = $name; # leave name as is, upper/lower case is relevant in gene names
-          $depe{ACCESSION} = $self->get_name($xref->{ACCESSION},$depe{LABEL});
-          $gene_name = $depe{ACCESSION};
-
-          $depe{SOURCE_NAME} = "Uniprot_gn";
-          $depe{SOURCE_ID} = $dependent_sources{"Uniprot_gn"};
-          $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-          push @{$xref->{DEPENDENT_XREFS}}, \%depe;
-          $dependent_xrefs{"Uniprot_gn"}++;
-        }
-        my @syn;
-        if($gn =~ /Synonyms=(.*)/s){ # use of /s as synonyms can be across more than one line
-# Example line
-# GN   Synonyms=cela2a {ECO:0000313|Ensembl:ENSXETP00000014934},
-# GN   MGC79767 {ECO:0000313|EMBL:AAH80976.1}
-          my $syn = $1;
-          $syn =~ s/{.*}//g;  # Remove any potential evidence codes
-          $syn =~ s/\n//g;    # Remove return carriages, as entry can span several lines
-          $syn =~ s/\s+$//g;  # Remove white spaces that are left over at the end if there was an evidence code
-          #$syn =~ s/^\s+//g;  # Remove white spaces that are left over at the beginning if there was an evidence code
-          $syn =~ s/\s+,/,/g;  # Remove white spaces that are left over before the comma if there was an evidence code
-          @syn = split(/, /,$syn);
-          push (@{$depe{"SYNONYMS"}}, @syn);
-        }
+  my $source_id_map = $transformer->get_source_id_map();
+  if ( $verbose ) {
+    while ( my ( $section, $pri_ref ) = each %{ $source_id_map } ) {
+      while ( my ( $priority, $source_id ) = each %{ $pri_ref } ) {
+        # FIXME: do we really care about the file name here?
+        print "$section $priority source id for $files->[0]: $source_id\n";
       }
     }
+  }
 
-    # dependent xrefs - only store those that are from sources listed in the source table
-    my ($deps) = $_ =~ /(DR\s+.+)/s; # /s allows . to match newline
+ RECORD:
+  while ( $extractor->get_uniprot_record() ) {
 
-    my @dep_lines = ();
-    if ( defined $deps ) { @dep_lines = split /\n/, $deps }
+    my $extracted_record = $extractor->extract();
 
-    my %seen=();  # per record basis
+    my $transformed_data
+      = $transformer->transform( $extracted_record );
 
-    foreach my $dep (@dep_lines) {
-      #both GO and UniGene have the own sources so ignore those in the uniprot files
-      #as the uniprot data should be older
-      if($dep =~ /GO/ || $dep =~ /UniGene/){
-	next;
-      }
-      if ($dep =~ /^DR\s+(.+)/) {
-        my ($source, $acc, @extra) = split /;\s*/, $1;
-        if($source =~ "RGD"){  #using RGD file now instead.
-      	  next;
-      	}
-        if($source =~ "CCDS"){
-          next;
-        }
-      	if($source =~ "IPI"){
-      	  next;
-      	}
-      	if($source =~ "UCSC"){
-      	  next;
-      	}
-      	if($source =~ "SGD"){
-      	  next;
-      	}
-      	if($source =~ "HGNC"){
-      	  next;
-      	}
-        # We get the mappings directly from the source
-        if($source =~ "MGI"){
-          next;
-        }
-        # Nomenclature data is imported directly from the source
-        if($source =~ "VGNC"){
-          next;
-        }
-      	if($source =~ "Orphanet"){
-      	  #we don't want to parse Orphanet xrefs via Uniprot, we get them from Orphanet with descriptions
-      	  next;
-      	}
-      	if($source =~ "ArrayExpress"){
-      	    next;
-      	}
-        if($source =~ "GenomeRNAi" || $source =~ "EPD"){
-            next;
-        }
-        if($source =~ "Xenbase"){
-            next;
-        }
-# Uniprot get Reactome links from Reactome, so we want to get the info from Reactome directly
-        if($source =~ "Reactome"){
-            next;
-        }
-# MIM xrefs are already imported separately, ignore from Uniprot
-# Also, Uniprot deals with proteins, not appropriate for gene level xrefs
-        if ($source =~ "MIM_GENE" || $source =~ "MIM_MORBID" || $source =~ "MIM") {
-            next;
-        }
-# If mapped to Ensembl, add as direct xref
-        if ($source eq "Ensembl") {
-# Example line:
-# DR   Ensembl; ENST00000380152; ENSP00000369497; ENSG00000139618.
-# $source is Ensembl, $acc is ENST00000380152 and @extra is the rest of the line
-          my %direct;
-          $direct{STABLE_ID} = $extra[0];
-          $direct{ENSEMBL_TYPE} = 'Translation';
-          $direct{LINKAGE_TYPE} = 'DIRECT';
-          if ($xref->{SOURCE_ID} == $sp_source_id) {
-            $direct{SOURCE_ID} = $sp_direct_source_id;
-            $num_direct_sp++;
-          } else {
-            $direct{SOURCE_ID} = $sptr_direct_source_id;
-            $num_direct_sptr++;
-          }
-          push @{$xref->{DIRECT_XREFS}}, \%direct;
-        }
-	   if (exists $dependent_sources{$source} ) {
-	  # create dependent xref structure & store it
-	  my %dep;
-          $dep{SOURCE_NAME} = $source;
-          $dep{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-          $dep{SOURCE_ID} = $dependent_sources{$source};
-
-	  if($source =~ /HGNC/){
-	    $acc =~ s/HGNC://;
-	    $extra[0] =~ s/[.]//;
-	    $dep{LABEL} = $extra[0];
-	  }
-	  $dep{ACCESSION} = $acc;
-
-#	  $dep{ACCESSION} = $acc;
-	  $dependent_xrefs{ $dep{SOURCE_NAME} }++; # get count of depenent xrefs.
-	  if(!defined($seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}})){
-	    push @{$xref->{DEPENDENT_XREFS}}, \%dep; # array of hashrefs
-	    $seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}} =1;
-	  }
-	  if($dep =~ /EMBL/ && !($dep =~ /ChEMBL/)){
-	    my ($protein_id) = $extra[0];
-	    if(($protein_id ne "-") and (!defined($seen{$source.":".$protein_id}))){
-	      my %dep2;
-	      $dep2{SOURCE_NAME} = $source;
-	      $dep2{SOURCE_ID} = $dependent_sources{"protein_id"};
-	      $dep2{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-	      # store accession unversioned
-	      $dep2{LABEL} = $protein_id;
-	      my ($prot_acc, $prot_version) = $protein_id =~ /([^.]+)\.([^.]+)/;
-	      $dep2{ACCESSION} = $prot_acc;
-	      $dependent_xrefs{ $dep2{SOURCE_NAME} }++; # get count of dependent xrefs.
-	      $seen{$source.":".$protein_id} = 1;
-	      push @{$xref->{DEPENDENT_XREFS}}, \%dep2; # array of hashrefs
-	    }
-	  }
-	}
-      }
-    }
-
-    push @xrefs, $xref;
-
-    if ($count > 1000) {
-      $self->upload_xref_object_graphs(\@xrefs, $dbi);
-      $count = 0;
-      undef @xrefs;
-    }
+    $loader->load( $transformed_data );
 
   }
 
-  $self->upload_xref_object_graphs(\@xrefs, $dbi) if scalar(@xrefs) > 0;
+  $loader->flush();
+  $extractor->close_input();
 
-  $uniprot_io->close();
-
-  print "Read $num_sp SwissProt xrefs, $num_sptr SPTrEMBL xrefs with protein evidence codes 1-2, and $num_sptr_non_display SPTrEMBL xrefs with protein evidence codes > 2 from $file\n" if($verbose);
-  print "Added $num_direct_sp direct SwissProt xrefs and $num_direct_sptr direct SPTrEMBL xrefs\n" if ($verbose);
-  print "Found $num_sp_pred predicted SwissProt xrefs and $num_sptr_pred predicted SPTrEMBL xrefs\n" if (($num_sp_pred > 0 || $num_sptr_pred > 0) and $verbose);
-  print "Skipped $ensembl_derived_protein_count ensembl annotations as Gene names\n";
-
-
-#  print "$kount gene anmes added\n";
-
-  print "Added the following dependent xrefs:-\n" if($verbose);
-  foreach my $key (keys %dependent_xrefs){
-    print $key."\t".$dependent_xrefs{$key}."\n" if($verbose);
+  # Extract release numbers from the release file, if provided
+  if ( defined $release_file ) {
+    my $release_numbers = $self->_get_release_numbers_from_file( $release_file,
+                                                                 $verbose );
+    $self->_set_release_numbers_on_uniprot_sources( $source_id_map,
+                                                    $release_numbers,
+                                                    $dbh );
   }
-  print "End.\n" if ($verbose);
 
-  #TODO - currently include records from other species - filter on OX line??
+  return 0;
 }
 
-sub get_name {
-  my $self = shift;
-  my $acc  = shift;
-  my $label = shift;
 
-  return $acc;
+# Extract Swiss-Prot and TrEMBL release info from the release file
+# Note: the only reason for this to be a method rather than a
+# standalone function is that it uses BaseParser::get_filehandle().
+sub _get_release_numbers_from_file {
+  my ( $self, $release_file_name, $verbose ) = @_;
+
+  my $release_io = $self->get_filehandle( $release_file_name );
+  my $release_numbers = {};
+
+  while ( my $line = $release_io->getline() ) {
+    my ( $section, $release )
+      = ( $line =~ m{
+                      \A
+                      UniProtKB/
+                      (
+                        Swiss-Prot
+                      |
+                        TrEMBL
+                      )
+                      \s+
+                      Release
+                      \s+
+                      ( [^\n]+ )
+                  }msx );
+    if ( defined $section ) {
+      $release_numbers->{ $source_name_for_section{$section} } = $release;
+      if ( $verbose ) {
+        print "$section release is '$release'\n";
+      }
+    }
+  }
+
+  $release_io->close();
+
+  return $release_numbers;
 }
+
+sub _set_release_numbers_on_uniprot_sources {
+  my ( $self, $source_id_map, $release_numbers, $dbh ) = @_;
+
+  foreach my $source ( keys %{ $source_id_map } ) {
+    # Priority names are not important here, we only need source IDs
+    foreach my $source_id ( values %{ $source_id_map->{$source} } ) {
+      $self->set_release( $source_id, $release_numbers->{$source}, $dbh );
+    }
+  }
+
+  return;
+}
+
 1;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -64,13 +64,16 @@ sub run {
   }
 
   my $extractor = XrefParser::UniProtParser::Extractor->new({
+    'baseParser' => $self,
     'file_names' => $files,
   });
   my $transformer = XrefParser::UniProtParser::Transformer->new({
+    'baseParser' => $self,
     'dbh'        => $dbh,
     'species_id' => $species_id,
   });
   my $loader = XrefParser::UniProtParser::Loader->new({
+    'baseParser' => $self,
     'batch_size' => $loader_batch_size,
     'dbh'        => $dbh,
   });

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -78,13 +78,23 @@ sub run {
     'dbh'        => $dbh,
   });
 
+  # Generate a map of existing dependent-xref links, which will be
+  # used to prevent insertion of duplicates
   my $source_id_map = $transformer->get_source_id_map();
-  if ( $verbose ) {
-    while ( my ( $section, $pri_ref ) = each %{ $source_id_map } ) {
-      while ( my ( $priority, $source_id ) = each %{ $pri_ref } ) {
-        # FIXME: do we really care about the file name here?
+  while ( my ( $section, $pri_ref ) = each %{ $source_id_map } ) {
+    while ( my ( $priority, $source_id ) = each %{ $pri_ref } ) {
+
+      if ( $priority ne 'direct' ) {
+        # Ugly but hopefully temporary
+        $loader->baseParserInstance()->get_dependent_mappings( $source_id, $dbh );
+      }
+
+      # Seeing as we are already looping over all sources.
+      # FIXME: do we really care about the file name here?
+      if ( $verbose ) {
         print "$section $priority source id for $files->[0]: $source_id\n";
       }
+
     }
   }
 

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-See the NOTICE file distributed with this work for additional
-information regarding copyright ownership.
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -28,7 +28,6 @@ use warnings;
 require 5.014_000;
 
 use Carp;
-use IO::File;
 use List::Util;
 use Readonly;
 use charnames ':full';
@@ -72,11 +71,13 @@ Readonly my %supported_taxon_database_qualifiers
 sub new {
   my ( $proto, $arg_ref ) = @_;
   my $file_names = $arg_ref->{'file_names'};
+  my $baseParserInstance = $arg_ref->{'baseParser'};
 
   my $filename = $file_names->[0];
-  # FIXME: should use baseParserInstance::get_filehandle() instead, as
-  # it is this e.g. won't work on compressed files
-  my $filehandle = IO::File->new($filename, '<') || croak 'fopen failed';
+  my $filehandle = $baseParserInstance->get_filehandle( $filename );
+  if ( !defined $filehandle ) {
+    croak "Failed to acquire a file handle for '${filename}'";
+  }
 
   # Keep the file name for possible debugging purposes, unless we can
   # somehow retrieve it from _io_handle

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -1,0 +1,644 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional
+information regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package XrefParser::UniProtParser::Extractor;
+
+use strict;
+use warnings;
+
+# For non-destructive substitutions in regexps (/r flag)
+require 5.014_000;
+
+use Carp;
+use IO::File;
+use List::Util;
+use Readonly;
+use charnames ':full';
+
+
+# Note that care must be taken when adding new prefixes to this list
+# because some of them - for instance the Rx family of fields,
+# describing publications - are not compatible with the current way of
+# processing.
+# Syntax: 1 is mandatory field, 0 - an optional one
+Readonly my %prefixes_of_interest
+  => (
+      'ID'  => 1,
+      'AC'  => 1,
+      'DE'  => 1,
+      'GN'  => 0,
+      'OX'  => 1,
+      'CC'  => 0,
+      'DR'  => 1,
+      'PE'  => 1,
+      'SQ'  => 1,
+      q{  } => 1,
+    );
+
+# FIXME: this should probably be combined with
+# Transformer::%taxonomy_ids_from_taxdb_codes to make sure
+# database qualifiers stay in sync
+Readonly my %supported_taxon_database_qualifiers
+  => (
+      'NCBI_TaxID' => 1,
+    );
+
+
+
+# FIXME: at the moment the extractor only handles one input file at a
+# time for backwards compatibility with the old UniProtParser, that
+# said there is no reason for it not to be able to handle multiple
+# files. Should we want to support this, we should stop opening the
+# filehandle in the constructor because it would no longer be a fixed
+# property of the object.
+sub new {
+  my ( $proto, $arg_ref ) = @_;
+  my $file_names = $arg_ref->{'file_names'};
+
+  my $filename = $file_names->[0];
+  # FIXME: should use baseParserInstance::get_filehandle() instead, as
+  # it is this e.g. won't work on compressed files
+  my $filehandle = IO::File->new($filename, '<') || croak 'fopen failed';
+
+  # Keep the file name for possible debugging purposes, unless we can
+  # somehow retrieve it from _io_handle
+  my $self = {
+              'input_name' => $filename,
+              '_io_handle' => $filehandle,
+            };
+  my $class = ref $proto || $proto;
+  bless $self, $class;
+  return $self;
+}
+
+
+sub close_input {
+  my ( $self ) = @_;
+
+  $self->{'_io_handle'}->close();
+
+  return;
+}
+
+
+sub extract {
+  my ( $self ) = @_;
+
+  $self->_record_has_all_needed_fields();
+
+  my $entry_object
+    = {
+       'accession_numbers' => $self->_get_accession_numbers(),
+       'comments'          => $self->_get_comments(),
+       'crossreferences'   => $self->_get_database_crossreferences(),
+       'description'       => $self->_get_description(),
+       'gene_names'        => $self->_get_gene_names(),
+       'quality'           => $self->_get_quality(),
+       'sequence'          => $self->_get_sequence(),
+       'taxon_codes'       => $self->_get_taxon_codes(),
+     };
+
+  return $entry_object;
+}
+
+
+sub get_uniprot_record {
+  my ( $self ) = @_;
+
+  my $io = $self->{'_io_handle'};
+  my $uniprot_record = {};
+
+ INPUT_LINE:
+  while ( my $file_line = $io->getline() ) {
+    chomp $file_line;
+
+    my ( $prefix, $content )
+      = ( $file_line =~ m{ \A
+                           ([A-Z /]{2})  # prefix
+                           (?:
+                             \s{3}       # leading spaces are important in e.g. DE, FT
+                             (.+)        # content
+                           )?            # end-of-record line will not have any of this
+                           \z
+                       }msx );
+    if ( ! defined $prefix ) {
+      croak 'Malformed prefix';
+    }
+
+    if ( $prefix eq q{//} ) {
+      # End of record, return what we have got so far
+      $self->{'record'} = $uniprot_record;
+      return 1;
+    }
+
+    # Do not waste time and memory on fields we do not need
+    if ( ! exists $prefixes_of_interest{$prefix} ) {
+      next INPUT_LINE;
+    }
+
+    if ( ! exists $uniprot_record->{$prefix} ) {
+      $uniprot_record->{$prefix} = [];
+    }
+    push @{ $uniprot_record->{$prefix} }, $content;
+
+  }
+
+  # If we began parsing fields but have never reached the //,
+  # something is very wrong
+  if ( scalar keys %{ $uniprot_record } > 0 ) {
+    croak "Incomplete input record";
+  }
+
+  # EOF
+  return 0;
+}
+
+
+
+# Parse the AC fields of the current record and produce a list of
+# UniProt accession numbers. The list will reflect the order in which
+# accession numbers appeared in the record, which as of October 2018
+# is: primary accession number first, then all the secondary ones in
+# alphanumerical order.
+sub _get_accession_numbers {
+  my ( $self ) = @_;
+
+  my $ac_fields = $self->{'record'}->{'AC'};
+  my @numbers
+    = split( qr{\s* ; \s*}msx, join( q{}, @{ $ac_fields } ) );
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+
+  return \@numbers;
+}
+
+
+# Parse the CC fields of the current record and produce a hash mapping
+# comments to their respective topics. Optionally, the returned data
+# can be restricted to specific topics.
+sub _get_comments {
+  my ( $self, @topics_to_return ) = @_;
+
+  my $cc_fields = $self->{'record'}->{'CC'};
+
+  # CC is an optional field
+  if ( ! defined $cc_fields ) {
+    return {};
+  }
+
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+  my %comments_by_topic;
+
+  # FIXME: get rid of extra whitespace from the beginning of
+  # continuation lines
+  my @topic_lines = split( qr{\s* -!- \s*}msx,
+                           join( q{ }, @{ $cc_fields } )
+                        );
+  foreach my $line ( @topic_lines ) {
+
+    my ($topic, $content)
+      = ( $line =~ m{
+                      \A
+
+                      # Topic name: one or more words in ALL CAPS
+                      ( [A-Z ]+ )
+
+                      # Separator
+                      \s*
+                      :
+                      \s*
+
+                      # Everything else is content
+                      ( .+ )
+                  }msx );
+
+    # This will bypass the first empty line of @topic_lines
+    if ( defined $topic ) {
+      # FIXME: can a record have multiple entries with the same topic???
+      $comments_by_topic{$topic} = $content;
+    }
+  }
+
+  # If we haven't been asked for specific topics, return all comments.
+  if ( scalar @topics_to_return == 0 ) {
+    return \%comments_by_topic;
+  }
+
+  my %comments_of_interest;
+  foreach my $topic ( @topics_to_return ) {
+    $comments_of_interest{$topic} = $comments_by_topic{$topic};
+  }
+  return \%comments_of_interest;
+}
+
+
+# Parse the DR fields of the current record, break them into
+# constituent parts and produce a list (or to be precise, a hash of
+# arrayrefs) of database cross-references grouped by reference.
+sub _get_database_crossreferences {
+  my ( $self ) = @_;
+
+  # Use named sequences for square brackets to avoid excessive
+  # escaping as well as for better readability.
+  Readonly my $isoform_field_pattern
+    => qr{
+           \s*
+           \N{LEFT SQUARE BRACKET}
+           \s*
+           ( [^\N{RIGHT SQUARE BRACKET}]+ )
+           \s*
+           \N{RIGHT SQUARE BRACKET}
+           \s*
+       }msx;
+
+  my $dr_fields = $self->{'record'}->{'DR'};
+
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+  my $crossreferences = {};
+
+  foreach my $dr_line ( @{ $dr_fields } ) {
+    my ( $res_abbrev, $res_id, @opts ) = split( qr{ ;\s* }msx, $dr_line);
+
+    my ( $last_opt, $isoform )
+      = ( $opts[-1] =~ m{
+                          ( .+ )  # will grab all dots but the last one
+                          [.]
+                          (?:
+                            $isoform_field_pattern
+                          )?
+                          \z
+                      }msx );
+    if ( ! defined $last_opt ) {
+      croak "Mailformed final-option match in:\n\t$dr_line";
+    }
+
+    # At the very least, strips the trailing dot
+    $opts[-1] = $last_opt;
+
+    my $crossref
+      = {
+         'id'            => $res_id,
+         'optional_info' => \@opts,
+       };
+    if ( defined $isoform ) {
+      $crossref->{'target_isoform'} = $isoform;
+    }
+
+    # There CAN be multiple cross-references to a database
+    push @{ $crossreferences->{$res_abbrev} }, $crossref;
+  }
+
+  return $crossreferences;
+}
+
+
+# Parse the DE fields of the current record and produce a description
+# string compatible with the output of the old UniProtParser, namely:
+#  - the description begins with a semicolon-separated list of
+#    top-level names (i.e. ones not belonging to a Contains or
+#    Includes section), in the order they appear in the record;
+#  - this list is followed by a space and a space-separated list of
+#    names from Contains and Includes sections, again in the order
+#    they appear in the record;
+#  - we process both RecNames and SubNames, and both types are
+#    considered of equal priority (i.e. ultimately it is their order
+#    that matters);
+#  - in either case we only consider full names;
+#  - evidence codes, PubMed references etc. are discarded.
+# Note that unlike most field parsers implemented so far, this one
+# does NOT attempt to fully process the syntax of DE fields; this is
+# in order to avoid messing with whitespace-defined context only to
+# discard most of the field data anyway. Keep this in mind should you
+# want to extend the parsing to e.g. extract EC numbers, in which case
+# you will likely have to implement a full parser.
+sub _get_description {
+  my ( $self ) = @_;
+
+  my $de_fields = $self->{'record'}->{'DE'};
+
+  Readonly my $description_name_value
+    => qr{
+           ( [^;\N{LEFT CURLY BRACKET}]+ )
+           # FIXME: the match will fail if there is no
+           # whitespace before the left curly bracket
+           (?: ; | \s+\N{LEFT CURLY BRACKET} )
+       }msx;
+
+  my @names;
+  my @subdescs;
+
+  foreach my $line ( @{ $de_fields } ) {
+    my ( $indent, $content )
+      = ( $line =~ m{
+                      \A
+                      ( \s* )  # FIXME: explain
+                      (?:
+                        RecName | SubName
+                      )
+                      :
+                      \s*
+                      Full=
+                      $description_name_value
+                  }msx );
+    if ( defined $indent ) {
+      if ( $indent eq q{} ) {
+        push @names, $content;
+      }
+      else {
+        push @subdescs, $content;
+      }
+    }
+  }
+
+  my $description
+    = join( q{ }, (
+                   join( q{;}, @names ),
+                   @subdescs
+                 ) );
+  # Make sure we do not return an empty string
+  return ( length( $description ) > 0 ) ? $description : undef;
+}
+
+
+# Parse the GN fields of the current record and produce a structured
+# list of names of genes coding the protein sequence in question.
+sub _get_gene_names {
+  my ( $self ) = @_;
+
+  my $gn_fields = $self->{'record'}->{'GN'};
+
+  # GN is an optional field
+  if ( ! defined $gn_fields ) {
+    return [];
+  }
+
+  my @gn_text_entries;
+
+  # Gene-name entries can span multiple GN names but we cannot simply
+  # concatenate them all because there can be multiple gene names per
+  # record. In order to merge data correctly we must look for the
+  # name-separator line.
+  my $current_entry = q{};
+  foreach my $line ( @{ $gn_fields } ) {
+    # This is what the separator line looks like
+    if ( $line eq 'and' ) {
+      push @gn_text_entries, $current_entry;
+      $current_entry = q{};
+    }
+    else {
+      # No need for extra spaces here
+      $current_entry .= $line;
+    }
+  }
+  # Make sure the last entry makes it in as well
+  push @gn_text_entries, $current_entry;
+
+  my $gene_names = [];
+  foreach my $entry ( @gn_text_entries ) {
+    my $parsed_entry = {};
+
+    my @entry_captures = ( $entry =~ m{
+                                        \s*
+                                        ( [^=]+ )
+                                        \s*
+                                        =
+                                        \s*
+                                        ( [^;]+ )
+                                        \s*
+                                        ;
+                                    }gmsx );
+
+    while ( my ( $key, $value ) = splice( @entry_captures, 0, 2 ) ) {
+      my @split_value = split( qr{ \s*,\s* }msx, $value );
+
+      $parsed_entry->{$key}
+        = ( $key eq 'Name' ) ? $value : \@split_value;
+    }
+
+    # UniProt-KB User Manual states a "Synonyms" token can only be
+    # present if there is a "Name" token.
+    if ( ( exists $parsed_entry->{'Synonyms'} )
+         && ( ! exists $parsed_entry->{'Name'} ) ) {
+      croak "Malformed input: found 'Synonyms' but no 'Name' in:\n\t$entry";
+    }
+
+    push @{ $gene_names }, $parsed_entry;
+  }
+
+  return $gene_names;
+}
+
+
+# Obtain quality information for the current record. This consists of
+# two parts: status (i.e. whether the entry has been reviewed or not)
+# from the ID line and evidence level from the PE line.
+sub _get_quality {
+  my ( $self ) = @_;
+
+  Readonly my $id_status_field
+    => qr{
+           (?: Unreviewed )
+         | (?: Reviewed )
+       }msx;
+
+  # These is only one ID line
+  my $id_line = $self->{'record'}->{'ID'}->[0];
+  my ( $entry_status )
+    = ( $id_line =~ m{
+                       \A
+
+                       # UniProt name
+                       [0-9A-Z_]+
+
+                       \s+
+
+                       ( $id_status_field )
+                       \s*
+                       ;
+                   }msx );
+  if ( ! defined $entry_status ) {
+    croak "Invalid entry status in:\n\t$id_line";
+  }
+
+  # Likewise, these is only one PE line
+  my $pe_line = $self->{'record'}->{'PE'}->[0];
+  my ( $evidence_level )
+    = ( $pe_line =~ m{
+                       \A
+
+                       ( [1-4] )
+                       \s*
+                       :
+                   }msx );
+  if ( ! defined $evidence_level ) {
+    croak "Invalid protein evidence level in:\n\t$pe_line";
+  }
+
+  return {
+          'status'         => $entry_status,
+          'evidence_level' => $evidence_level,
+        };
+}
+
+
+# Parse the sequence ('  ') fields of the current record and produce
+# its polypeptide sequence. as a continuous string i.e. without
+# decorative whitespace.
+sub _get_sequence {
+  my ( $self ) = @_;
+
+  my $sequence_fields = $self->{'record'}->{ q{  } };
+
+  # Concatenate the sequence into a single continuous string. We do
+  # not expect to see more than whitespace at a time so instead of
+  # trying to match as long a string of them as possible in order to
+  # minimise the number of independent substitutions, we always match
+  # on one in order to avoid unnecessary backtracking.
+  # Note that we use non-destructive substitution.
+  my $sequence = ( join( q{}, @{ $sequence_fields } ) =~ s{ \s }{}grmsx );
+
+  # We could in principle directly return substitution result but then
+  # we would have to make sure we always call get_sequence() in scalar
+  # context. Safer to simply return a scalar instead.
+  return $sequence;
+}
+
+
+
+# Parse the OX field of the current record and produce a list of
+# database_qualifier/taxon_code pairs.
+sub _get_taxon_codes {
+  my ( $self ) = @_;
+
+  # There is only one OX line
+  my $ox_line = $self->{'record'}->{'OX'}->[0];
+
+  # On the one hand, according to UniProt-KB User Manual from October
+  # 2018 there should only be a single taxon code per OX line and the
+  # current SwissProt data file doesn't contain any records which
+  # violate this. On the other hand we haven't checked this in the
+  # TrEMBL file because of its size and the old UniProtParser did have
+  # support for synonyms (albeit using different syntax -
+  # "db=id1, id2, ...;" rather than "db1=id1; db2=id2; ...").
+  # The code below assumes there might be multiple entries present, if
+  # you want to force it to only ever look for one simply drop the /g
+  # modifier from the regex match.
+
+  Readonly my $taxon_db_entry
+    => qr{
+           # Database qualifier. Chances are the list of
+           # allowed characters will change should DBs
+           # other than NCBI ever become supported here.
+           ( [A-Za-z_]+ )
+
+           \s*  # just in case
+           =
+           \s*  # same
+
+           # Taxon ID. This is almost certainly NCBI-specific.
+           ( [0-9]+ )
+       }msx;
+  Readonly my $evidence_code_list
+    => qr{
+           # As of October 2018, this syntax is not declared in
+           # UniProt-KB User Manual yet frequently encountered in data
+           # files.  Use named sequences for curly brackets to avoid
+           # excessive escaping as well as for better readability.
+           \N{LEFT CURLY BRACKET}
+           \s*
+           [^\N{RIGHT CURLY BRACKET}]+
+           \s*
+           \N{RIGHT CURLY BRACKET}
+           \s*
+       }msx;
+  my @ox_captures
+    = ( $ox_line =~ m{
+                       $taxon_db_entry
+                       \s*
+
+                       # Optional things (e.g. evidence codes) we do
+                       # not need now but must parse on the off chance
+                       # someone decides e.g. that curly braces
+                       # constitute quotes so it is okay to have a
+                       # semicolon between them
+                       (?:
+                         $evidence_code_list
+                         | [^;]+
+                       )?
+
+                       # End of record
+                       ;
+                   }gmsx );
+
+  my @extracted_taxon_codes;
+
+  # Reminder: if you change the number of capture groups above
+  # remember to adapt both the variable list *and* the third argument
+  # to splice().
+ TAXON_ENTRY:
+  while ( my ( $db_qualifier, $taxon_code ) = splice( @ox_captures, 0, 2 ) ) {
+
+    if ( ( ! defined $db_qualifier )
+         || ( ! exists $supported_taxon_database_qualifiers{$db_qualifier} ) ) {
+      # Abort on malformed or new database qualifiers
+      croak "Cannot use taxon-DB qualifier '${db_qualifier}'";
+    }
+    elsif ( ! $supported_taxon_database_qualifiers{$db_qualifier} ) {
+      # Known but of no interest. Ignore it.
+      next TAXON_ENTRY;
+    }
+
+    if ( ! defined $taxon_code ) {
+      croak "Failed to extract taxon code from:\n\t${ox_line}";
+    }
+
+    # FIXME: further processing?
+
+    push @extracted_taxon_codes, {
+                                  'db_qualifier' => $db_qualifier,
+                                  'taxon_code'     => $taxon_code,
+                                };
+
+  }
+
+  return \@extracted_taxon_codes;
+}
+
+
+sub _record_has_all_needed_fields {
+  my ( $self ) = @_;
+
+  # Only check mandatory fields
+  my @needed_fields = grep { $prefixes_of_interest{$_} } %prefixes_of_interest;
+
+  my $has_all
+    = List::Util::all { exists $self->{'record'}->{$_} } @needed_fields;
+  if ( ! $has_all ) {
+    croak 'One or more required fields missing in record';
+ }
+
+  return;
+}
+
+
+1;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -121,7 +121,6 @@ Readonly my %prefixes_of_interest
       'DE'  => 1,
       'GN'  => 0,
       'OX'  => 1,
-      'CC'  => 0,
       'DR'  => 1,
       'PE'  => 1,
       'RG'  => 0,
@@ -186,7 +185,6 @@ sub extract {
     = {
        'accession_numbers' => $self->_get_accession_numbers(),
        'citation_groups'   => $self->_get_citation_groups(),
-       'comments'          => $self->_get_comments(),
        'crossreferences'   => $self->_get_database_crossreferences(),
        'description'       => $self->_get_description(),
        'gene_names'        => $self->_get_gene_names(),
@@ -299,6 +297,9 @@ sub _get_citation_groups {
 # Parse the CC fields of the current record and produce a hash mapping
 # comments to their respective topics. Optionally, the returned data
 # can be restricted to specific topics.
+# FIXME: not used at present, which could result in it no longer
+# working by the time it has been reenabled. Either ensure it is
+# tested or remove it.
 sub _get_comments {
   my ( $self, @topics_to_return ) = @_;
 

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -514,7 +514,7 @@ sub _get_gene_names {
 sub _get_quality {
   my ( $self ) = @_;
 
-  # These is only one ID line
+  # There is only one ID line
   my $id_line = $self->{'record'}->{'ID'}->[0];
   my ( $entry_status )
     = ( $id_line =~ m{
@@ -533,7 +533,7 @@ sub _get_quality {
     croak "Invalid entry status in:\n\t$id_line";
   }
 
-  # Likewise, these is only one PE line
+  # Likewise, there is only one PE line
   my $pe_line = $self->{'record'}->{'PE'}->[0];
   my ( $evidence_level )
     = ( $pe_line =~ m{

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -124,6 +124,7 @@ Readonly my %prefixes_of_interest
       'CC'  => 0,
       'DR'  => 1,
       'PE'  => 1,
+      'RG'  => 0,
       'SQ'  => 1,
       q{  } => 1,
     );
@@ -184,6 +185,7 @@ sub extract {
   my $entry_object
     = {
        'accession_numbers' => $self->_get_accession_numbers(),
+       'citation_groups'   => $self->_get_citation_groups(),
        'comments'          => $self->_get_comments(),
        'crossreferences'   => $self->_get_database_crossreferences(),
        'description'       => $self->_get_description(),
@@ -265,6 +267,32 @@ sub _get_accession_numbers {
   # been loaded
 
   return \@numbers;
+}
+
+
+# Parse the RG fields of the current record, if any, and produce a
+# list of names of groups which cite this protein.
+# Warning: this is intentionally simplistic (for example it makes no
+# attempt to associate group names for specific reference numbers) and
+# will NOT work properly if more detailed citation information is
+# required! If you need that, you will have to implement comprehensive
+# processing of different Rx lines.
+sub _get_citation_groups {
+  my ( $self ) = @_;
+
+  my $rg_fields = $self->{'record'}->{'RG'};
+
+  # RG is an optional field
+  if ( ! defined $rg_fields ) {
+    return [];
+  }
+
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+  my @citation_groups = split( qr{ \s*;\s* }msx,
+                               join( q{}, @{ $rg_fields } ) );
+
+  return \@citation_groups;
 }
 
 

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-See the NOTICE file distributed with this work for additional
-information regarding copyright ownership.
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -412,7 +412,10 @@ sub _get_description {
                    @subdescs
                  ) );
   # Make sure we do not return an empty string
-  return ( length( $description ) > 0 ) ? $description : undef;
+  if ( length( $description ) > 0 ) {
+    return $description;
+  }
+  return;
 }
 
 

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -290,7 +290,7 @@ sub _get_database_crossreferences {
                           \z
                       }msx );
     if ( ! defined $last_opt ) {
-      croak "Mailformed final-option match in:\n\t$dr_line";
+      croak "Malformed final-option match in:\n\t$dr_line";
     }
 
     # At the very least, strips the trailing dot

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -121,7 +121,7 @@ Readonly my %prefixes_of_interest
       'DE'  => 1,
       'GN'  => 0,
       'OX'  => 1,
-      'DR'  => 1,
+      'DR'  => 0,
       'PE'  => 1,
       'RG'  => 0,
       'SQ'  => 1,
@@ -364,6 +364,11 @@ sub _get_database_crossreferences {
   my ( $self ) = @_;
 
   my $dr_fields = $self->{'record'}->{'DR'};
+
+  # DR is an optional field
+  if ( ! defined $dr_fields ) {
+    return [];
+  }
 
   # FIXME: we should probably make this persist until a new record has
   # been loaded

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -635,7 +635,8 @@ sub _record_has_all_needed_fields {
   my ( $self ) = @_;
 
   # Only check mandatory fields
-  my @needed_fields = grep { $prefixes_of_interest{$_} } %prefixes_of_interest;
+  my @needed_fields
+    = grep { $prefixes_of_interest{$_} } keys %prefixes_of_interest;
 
   my $has_all
     = List::Util::all { exists $self->{'record'}->{$_} } @needed_fields;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Extractor.pm
@@ -33,6 +33,9 @@ use Readonly;
 use charnames ':full';
 
 
+# While processing DR fields i.e. crossreferences, used to match the
+# syntax attaching a crossreference to a specific isoform. Declares
+# ONE capture group, the isoform identifier.
 # Use named sequences for square brackets to avoid excessive
 # escaping as well as for better readability.
 Readonly my $QR_DR_ISOFORM_FIELD_PATTERN
@@ -46,6 +49,12 @@ Readonly my $QR_DR_ISOFORM_FIELD_PATTERN
          \s*
      }msx;
 
+# While processing DE fields i.e. descriptions, used to separate the
+# value part of key-value pairs those fields contain from evidence
+# codes, PubMed references etc. which might optionally
+# follow. Declares ONE capture group, the value.
+# Use named sequences for curly brackets to avoid excessive
+# escaping as well as for better readability.
 Readonly my $QR_DE_DESCRIPTION_NAME_VALUE
   => qr{
          ( [^;\N{LEFT CURLY BRACKET}]+ )
@@ -54,12 +63,17 @@ Readonly my $QR_DE_DESCRIPTION_NAME_VALUE
          (?: ; | \s+\N{LEFT CURLY BRACKET} )
      }msx;
 
+# While processing ID fields, used to confirm that the status of an
+# entry matches an expected value. Declares NO capture groups.
 Readonly my $QR_ID_STATUS_FIELD
   => qr{
          (?: Unreviewed )
        | (?: Reviewed )
      }msx;
 
+# While processing OX fields i.e. taxonomy cross-references, used to
+# extract both the taxon code and the database qualifier. Declares TWO
+# capture groups: the database qualifier, and the taxonomic code.
 Readonly my $QR_OX_TAXON_DB_ENTRY
   => qr{
          # Database qualifier. Chances are the list of
@@ -75,12 +89,14 @@ Readonly my $QR_OX_TAXON_DB_ENTRY
          ( [0-9]+ )
      }msx;
 
+# While processing OX fields i.e. taxonomy cross-references, allows
+# accounting for the fact some cross-references might be followed by
+# evidence codes. As of October 2018, this syntax is not declared in
+# UniProt-KB User Manual yet frequently encountered in data files.
+# Use named sequences for curly brackets to avoid excessive escaping
+# as well as for better readability.
 Readonly my $QR_OX_EVIDENCE_CODE_LIST
   => qr{
-         # As of October 2018, this syntax is not declared in
-         # UniProt-KB User Manual yet frequently encountered in data
-         # files.  Use named sequences for curly brackets to avoid
-         # excessive escaping as well as for better readability.
          \N{LEFT CURLY BRACKET}
          \s*
          [^\N{RIGHT CURLY BRACKET}]+
@@ -89,6 +105,10 @@ Readonly my $QR_OX_EVIDENCE_CODE_LIST
          \s*
      }msx;
 
+# To save memory and processing time, when we process a record we only
+# load into memory the fields we need. Conversely, the same list can
+# later on be used that we have indeed encountered all the mandatory
+# fields.
 # Note that care must be taken when adding new prefixes to this list
 # because some of them - for instance the Rx family of fields,
 # describing publications - are not compatible with the current way of

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
@@ -26,10 +26,6 @@ use warnings;
 
 use Carp;
 
-# FIXME: for testing
-use Data::Dumper;
-
-
 
 sub new {
   my ( $proto, $arg_ref ) = @_;
@@ -37,6 +33,7 @@ sub new {
   my $self = {
               'batch_size'  => $arg_ref->{'batch_size'} // 1,
               'dbh'         => $arg_ref->{'dbh'},
+              '_baseParser' => $arg_ref->{'baseParser'},
             };
   my $class = ref $proto || $proto;
   bless $self, $class;
@@ -66,14 +63,17 @@ sub load {
 sub flush {
   my ( $self ) = @_;
 
-  # FIXME: call BaseParser::upload_xref_object_graphs($buffer, $dbh)
-  print "SENDING: " . Dumper( $self->{'send_buffer'} );
+  my $bp = $self->{'_baseParser'};
+
+  if ( ! $bp->upload_xref_object_graphs($self->{'send_buffer'},
+                                        $self->{'dbh'}) ) {
+    croak 'Failed to upload xref object graphs. Check for errors on STDOUT)';
+  }
 
   $self->_clear_send_buffer();
 
   return;
 }
-
 
 
 sub _add_to_send_buffer {
@@ -93,6 +93,7 @@ sub _add_to_send_buffer {
 
   return;
 }
+
 
 sub _clear_send_buffer {
   my ( $self ) = @_;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
@@ -1,0 +1,100 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional
+information regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package XrefParser::UniProtParser::Loader;
+
+use strict;
+use warnings;
+
+use Carp;
+
+# FIXME: for testing
+use Data::Dumper;
+
+
+
+sub new {
+  my ( $proto, $arg_ref ) = @_;
+
+  my $self = {
+              'batch_size'  => $arg_ref->{'batch_size'} // 1,
+              'dbh'         => $arg_ref->{'dbh'},
+            };
+  my $class = ref $proto || $proto;
+  bless $self, $class;
+  $self->_clear_send_buffer();
+
+  return $self;
+}
+
+
+sub load {
+  my ( $self, $transformed_data ) = @_;
+
+  if ( ! defined $transformed_data ) {
+    return;
+  }
+
+  # FIXME: pass $count from Transformer
+  $self->_add_to_send_buffer( $transformed_data );
+
+  if ( $self->{'send_backlog'} >= $self->{'batch_size'} ) {
+    $self->flush();
+  }
+
+  return;
+}
+
+
+sub flush {
+  my ( $self ) = @_;
+
+  # FIXME: call BaseParser::upload_xref_object_graphs($buffer, $dbh)
+  print "SENDING: " . Dumper( $self->{'send_buffer'} );
+
+  $self->_clear_send_buffer();
+
+  return;
+}
+
+
+
+sub _add_to_send_buffer {
+  my ( $self, $entry ) = @_;
+
+  push @{ $self->{'send_buffer'} }, $entry;
+  # FIXME: update the counter CORRECTLY
+  $self->{'send_backlog'}++;
+
+  return;
+}
+
+sub _clear_send_buffer {
+  my ( $self ) = @_;
+
+  $self->{'send_buffer'}  = [];
+  $self->{'send_backlog'} = 0;
+
+  return;
+}
+
+
+1;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
@@ -43,6 +43,14 @@ sub new {
 }
 
 
+sub DESTROY {
+  my ( $self ) = @_;
+
+  $self->flush();
+  return;
+}
+
+
 sub baseParserInstance {
   my ( $self ) = @_;
   return $self->{'_baseParser'};

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-See the NOTICE file distributed with this work for additional
-information regarding copyright ownership.
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Loader.pm
@@ -43,6 +43,12 @@ sub new {
 }
 
 
+sub baseParserInstance {
+  my ( $self ) = @_;
+  return $self->{'_baseParser'};
+}
+
+
 sub load {
   my ( $self, $transformed_data ) = @_;
 
@@ -63,7 +69,7 @@ sub load {
 sub flush {
   my ( $self ) = @_;
 
-  my $bp = $self->{'_baseParser'};
+  my $bp = $self->baseParserInstance();
 
   if ( ! $bp->upload_xref_object_graphs($self->{'send_buffer'},
                                         $self->{'dbh'}) ) {

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
@@ -1,0 +1,259 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional
+information regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package XrefParser::UniProtParser::Transformer;
+
+use strict;
+use warnings;
+
+use Carp;
+use Readonly;
+
+# FIXME: for testing
+use Data::Dumper;
+
+
+# FIXME: this should probably be combined with
+# Extractor::%supported_taxon_database_qualifiers to make sure
+# database qualifiers stay in sync
+Readonly my %taxonomy_ids_from_taxdb_codes
+  => {
+      # NCBI taxon codes and Ensembl taxonomy IDs are identical
+      'NCBI_TaxID' => sub { return $_[0]; },
+    };
+
+Readonly my %whitelisted_crossreference_sources
+  => (
+      'ChEMBL'  => 1,
+      'EMBL'    => 1,
+      'Ensembl' => 1,
+      'MEROPS'  => 1,
+      'PDB'     => 1,
+    );
+
+Readonly my $MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD => 2;
+Readonly my %source_selection_criteria_for_status
+  => (
+      'Reviewed'   => [ 'Uniprot/SWISSPROT',
+                        sub {
+                          return 'sequence_mapped';
+                        }, ],
+      'Unreviewed' => [ 'Uniprot/SPTREMBL', sub {
+                          my ( $level ) = @_;
+                          return ( $level <= $MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD ) ?
+                            'sequence_mapped' :
+                            "protein_evidence_gt_$MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD";
+                        }, ],
+    );
+
+
+
+sub new {
+  my ( $proto, $arg_ref ) = @_;
+
+  my $self = {
+              'dbh'        => $arg_ref->{'dbh'},
+              'species_id' => $arg_ref->{'species_id'},
+              'maps'       => {},
+            };
+  my $class = ref $proto || $proto;
+  bless $self, $class;
+
+  $self->_load_maps();
+
+  return $self;
+}
+
+
+# Transforms extracted record into form that can be consumed by
+# BaseParser::upload_xref_object_graphs().
+sub transform {
+  my ( $self, $extracted_record ) = @_;
+
+  $self->{'extracted_record'} = $extracted_record;
+
+  # Only proceed if at least one taxon code in the entry maps
+  # to a valid Ensembl species ID
+  if ( ! $self->_recognised_taxon_ids() ) {
+    return;
+  }
+
+  # Skip unreviewed entries
+  if ( $self->_entry_is_unreviewed() ) {
+    return;
+  }
+
+  my ( $accession, @synonyms )
+    = @{ $extracted_record->{'accession_numbers'} };
+
+  my $xref_graph_node
+    = {
+       'ACCESSION'     => $accession,
+       'DESCRIPTION'   => $extracted_record->{'description'},
+       'INFO_TYPE'     => 'SEQUENCE_MATCH',  # FIXME: is this always right?
+       'LABEL'         => $accession,
+       'SEQUENCE'      => $extracted_record->{'sequence'},
+       'SEQUENCE_TYPE' => 'peptide',
+       'SOURCE_ID'     => $self->_get_source_id(),
+       'SPECIES_ID'    => $self->{'species_id'},
+       'STATUS'        => 'experimental',     # FIXME: seems at least some TrEMBL entries should be 'predicted' instead
+       'SYNONYMS'      => \@synonyms,
+     };
+  # FIXME: still to be defined: DIRECT_XREFS, DEPENDENT_XREFS
+  # Remember not to add UniProt Gene Name dependent xrefs for proteins
+  # derived from Ensembl.
+
+  return $xref_graph_node;
+}
+
+
+# FIXME: description
+sub get_source_id_map {
+  my ( $self ) = @_;
+
+  # Just in case, even though we presently call _load_maps() in the
+  # constructor so it shouldn't be possible to call this method before
+  # maps have been loaded
+  if ( ! exists $self->{'maps'}->{'named_source_ids'} ) {
+    croak 'Source-ID map is missing';
+  }
+
+  return $self->{'maps'}->{'named_source_ids'};
+}
+
+
+# FIXME: at present these are ALL mock entries
+sub _load_maps {
+  my ( $self ) = @_;
+
+  # FIXME: $self->baseParserInstance->get_taxonomy_from_species_id( $species_id, $dbh );
+  my $mock_taxonomy_ids_for_species
+    = {
+       9606 => 1, ## no critic(ProhibitMagicNumbers)
+     };
+  $self->{'maps'}->{'taxonomy_ids_for_species'}
+    = $mock_taxonomy_ids_for_species;
+
+  # FIXME: $self->baseParserInstance->get_source_id_for_source_name( $name, $priority, $dbh );
+  my $mock_source_id_map
+    = {
+       'Uniprot/SWISSPROT'
+       => {
+           'direct'          => 138,
+           'sequence_mapped' => 139,
+         },
+       'Uniprot/SPTREMBL'
+       => {
+           'direct'            => 134,
+           "protein_evidence_gt_$MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD" => 136,
+           'sequence_mapped'   => 135,
+         },
+     };
+  $self->{'maps'}->{'named_source_ids'}
+    = $mock_source_id_map;
+
+  # FIXME: either abort on any loading failure or implement lazy loading
+
+  return;
+}
+
+
+# Returns true if the current record describes an entry derived from
+# Ensembl, false otherwise.
+sub _entry_is_from_ensembl {
+  my ( $self ) = @_;
+
+  # As of end of October 2018, the old parser's way of identifying
+  # proteins derived from Ensembl by searching for a comment topic
+  # "CAUTION" stating "The sequence shown here is derived from an
+  # Ensembl" no longer works because there seem to be no entries
+  # containing this string any more. Therefore, for the time being
+  # this test always returns false.
+
+  return 0;
+}
+
+
+# Returns true if the current record describes an entry tagged as
+# unreviewed, false otherwise.
+sub _entry_is_unreviewed {
+  my ( $self ) = @_;
+
+  # This is the way the old UniProtParser identified unreviewed
+  # entries. FIXME: is this still a thing? As of October 2018 there
+  # are NO such entries in either the first ~1000 lines of the TrEMBL
+  # file or anywhere in the SwissProt one.
+  my $accession_numbers = $self->{'extracted_record'}->{'accession_numbers'};
+  if ( lc( $accession_numbers->[0] ) eq 'unreviewed' ) {
+    return 1;
+  }
+
+  return 0;
+}
+
+
+# Translate quality of the extracted entry into the matching Ensembl
+# source_id.
+sub _get_source_id {
+  my ( $self ) = @_;
+
+  my $source_id_map = $self->{'maps'}->{'named_source_ids'};
+
+  my $entry_quality = $self->{'extracted_record'}->{'quality'};
+  my $criteria = $source_selection_criteria_for_status{ $entry_quality->{'status'} };
+  my $priority_mapper = $criteria->[1];
+
+  my ( $source_name, $priority )
+    = (
+       $criteria->[0],
+       $priority_mapper->( $entry_quality->{'evidence_level'} ),
+     );
+
+  return $source_id_map->{$source_name}->{$priority};
+}
+
+
+# Translate extracted taxon codes into Ensembl taxonomy IDs, then
+# return the number of taxons matching the species ID under
+# consideration.
+sub _recognised_taxon_ids {
+  my ( $self ) = @_;
+
+  my $taxon_codes = $self->{'extracted_record'}->{'taxon_codes'};
+  my $tid4s_map = $self->{'maps'}->{'taxonomy_ids_for_species'};
+
+  my @taxonomy_ids;
+  foreach my $taxon ( @{ $taxon_codes } ) {
+    my $code_mapper
+      = $taxonomy_ids_from_taxdb_codes{ $taxon->{'db_qualifier'} };
+    push @taxonomy_ids, $code_mapper->( $taxon->{'taxon_code'} );
+  }
+
+  my $recognised_taxonomy_ids = 0;
+  foreach my $taxonomy_id ( @taxonomy_ids ) {
+    $recognised_taxonomy_ids += ( exists $tid4s_map->{$taxonomy_id} );
+  }
+
+  return $recognised_taxonomy_ids;
+}
+
+
+1;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
@@ -92,7 +92,8 @@ sub transform {
 
   # Only proceed if at least one taxon code in the entry maps
   # to a valid Ensembl species ID
-  if ( ! $self->_recognised_taxon_ids() ) {
+  my $xref_multiplicity = $self->_recognised_taxon_ids();
+  if ( ! $xref_multiplicity ) {
     return;
   }
 
@@ -116,6 +117,7 @@ sub transform {
        'SPECIES_ID'    => $self->{'species_id'},
        'STATUS'        => 'experimental',     # FIXME: seems at least some TrEMBL entries should be 'predicted' instead
        'SYNONYMS'      => \@synonyms,
+       '_multiplicity' => $xref_multiplicity, # hint for Loader
      };
   # FIXME: still to be defined: DIRECT_XREFS, DEPENDENT_XREFS
   # Remember not to add UniProt Gene Name dependent xrefs for proteins

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
@@ -226,9 +226,9 @@ sub _entry_is_unreviewed {
 
 
 # Translate quality of the extracted entry into the matching Ensembl
-# source_id.
+# source_id, optionally with an override of priority.
 sub _get_source_id {
-  my ( $self ) = @_;
+  my ( $self, $priority_override ) = @_;
 
   my $source_id_map = $self->{'maps'}->{'named_source_ids'};
 
@@ -236,11 +236,9 @@ sub _get_source_id {
   my $criteria = $source_selection_criteria_for_status{ $entry_quality->{'status'} };
   my $priority_mapper = $criteria->[1];
 
-  my ( $source_name, $priority )
-    = (
-       $criteria->[0],
-       $priority_mapper->( $entry_quality->{'evidence_level'} ),
-     );
+  my $source_name = $criteria->[0];
+  my $priority = $priority_override
+    // $priority_mapper->( $entry_quality->{'evidence_level'} );
 
   return $source_id_map->{$source_name}->{$priority};
 }

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-See the NOTICE file distributed with this work for additional
-information regarding copyright ownership.
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
@@ -430,6 +430,19 @@ sub _make_links_from_gene_names {
     }
 
     push @genename_xrefs, $xref;
+
+    # Regardless of how many gene-name entries a protein might have in
+    # UniProt, we only want at most *one* such xref - there are bits
+    # of Ensembl code which implicitly assume there can only be one
+    # xref per unique (accerssion,source_id,species_id) triplet and
+    # Uniprot_gn is essentially a last-resort source for when nothing
+    # else works. At least we should be able to consistently output
+    # the first encountered gene name (and synonyms), the old parser
+    # happily ignored the fact there can be multiple gene names and
+    # clobbered old names and synonyms every time a new one was
+    # encountered - potentially resulting in xrefs with the last
+    # encountered name but synonyms from an earlier one.
+    last GN_ENTRY;
   }
 
   return \@genename_xrefs;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser/Transformer.pm
@@ -263,14 +263,24 @@ sub _load_maps {
 sub _entry_is_from_ensembl {
   my ( $self ) = @_;
 
-  # As of end of October 2018, the old parser's way of identifying
-  # proteins derived from Ensembl by searching for a comment topic
-  # "CAUTION" stating "The sequence shown here is derived from an
-  # Ensembl" no longer works because there seem to be no entries
-  # containing this string any more. Therefore, for the time being
-  # this test always returns false.
+  # The old parser's way of identifying proteins derived from Ensembl
+  # was to search for a comment topic "CAUTION" stating "The sequence
+  # shown here is derived from an Ensembl". It was confirmed with
+  # UniProt in November 2018 that this hadn't been done since late
+  # 2017, therefore we no longer check this.
 
-  return 0;
+  # As of November 2018, the official way of identifying proteins
+  # derived from Ensembl is to look for a special citation identifying
+  # the record as such. There are several ways in which such special
+  # citations could be identified, it seems the simplest to look at
+  # "reference group name" fields to see if any of them says
+  # 'Ensembl'.
+  my $citation_groups
+    = $self->{'extracted_record'}->{'citation_groups'};
+  my $from_group_names
+    = List::Util::any { $_ eq 'Ensembl' } @{ $citation_groups };
+
+  return $from_group_names;
 }
 
 

--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -184,7 +184,7 @@ my @recognised_sources = (
  "MEROPS; C26.956; -.",
 );
 for my $l (@recognised_sources) {
-  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR  $l/;
+  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR   $l/;
   test_parser("XrefParser::UniProtParser", $uniprot_elegans_record_extra_line,  {
     xref => 4,
     primary_xref => 1,

--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -40,6 +40,11 @@ $database->populate(
   "with force please",
 );
 
+
+# UniProt species taxon codes happen to match species ids of the core database
+my $SPECIES_ID = 6239;
+my $SPECIES_NAME = "Caenorhabditis elegans";
+
 my %xref_tables_expected_empty_by_default = (
   checksum_xref=>0,
   coordinate_xref=>0,
@@ -53,6 +58,7 @@ my %xref_tables_expected_empty_by_default = (
   translation_direct_xref=>0,
   xref=>0,
 );
+
 my $tmp_dir = tempdir(CLEANUP=>1);
 sub store_in_temporary_file {
   my ($content, %opts) = @_;
@@ -62,9 +68,7 @@ sub store_in_temporary_file {
   close($fh);
   return $path;
 }
-# Happens to match the species id of the core database
-my $SPECIES_ID = 1;
-my $SPECIES_NAME = "Homo sapiens";
+
 sub test_parser {
   my ($parser, $content, $expected, $test_name, %opts) = @_;
   require_ok($parser);


### PR DESCRIPTION
**Edited: DO NOT MERGE at this point, please see the "Testing" section below for details.**


## Description

The old UniProtParser is very complex, includes a lot of legacy code, contains several bugs (see _e.g._ ENSCORESW-2837) and would be difficult to adapt to follow the Extract-Transform-Load process of operation.

## Use case

UniProt-KB xrefs are a crucial component of every Ensembl release.

## Benefits

Hopefully cleaner, more modular and ETL-friendly code base which might be easier to transplant to the refactored xref pipeline or extend (_e.g._ to process XML rather than text dumps or to query the UniProt database directly) in the future.

## Possible Drawbacks

Differences in the output of the old and the new parser due to bug fixes, which will be fairly challenging to validate given the size of the input.

## Testing

_Have you added/modified unit tests to test the changes?_
No.

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
1. I have confirmed that the new parser works fine on and produces expexted results from a small subset of both Swiss-Prot and TrEMBL data - **but only if the input is uncompressed**, gzipped files cause a "broken pipe" error in zcat.
2. xref_parser.t, which got added to the repository by PR #286 and which tests, among others, UniProtParser, **fails**. Problems pertaining directly to UniProtParser have been traced down to bugs in the test suite and subsequently fixed, unfortunately it turns out WormbaseCElegansUniProtParser inherits UniProtParser and will therefore have to be refactored as well in order to become compatible with the ETL version.
