### PR TITLE
Improve symmetry of store / remove in CoordSystemAdaptor

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/CoordSystemAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/CoordSystemAdaptor.pm
@@ -1284,6 +1284,10 @@ sub remove {
 
   delete $self->{'_dbID_cache'}->{$dbID};
   delete $self->{'_rank_cache'}->{$rank};
+  delete $self->{'_is_sequence_level'}->{$dbID};
+  delete $self->{'_is_default_version'}->{$dbID};
+  $cs->dbID(undef);
+  $cs->adaptor(undef);
 
   return $cs;
 }

--- a/modules/t/coordSystemAdaptor.t
+++ b/modules/t/coordSystemAdaptor.t
@@ -235,7 +235,7 @@ my $old_dbID = $cs->dbID;
 is($csa->remove($cs), $cs, 'Adaptor remove() returns the same coordinate system object');
 is_deeply($csa->{_is_sequence_level}, {}, 'Adaptor sequence_level cache updated to reflect the removal');
 is($csa->{_is_default_version}{$old_dbID}, undef, 'Adaptor default_version cache updated to reflect removal');
-lives_ok({ $csa->store($cs); }, 'Adaptor store() successful. Coordinate system did not have dbID() or adaptor()');
+lives_ok(sub { $csa->store($cs); }, 'Adaptor store() successful. Coordinate system did not have dbID() or adaptor()');
 
 $multi->restore('core', 'coord_system');
 $multi->restore('core', 'meta');

--- a/modules/t/coordSystemAdaptor.t
+++ b/modules/t/coordSystemAdaptor.t
@@ -225,6 +225,18 @@ is_deeply(
   'Retrieval by name should return the same as version for NCBI33');
 is_deeply($csa->fetch_all_by_version('thisdoesnotexist'), [], 'Bogus coordinate system results in no results');
 
+#
+# Test remove() and store() sequence level
+#
+$cs = $csa->fetch_sequence_level();
+ok($cs, 'There is a sequence level coord system - fetched ok');
+ok($cs->is_default, 'sequence level is the default coord system');
+my $old_dbID = $cs->dbID;
+is($csa->remove($cs), $cs, 'Adaptor remove() returns the same coordinate system object');
+is_deeply($csa->{_is_sequence_level}, {}, 'Adaptor sequence_level cache updated to reflect the removal');
+is($csa->{_is_default_version}{$old_dbID}, undef, 'Adaptor default_version cache updated to reflect removal');
+lives_ok { $csa->store($cs); }, 'Adaptor store() successful. Coordinate system did not have dbID() or adaptor()';
+
 $multi->restore('core', 'coord_system');
 $multi->restore('core', 'meta');
 

--- a/modules/t/coordSystemAdaptor.t
+++ b/modules/t/coordSystemAdaptor.t
@@ -235,7 +235,7 @@ my $old_dbID = $cs->dbID;
 is($csa->remove($cs), $cs, 'Adaptor remove() returns the same coordinate system object');
 is_deeply($csa->{_is_sequence_level}, {}, 'Adaptor sequence_level cache updated to reflect the removal');
 is($csa->{_is_default_version}{$old_dbID}, undef, 'Adaptor default_version cache updated to reflect removal');
-lives_ok { $csa->store($cs); }, 'Adaptor store() successful. Coordinate system did not have dbID() or adaptor()';
+lives_ok({ $csa->store($cs); }, 'Adaptor store() successful. Coordinate system did not have dbID() or adaptor()');
 
 $multi->restore('core', 'coord_system');
 $multi->restore('core', 'meta');


### PR DESCRIPTION
## Description

The internal caches are not accurately maintained for the CoordSystemAdaptor when calling `$csa->remove($cs)`. This is especially a problem for `default` and `sequence level` coordinate systems.

## Use case

```
$cs = $csa->fetch_sequence_level();
$csa->remove($cs);
$cs->name('fix typo');
$csa->store($cs);
```

## Benefits

Completeness, symmetry.

## Possible Drawbacks

Unsure.

## Testing

New test for `$csa->remove($cs)` and side effects included which all pass. No regressions detected.

