### PR TITLE
Bugfix / DBD::mysql version restriction in release/95

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '< 4.050';
 requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';


### PR DESCRIPTION
## Description

A so far unidentified change made in version 4.050 causes dbConnection.t
tests checking if database ping returns an undef with
disconnect_when_inactive(1) to fail. Prevent installation of that
(or newer) version of DBD::mysql until we have had a chance to debug the
issue. Yes, this is very much a stopgap measure.

## Use case

Both Travis and users who rely on our cpanfiles to install DBD::mysql currently end up with a version which fails tests, and possibly does not in fact disconnect from the database when inactive.

## Benefits

DBD::mysql-4.050 is brand-new so for the time being, having this restriction in place should keep things chugging along until we have actually fixed this.

## Possible Drawbacks

Will likely fail spectacularly once new versions od DBD::mysql have made it into distros and so on. Merely bypasses the issue rather than fixing it.

## Testing

_Have you added/modified unit tests to test the changes?_
no

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
Have run dbConnection.t before and after the change. The three ping() failures go away, no new ones appear.
