### PR TITLE
Updated ensembl_ontology schema scripts

### DIFF
--- a/misc-scripts/ontology/sql/patch_95_96_b.sql
+++ b/misc-scripts/ontology/sql/patch_95_96_b.sql
@@ -1,0 +1,26 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2018] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- patch_95_96_a.sql
+--
+-- Title: Update schema version.
+--
+-- Description:
+--  Added fields to Term and Ontology tables
+
+-- Added columns
+ALTER TABLE ontology ADD COLUMN `title` varchar(255) NULL;
+
+ALTER TABLE term ADD COLUMN `iri` varchar(1000) NULL;

--- a/misc-scripts/ontology/sql/tables.sql
+++ b/misc-scripts/ontology/sql/tables.sql
@@ -43,7 +43,7 @@ CREATE TABLE ontology (
   name          VARCHAR(64) NOT NULL,
   namespace     VARCHAR(64) NOT NULL,
   data_version  VARCHAR(64) DEFAULT NULL,
-
+  `title` varchar(255) NULL,
   PRIMARY KEY (ontology_id),
   UNIQUE INDEX name_namespace_idx (name, namespace)
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
@@ -66,7 +66,7 @@ CREATE TABLE term (
   definition    TEXT,
   is_root       INT NOT NULL DEFAULT 0,
   is_obsolete   INT NOT NULL DEFAULT 0,
-
+  `iri` varchar(1000) NULL,
   PRIMARY KEY (term_id),
   UNIQUE INDEX accession_idx (accession),
   UNIQUE INDEX ontology_acc_idx (ontology_id, accession),

--- a/modules/t/test-genome-DBs/ontology/ontology/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/table.sql
@@ -146,6 +146,7 @@ CREATE TABLE `ontology` (
   `name` varchar(64) NOT NULL,
   `namespace` varchar(64) NOT NULL,
   `data_version` varchar(64) DEFAULT NULL,
+  `title` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ontology_id`),
   UNIQUE KEY `name_namespace_idx` (`name`,`namespace`)
 ) ENGINE=MyISAM AUTO_INCREMENT=8 DEFAULT CHARSET=latin1;
@@ -197,6 +198,7 @@ CREATE TABLE `term` (
   `definition` text,
   `is_root` int(11) DEFAULT NULL,
   `is_obsolete` int(11) DEFAULT NULL,
+  `iri` varchar(1000) DEFAULT NULL,
   PRIMARY KEY (`term_id`),
   UNIQUE KEY `accession_idx` (`accession`),
   UNIQUE KEY `ontology_acc_idx` (`ontology_id`,`accession`),


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Updated Ontology schema model:
- Added field `iri` on Term
- Added field `title` on Ontology

## Use case

NTR

## Benefits

Added new fields. could help retrieve terms directly from their `iri` (specially when loaded via OLS loader)

## Possible Drawbacks

None afaik

## Testing

Updated tests scripts to include schema updates

Passed

_Have you run the entire test suite and no regression was detected?_ I am afraid not, but modification only impacts ontology model, nothing else.

