### PR TITLE
registry.t: Skip the testing of load_registry_from_db() parameter-name auto-correction on databases other than MySQL

### DIFF
--- a/modules/t/registry.t
+++ b/modules/t/registry.t
@@ -110,7 +110,8 @@ TMPL
 }
 
 #Testing auto-correction of arguments for common 1st line methods
-{
+SKIP: {
+  skip 'Tests for load_registry_from_db are done on MySQL engine', 4 unless $dbc->driver eq 'mysql';
   my $tester = sub {
     my ($misspelling) = @_;
     my %params = (-HOST => $dbc->host(), -PORT => $dbc->port(), -USER => $dbc->username());


### PR DESCRIPTION
## Description

Stop the following exception when running test harness without a local mysql server. i.e. `DB=sqlite`.

```
modules/t/registry.t ............................................. 1/? 
-------------------- EXCEPTION --------------------
MSG: Cannot connect to the Ensembl MySQL server at :3306; check your settings & DBI error message: Can't connect to local MySQL server through socket '/opt/local/var/run/mariadb/mysqld.sock' (2)
STACK Bio::EnsEMBL::Registry::load_registry_from_db /code/ensembl/modules/Bio/EnsEMBL/Registry.pm:1769
STACK main::__ANON__ modules/t/registry.t:120
STACK Bio::EnsEMBL::Test::TestUtils::warns_like /code/ensembl-test/modules/Bio/EnsEMBL/Test/TestUtils.pm:268
STACK main::__ANON__ modules/t/registry.t:120
STACK toplevel modules/t/registry.t:123
Date (localtime)    = Fri Jan 11 00:07:01 2019
Ensembl API version = 96
---------------------------------------------------
```
## Use case

Testing

## Benefits

Easier to spot regressions.

## Possible Drawbacks

The tests are actually required.
