### PR TITLE
s/localtime/gmtime/ for successful tests down under.

### DIFF
--- a/modules/t/exon.t
+++ b/modules/t/exon.t
@@ -224,10 +224,10 @@ my $supfeat_count = count_rows($db, 'supporting_feature');
 $exon = $exonad->fetch_by_stable_id('ENSE00000859937');
 
 # check the created and modified times
-my @date_time = localtime( $exon->created_date());
+my @date_time = gmtime( $exon->created_date());
 ok( $date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104 );
 
-@date_time = localtime( $exon->modified_date());
+@date_time = gmtime( $exon->modified_date());
 ok( $date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104 );
 
 

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -74,10 +74,10 @@ $gene = $ga->fetch_by_stable_id("ENSG00000171456");
 debug("Gene->fetch_by_stable_id()");
 ok($gene);
 
-my @date_time = localtime($gene->created_date());
+my @date_time = gmtime($gene->created_date());
 ok($date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104);
 
-@date_time = localtime($gene->modified_date());
+@date_time = gmtime($gene->modified_date());
 ok($date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104);
 
 debug("Gene dbID: " . $gene->dbID());

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -136,10 +136,10 @@ ok( test_getter_setter( $tr, "created_date", time() ));
 ok( test_getter_setter( $tr, "modified_date", time() ));
 
 
-my @date_time = localtime( $tr->created_date());
+my @date_time = gmtime( $tr->created_date());
 ok( $date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104 );
 
-@date_time = localtime( $tr->modified_date());
+@date_time = gmtime( $tr->modified_date());
 ok( $date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104 );
 
 

--- a/modules/t/translation.t
+++ b/modules/t/translation.t
@@ -89,10 +89,10 @@ my $translation = $ta->fetch_by_Transcript($transcript);
 
 ok($translation && $translation->stable_id eq 'ENSP00000201961');
 
-my @date_time = localtime($translation->created_date());
+my @date_time = gmtime($translation->created_date());
 ok($date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104);
 
-@date_time = localtime($translation->modified_date());
+@date_time = gmtime($translation->modified_date());
 ok($date_time[3] == 6 && $date_time[4] == 11 && $date_time[5] == 104);
 
 ok($translation && $translation->start_Exon->stable_id eq 'ENSE00000661216');


### PR DESCRIPTION
## Description

Fixed tests, I hope, for those in distant, to GMT, timezones.

## Use case

NZ testing on localhost. Specifically, it was difficult to understand consequences when preparing #353.

## Benefits

* Easier to spot regressions.
* More contributions from far off lands?

## Possible Drawbacks

Both `gmtime` and `localtime` have entries in `perlport`.

## Testing

They are the tests.