### PR TITLE
Bugfix/xref parser tests

### DIFF
--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -184,7 +184,7 @@ my @recognised_sources = (
  "MEROPS; C26.956; -.",
 );
 for my $l (@recognised_sources) {
-  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR  $l/;
+  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR   $l/;
   test_parser("XrefParser::UniProtParser", $uniprot_elegans_record_extra_line,  {
     xref => 4,
     primary_xref => 1,

--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -40,6 +40,11 @@ $database->populate(
   "with force please",
 );
 
+
+# UniProt species taxon codes happen to match species ids of the core database
+my $SPECIES_ID = 6239;
+my $SPECIES_NAME = "Caenorhabditis elegans";
+
 my %xref_tables_expected_empty_by_default = (
   checksum_xref=>0,
   coordinate_xref=>0,
@@ -53,6 +58,7 @@ my %xref_tables_expected_empty_by_default = (
   translation_direct_xref=>0,
   xref=>0,
 );
+
 my $tmp_dir = tempdir(CLEANUP=>1);
 sub store_in_temporary_file {
   my ($content, %opts) = @_;
@@ -62,9 +68,7 @@ sub store_in_temporary_file {
   close($fh);
   return $path;
 }
-# Happens to match the species id of the core database
-my $SPECIES_ID = 1;
-my $SPECIES_NAME = "Homo sapiens";
+
 sub test_parser {
   my ($parser, $content, $expected, $test_name, %opts) = @_;
   require_ok($parser);


### PR DESCRIPTION
## Description

Two bugs have been discovered in _xref_parser.t_ in the course of testing the new UniProtParser, which is more strict regarding its input than the old version.

## Use case

For the new UniProtParser, _xref_parser.t_ (now a part of the Ensembl Core test suite and is executed by Travis) as it is fails due to:
 * using a nonexistent species ID in UniProtKB records it uses, and
 * inserting malformed cross-reference lines into said records.

For the old parser the latter is of no consequence due to more loose parsing of UniProtKB input, whereas the former causes offending entries to be quietly skipped.

## Benefits

Makes _xref_parser.t_ compatible with the new UniProtParser, and hopefully somewhat increases test coverage of the old one.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Yes

_Have you run the entire test suite and no regression was detected?_
N/A - the only thing that has changed is a single test file.
