### PR TITLE
Document a feature: update() removes web_data

### DIFF
--- a/modules/t/analysis.t
+++ b/modules/t/analysis.t
@@ -94,6 +94,7 @@ is($analysis_updated->logic_name(), "new_dummy", "Logic name is correct");
 is($analysis_updated->description(), "new description", "Description is correct");
 is($analysis_updated->display_label(), "new label", "Label is correct");
 is($analysis_updated->displayable(), 0, "Displayable is correct");
+is($analysis_updated->web_data(), undef, "web_data is wiped on update");
 
 # now try updating analysis that has no existing description
 $analysis = Bio::EnsEMBL::Analysis->new();


### PR DESCRIPTION
## Description

I call update() to populate analysis descriptions, from a script `ensembl_genomes/eg-pipelines/scripts/production_db/analysis_desc_from_prod.pl`. I found this when I was searching why `analysis_description.web_data` wasn't populated in WormBase ParaSite. Ensembl probably populates `analysis_description.web_data` differently, and has it working.

 As far as I see the code has been like that for a long time (2 years?), and there's some special behaviour and disclaimers about this field which I don't understand. I also don't really understand the consequences of making the column populated again. So I'm calling it a feature instead of a bug.

@nerdstrike you might know what to do with it!

## Use case

Tell people about the change, focus some eyes on the issue and see if it's a problem. If it's not a problem, document the current behaviour (calling update() wipes the web_data field)

## Benefits

More complete test suites are better

## Possible Drawbacks

The test suite will run longer

## Testing
I have ran this unit test with and without the change, and both pass.

