### PR TITLE
RefSeqGPFFParser update

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RefSeqGPFFParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqGPFFParser.pm
@@ -17,25 +17,19 @@ limitations under the License.
 
 =cut
 
-# Parse RefSeq GPFF files to create xrefs.
-
 package XrefParser::RefSeqGPFFParser;
 
 use strict;
 use warnings;
 use Carp;
-use File::Basename;
+use List::MoreUtils qw(uniq);
+use Bio::EnsEMBL::IO::Parser::Genbank;
 
-use base qw( XrefParser::BaseParser );
-my $peptide_source_id;
-my $mrna_source_id ;
-my $ncrna_source_id ;
-my $pred_peptide_source_id ;
-my $pred_mrna_source_id ;
-my $pred_ncrna_source_id ;
-my $entrez_source_id;
-my $wiki_source_id;
-my %entrez;
+# use Smart::Comments;
+
+
+use parent qw( XrefParser::BaseParser );
+
 
 sub run {
 
@@ -45,312 +39,232 @@ sub run {
   my $species_name = $ref_arg->{species};
   my $files        = $ref_arg->{files};
   my $release_file = $ref_arg->{rel_file};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
+  my $dbi          = $ref_arg->{dbi} // $self->dbi;
+  my $verbose      = $ref_arg->{verbose} // 0;
+
+### $ref_arg
 
   if((!defined $source_id) or (!defined $species_id) or (!defined $files)){
     croak "Need to pass source_id, species_id, files and rel_file as pairs";
   }
-  $verbose |=0;
 
-  my @files = @{$files};
+  # set the list of RefSeq source names
+  my $refseq_sources = {
+    NM => 'RefSeq_mRNA',
+    NR => 'RefSeq_ncRNA',
+    XM => 'RefSeq_mRNA_predicted',
+    XR => 'RefSeq_ncRNA_predicted',
+    NP => 'RefSeq_peptide',
+    XP => 'RefSeq_peptide_predicted',
+  };
 
-
-  $peptide_source_id =
-    $self->get_source_id_for_source_name('RefSeq_peptide', undef, $dbi);
-  $mrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_mRNA','refseq', $dbi);
-  $ncrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_ncRNA', undef, $dbi);
-
-  $pred_peptide_source_id =
-    $self->get_source_id_for_source_name('RefSeq_peptide_predicted', undef, $dbi);
-  $pred_mrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_mRNA_predicted','refseq', $dbi);
-  $pred_ncrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_ncRNA_predicted', undef, $dbi);
-
-  $entrez_source_id = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
-  $wiki_source_id = $self->get_source_id_for_source_name('WikiGene', undef, $dbi);
-
-  if($verbose){
-    print "RefSeq_peptide source ID = $peptide_source_id\n";
-    print "RefSeq_mRNA source ID = $mrna_source_id\n";
-    print "RefSeq_ncRNA source ID = $ncrna_source_id\n";
-    print "RefSeq_peptide_predicted source ID = $pred_peptide_source_id\n";
-    print "RefSeq_mRNA_predicted source ID = $pred_mrna_source_id\n" ;
-    print "RefSeq_ncRNA_predicted source ID = $pred_ncrna_source_id\n" ;
+  # get RefSeq source ids
+  my $source_ids = {};
+  while (my ($source_prefix, $source_name) = each %{$refseq_sources}) {
+    $source_ids->{$source_name} = $self->get_source_id_for_source_name( $source_name, undef, $dbi )
   }
 
-  (%entrez)     = %{$self->get_acc_to_label("EntrezGene",$species_id, undef, $dbi)};
-
-    my @xrefs;
-    foreach my $file (@files) {
-        my $xrefs =
-          $self->create_xrefs( $file, $species_id, $verbose, $dbi, $species_name );
-
-        if ( !defined( $xrefs ) ) {
-            return 1;    #error
-        }
-        $self->upload_xref_object_graphs( $xrefs, $dbi )
-    }
-
-    if ( defined $release_file ) {
-        # Parse and set release info.
-        my $release_io = $self->get_filehandle($release_file);
-        local $/ = "\n*";
-        my $release = $release_io->getline();
-        $release_io->close();
-
-        $release =~ s/\s{2,}/ /g;
-        $release =~ s/.*(NCBI Reference Sequence.*) Distribution.*/$1/s;
-        # Put a comma after the release number to make it more readable.
-        $release =~ s/Release (\d+)/Release $1,/;
-
-        print "RefSeq release: '$release'\n" if($verbose);
-
-        $self->set_release( $source_id,              $release, $dbi );
-        $self->set_release( $peptide_source_id,      $release, $dbi );
-        $self->set_release( $mrna_source_id,         $release, $dbi );
-        $self->set_release( $ncrna_source_id,        $release, $dbi );
-        $self->set_release( $pred_mrna_source_id,    $release, $dbi );
-        $self->set_release( $pred_ncrna_source_id,   $release, $dbi );
-        $self->set_release( $pred_peptide_source_id, $release, $dbi );
-    }
-
-  return 0; # successful
-}
-
-# --------------------------------------------------------------------------------
-# Parse file into array of xref objects
-# There are 2 types of RefSeq files that we are interested in:
-# - protein sequence files *.protein.faa
-# - mRNA sequence files *.rna.fna
-# Slightly different formats
-
-sub create_xrefs {
-  my ($self, $file,$species_id, $verbose, $dbi, $species_name ) = @_;
-
-  # Create a hash of all valid names and taxon_ids for this species
-  my %species2name = $self->species_id2name($dbi);
-  if (defined $species_name) { push @{$species2name{$species_id}}, $species_name; }
-  if (!defined $species2name{$species_id}) { return; }
-  my %species2tax  = $self->species_id2taxonomy($dbi);
-  push @{$species2tax{$species_id}}, $species_id;
-  my @names   = @{$species2name{$species_id}};
-  my @tax_ids = @{$species2tax{$species_id}};
-  my %name2species_id     = map{ $_=>$species_id } @names;
-  my %taxonomy2species_id = map{ $_=>$species_id } @tax_ids;
+  # get extra source ids
+  $source_ids->{EntrezGene} = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
+  $source_ids->{WikiGene} = $self->get_source_id_for_source_name('WikiGene', undef, $dbi);
 
   # Retrieve existing RefSeq mRNA
-  my (%refseq_ids) = (%{ $self->get_valid_codes("RefSeq_mRNA", $species_id, $dbi) }, %{ $self->get_valid_codes("RefSeq_mRNA_predicted", $species_id, $dbi) });
-  my (%entrez_ids) = %{ $self->get_valid_codes("EntrezGene", $species_id, $dbi) };
-  my (%wiki_ids) = %{ $self->get_valid_codes("WikiGene", $species_id, $dbi) };
+  my $refseq_ids = { %{$self->get_valid_codes('RefSeq_mRNA', $species_id, $dbi)},
+      %{$self->get_valid_codes('RefSeq_mRNA_predicted', $species_id, $dbi)} };
+  my $entrez_ids = $self->get_valid_codes('EntrezGene', $species_id, $dbi);
+  my $wiki_ids = $self->get_valid_codes('WikiGene', $species_id, $dbi);
 
-
-  my %dependent_sources =  $self->get_xref_sources($dbi);
-
-  my $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)");
-
-  my $refseq_io = $self->get_filehandle($file);
-
-  if ( !defined $refseq_io ) {
-    print STDERR "ERROR: Can't open RefSeqGPFF file $file\n";
-    return;
+  if ($verbose) {
+    for my $source_name (sort values %{$refseq_sources}) {
+      print "$source_name source ID = $source_ids->{$source_name}\n";
+    }
   }
 
-  my @xrefs;
+  # populate entrez gene id => label hash
+  my $entrez = $self->get_acc_to_label("EntrezGene", $species_id, undef, $dbi);
 
-  local $/ = "\/\/\n";
 
-  my $type = $self->type_from_file($file);
-  return unless $type;
+  # get the species name
+  my %id2name = $self->species_id2name($dbi);
+  $species_name //= shift @{$id2name{$species_id}};
 
-  while ( my $entry = $refseq_io->getline() ) {
 
-    my $xref = $self->xref_from_record(
-      $entry,
-      \%name2species_id, \%taxonomy2species_id, 
-      $pred_mrna_source_id, $pred_ncrna_source_id,
-      $mrna_source_id, $ncrna_source_id,
-      $pred_peptide_source_id, $peptide_source_id,
-      $entrez_source_id, $wiki_source_id, $add_dependent_xref_sth,
-      $species_id, $type, \%refseq_ids,\%entrez_ids,\%wiki_ids
-     );
+  my %species2name = $self->species_id2name($dbi);
 
-      push @xrefs, $xref if $xref;
 
-  } # while <REFSEQ>
+  # process the source files
+  foreach my $file (@{$files}) {
+    ### $file
 
-  $refseq_io->close();
+    # type from the file (peptide or dna)
+    my $type = $self->type_from_file($file);
 
-  print "Read " . scalar(@xrefs) ." xrefs from $file\n" if($verbose);
+    # get the file handler
+    my $refseq_fh = $self->get_filehandle($file);
 
-  return \@xrefs;
-
-}
-sub type_from_file {
-    my ($self, $file) = @_;
-    return 'peptide' if $file =~ /RefSeq_protein/;
-    return 'dna' if $file =~ /rna/;
-    return 'peptide' if $file =~ /protein/;
-    print STDERR "Could not work out sequence type for $file\n";
-    return;
-}
-sub xref_from_record {
-    my ( $self, $entry, $name2species_id, $taxonomy2species_id,
-      $pred_mrna_source_id, $pred_ncrna_source_id,
-      $mrna_source_id, $ncrna_source_id,
-      $pred_peptide_source_id, $peptide_source_id,
-      $entrez_source_id, $wiki_source_id, $add_dependent_xref_sth,
-      $species_id, $type, $refseq_ids,$entrez_ids,$wiki_ids
-) = @_;
-    chomp $entry;
-
-    my ($species) = $entry =~ /\s+ORGANISM\s+(.*)\n/;
-    $species = lc $species;
-    $species =~ s/^\s*//g;
-    $species =~ s/\s*\(.+\)//; # Ditch anything in parens
-    $species =~ s/\s+/_/g;
-    $species =~ s/\n//g;
-    my $species_id_check = $name2species_id->{$species};
-
-    # Try going through the taxon ID if species check didn't work.
-    if ( !defined $species_id_check ) {
-        my ($taxon_id) = $entry =~ /db_xref="taxon:(\d+)"/;
-        $species_id_check = $taxonomy2species_id->{$taxon_id};
+    if ( !defined $refseq_fh ) {
+      warn "WARNING: Can't open RefSeqGPFF file $file\n";
+      return;
     }
 
-    # skip xrefs for species that aren't in the species table
-    if (   defined $species_id
-        && defined $species_id_check
-        && $species_id == $species_id_check )
-    {
-      my $xref = {};
-      my ($acc) = $entry =~ /ACCESSION\s+(\S+)/;
-      my ($ver) = $entry =~ /VERSION\s+(\S+)/;
-      my ($refseq_pair) = $entry =~ /DBSOURCE\s+REFSEQ: accession (\S+)/;
+    # instantiate ensembl-io genbank parser
+    my $parser = Bio::EnsEMBL::IO::Parser::Genbank->open($refseq_fh);
 
-      # get the right source ID based on $type and whether this is predicted (X*) or not
-      my $source_id;
-      if ($type =~ /dna/) {
-	if ($acc =~ /^XM_/ ){
-	  $source_id = $pred_mrna_source_id;
-	} elsif( $acc =~ /^XR/) {
-	  $source_id = $pred_ncrna_source_id;
-	} elsif( $acc =~ /^NM/) {
-	  $source_id = $mrna_source_id;
-	} elsif( $acc =~ /^NR/) {
-	  $source_id = $ncrna_source_id;
-	}
-      } 
-      elsif ($type =~ /peptide/) {
-	if ($acc =~ /^XP_/) {
-	  $source_id = $pred_peptide_source_id;
-	} else {
-	  $source_id = $peptide_source_id;
-	}
-      }
-      print "Warning: can't get source ID for $type $acc\n" if (!$source_id);
+    # this will hold the array of xrefs to bulk insert
+    my $xrefs;
 
-      # Description - may be multi-line
-      my ($description) = $entry =~ /DEFINITION\s+([^[]+)/s;
-      print $entry if (length($description) == 0);
-      $description =~ s/\nACCESSION.*//s;
-      $description =~ s/\n//g;
-      $description =~ s/\s+/ /g;
-      $description = substr($description, 0, 255) if (length($description) > 255);
+    # For each record in the file
+    while ( $parser->next ) {
 
-      my ($seq) = $entry =~ /^\s*ORIGIN\s+(.+)/ms; # /s allows . to match newline
-      my @seq_lines = split /\n/, $seq;
-      my $parsed_seq = "";
-      foreach my $x (@seq_lines) {
-        my ($seq_only) = $x =~ /^\s*\d+\s+(.*)$/;
-        next if (!defined $seq_only);
-        $parsed_seq .= $seq_only;
-      }
-      $parsed_seq =~ s#//##g;    # remove trailing end-of-record character
-      $parsed_seq =~ s#\s##g;    # remove whitespace
+      # Get the record species
+      my $record_species = lc $parser->get_organism;
+      $record_species =~ s/\s+/_/xg;
 
-      ( my $acc_no_ver, $ver ) = split( /\./, $ver );
+      # skip if species is not the required
+      next unless ( $species_name eq $record_species);
 
-      $xref->{ACCESSION} = $acc;
-      if($acc eq $acc_no_ver){
-         $xref->{VERSION} = $ver;
-      }
-      else{
-         print "$acc NE $acc_no_ver\n";
-      }
+      # get the acc
+      my $acc = $parser->get_accession;
 
-      $xref->{LABEL} = $acc . "\." . $ver;
-      $xref->{DESCRIPTION} = $description;
-      $xref->{SOURCE_ID} = $source_id;
-      $xref->{SEQUENCE} = $parsed_seq;
-      $xref->{SEQUENCE_TYPE} = $type;
-      $xref->{SPECIES_ID} = $species_id;
-      $xref->{INFO_TYPE} = "SEQUENCE_MATCH";
+      my $taxon = $parser->get_taxon_id;
+### $taxon
 
-      # TODO experimental/predicted
+      # get description and remove the [species] at the end
+      my $description = $parser->get_description;
+      $description =~ s/\s*\[[^]]*\]\.?\z//x;
 
-      my @EntrezGeneIDline = $entry =~ /db_xref=.GeneID:(\d+)/g;
-#      my @SGDGeneIDline = $entry =~ /db_xref=.SGD:(S\d+)/g;
-      my @protein_id = $entry =~ /\/protein_id=.(\S+_\d+)/g;
-      my @coded_by = $entry =~  /\/coded_by=.(\w+_\d+)/g;
+      # get refseq pair if available
+      my $refseq_pair = $parser->get_dbsource_acc;
 
-      foreach my $cb (@coded_by){
-	$xref->{PAIR} = $cb;
-      }
-      if (!defined $xref->{PAIR}) {
-        $xref->{PAIR} = $refseq_pair;
-      }
+      # get the source_id for this acc type
+      my $acc_source_id = $source_ids->{$refseq_sources->{substr $acc, 0, 2}};
 
-      foreach my $pi (@protein_id){
-	$xref->{PROTEIN} = $pi;
-      }
+      # the "pair" is the id from coded_by, or the dbsource_acc if that does not exist
+      my $pair = pop @{$parser->get_coded_by_list};
+      $pair //= $parser->get_dbsource_acc;
 
-      foreach my $ll (@EntrezGeneIDline) {
-	my %dep;
-        #my $entrez_source = $dependent_sources{EntrezGene} || die( 'No source for EntrezGene!' );
-        #my $wiki_source = $dependent_sources{WikiGene} || die( 'No source for WikiGene!' );
-        if (defined $entrez{$ll}) {
-          $dep{SOURCE_ID} = $entrez_source_id;
-	  $dep{LINKAGE_SOURCE_ID} = $source_id;
-	  $dep{ACCESSION} = $ll;
-          $dep{LABEL} = $entrez{$ll};
-	  push @{$xref->{DEPENDENT_XREFS}}, \%dep;
+      # set up the direct xref
+      my $xref = {
+        ACCESSION     => $acc,
+        LABEL         => $parser->get_sequence_name,
+        VERSION       => $parser->get_sequence_version,
+        DESCRIPTION   => $description,
+        INFO_TYPE     => 'SEQUENCE_MATCH',
+        PAIR          => $pair,
+        SEQUENCE      => $parser->get_sequence,
+        SEQUENCE_TYPE => $type,
+        SOURCE_ID     => $acc_source_id,
+        SPECIES_ID    => $species_id,
+        PROTEIN       => pop @{$parser->get_protein_id_list},
+      };
 
-  	  my %dep2;
-	  $dep2{SOURCE_ID} = $wiki_source_id;
-	  $dep2{LINKAGE_SOURCE_ID} = $source_id;
-	  $dep2{ACCESSION} = $ll;
-          $dep2{LABEL} = $entrez{$ll};
-	  push @{$xref->{DEPENDENT_XREFS}}, \%dep2;
+      # retrieve and remove duplicates from referenced entrez GeneID
+      my $entrez_gene_ids = $parser->get_db_xref_list_for_type('GeneID');
+      my @gene_ids = uniq( @{$entrez_gene_ids}); 
 
-          # Add xrefs for RefSeq mRNA as well where available
-          $refseq_pair =~ s/\.[0-9]*// if $refseq_pair;
-          if (defined $refseq_pair) {
-            if ($refseq_ids->{$refseq_pair}) {
-              foreach my $refseq_id (@{ $refseq_ids->{$refseq_pair} }) {
-                foreach my $entrez_id (@{ $entrez_ids->{$ll} }) {
-                  $add_dependent_xref_sth->execute($refseq_id, $entrez_id);
-                }
-                foreach my $wiki_id (@{ $wiki_ids->{$ll} }) {
-                  $add_dependent_xref_sth->execute($refseq_id, $wiki_id);
-                }
-              }
-            }
+      # process existing entrez_gene_ids as dependent xrefs
+      foreach my $gene_id (@gene_ids) {
+
+        next unless (defined $entrez->{$gene_id});
+
+        push @{$xref->{DEPENDENT_XREFS}}, {
+            SOURCE_ID         => $source_ids->{'EntrezGene'},
+            LINKAGE_SOURCE_ID => $acc_source_id,
+            ACCESSION         => $gene_id,
+            LABEL             => $entrez->{$gene_id}
+        };
+
+        push @{$xref->{DEPENDENT_XREFS}}, {
+            SOURCE_ID         => $source_ids->{'WikiGene'},
+            LINKAGE_SOURCE_ID => $acc_source_id,
+            ACCESSION         => $gene_id,
+            LABEL             => $entrez->{$gene_id}
+        };
+
+        next unless (defined $refseq_pair);
+
+        # discard the version number
+        $refseq_pair =~ s/\.\d+//x;
+
+        # Add xrefs for RefSeq mRNA as well where available
+        foreach my $refseq_id (@{ $refseq_ids->{$refseq_pair} }) {
+          foreach my $entrez_id (@{ $entrez_ids->{$gene_id} }) {
+            $self->add_dependent_xref_maponly(
+                $entrez_id,
+                $source_ids->{'EntrezGene'},
+                $refseq_id,
+                $source_ids->{$refseq_sources->{substr $refseq_id, 0, 2}},
+                $dbi
+            );
+          }
+          foreach my $wiki_id (@{ $wiki_ids->{$gene_id} }) {
+            $self->add_dependent_xref_maponly(
+                $wiki_id,
+                $source_ids->{'WikiGene'},
+                $refseq_id,
+                $source_ids->{$refseq_sources->{substr $refseq_id, 0, 2}},
+                $dbi
+            );
           }
         }
+
       }
 
-      # Don't add SGD Xrefs, as they are mapped directly from SGD ftp site
+### $xref
+      push @{$xrefs}, $xref;
 
-      # Refseq's do not tell whether the mim is for the gene of morbid so ignore for now.
-      return $xref;
+    }
+
+    $refseq_fh->close();
+
+    # no xrefs in this record...
+    if ( !defined( $xrefs ) ) {
+      next;
+    }
+
+    # upload the xrefs
+    $self->upload_xref_object_graphs( $xrefs, $dbi );
+
   }
+
+
+  # process the release file
+  if ( defined $release_file ) {
+    # get filehandle
+    my $release_io = $self->get_filehandle($release_file);
+
+    # get file header
+    my $release = do { local $/ = "\n*"; <$release_io> };
+
+    # extract release string
+    $release =~ s/\s+/ /xg;
+    $release =~ s/.*(NCBI Reference.*\s\d+)(\s.*)\sDistribution.*/$1,$2/x;
+
+    if ($verbose) {
+      print "RefSeq release: '$release'\n";
+    }
+
+    # set release info
+    $self->set_release( $source_id, $release, $dbi );
+    for my $source_name (sort values %{$refseq_sources}) {
+      $self->set_release( $source_ids->{$source_name}, $release, $dbi );
+    }
+  }
+
+  return 0;
 }
 
-# --------------------------------------------------------------------------------
+
+
+# get type from filename path. this includes the source name and that's enough to extract it
+sub type_from_file {
+  my ($self, $file) = @_;
+
+  my ($type) = $file =~ /RefSeq_(\w+)\//x;
+
+  warn "Could not work out sequence type for $file\n" unless $type;
+
+  return $type;
+}
 
 1;


### PR DESCRIPTION
## Description

Update to the RefSeqGPFFParserr as part of the efforts of the xref sprint.
See ENSCORESW-2898.
Genbank parser from ensembl-io is now used to parse the source files instead of a custom parser.
This will require https://github.com/Ensembl/ensembl-io/pull/69 to be merged.
There are a few differences introduced from the original parser. For instance, only refseq ids with the prefixes defined in $refseq_sources are considered. Previously for peptide files all other possible types were considered and treated as RefSeq_peptide.

## Testing
No unit tests.
Tested with subset of rat, however related xrefs were absent.
Ongoing testing with full dataset.

