### PR TITLE
dbConnection.t: do not use $dbh->ping() to check if disconnected from DB [release/95]

### DIFF
--- a/modules/t/dbConnection.t
+++ b/modules/t/dbConnection.t
@@ -120,9 +120,11 @@ is_deeply($dbc->to_hash(), \%dbc_args, 'Checking to_hash() can roundtrip a DBCon
 #
 my $dbh = $dbc->db_handle();
 
+ok( $dbh->{Active}, 'DB handle is active before enabling disconnect_when_inactive()' );
+
 $dbc->disconnect_when_inactive(1);
 
-ok(!$dbh->ping());
+ok( !$dbh->{Active}, 'DB handle has deactivated after enabling disconnect_when_inactive()' );
 
 {
   # reconnect should happen now
@@ -135,7 +137,7 @@ ok(!$dbh->ping());
   # disconnect should occur now
 }
 
-ok(!$dbh->ping());
+ok( !$dbh->{Active}, 'DB handle has deactivated after previous test' );
 
 $dbh = $dbc->db_handle();
 
@@ -161,7 +163,7 @@ $dbh = $dbc->db_handle();
 }
 
 
-ok(!$dbh->ping());
+ok( !$dbh->{Active}, 'DB handle has deactivated after previous tests' );
 
 $dbc->disconnect_when_inactive(0);
 

--- a/modules/t/dbConnection.t
+++ b/modules/t/dbConnection.t
@@ -162,13 +162,11 @@ $dbh = $dbc->db_handle();
   $sth1->finish;
 }
 
-
 ok( !$dbh->{Active}, 'DB handle has deactivated after previous tests' );
 
 $dbc->disconnect_when_inactive(0);
 
-ok($dbc->db_handle->ping());
-
+$dbh = $dbc->db_handle();
 {
   my $sth1 = $dbc->prepare('SELECT * from gene limit 1');
   $sth1->execute();
@@ -176,9 +174,9 @@ ok($dbc->db_handle->ping());
   ok($sth1->rows());
   $sth1->finish();
 }
-
 #should not have disconnected this time
-ok($dbc->db_handle->ping());
+ok( $dbh->{Active}, 'DB handle stays active post-query with disconnect_when_inactive() disabled' );
+
 $dbc->disconnect_when_inactive(1);
 
 # construct a second database handle using a first one:


### PR DESCRIPTION
## Description

Make _dbConnection.t_ compatible with newly released DBD::mysql-4.050 by using _$dbh->{Active}_ rather than _$dbh->ping()_ to confirm _disconnect_when_inactive()_ works.

## Use case

DBD::mysql::ping() cannot be relied to return _false_ if the client has been disconnected from the database server because it actively attempts to reconnect to the database and only failed to do so in the past because of a bug. With the first version with that bug fixed, 4.050, having been released a couple of days ago, everyone always using the latest release of DBD::mysql (_e.g._ our Travis builds) now see the three _dbConnection.t_ tests aiming at confirming correct operation of disconnect-when-inactive mode fail.

## Benefits

DBD::mysql-4.050 can be used without test failures, which among other things means Travis becoming happy again.

## Possible Drawbacks

None I can think of, DBI documentation says that while the exact meaning of the "Active" attribute is hazy it *is* to be set to false on the database by disconnect() and all drivers I have seen so far do observe this requirement.

## Testing

_Have you added/modified unit tests to test the changes?_

The change is _in_ unit tests.

_If so, do the tests pass/fail?_

Pass.

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected.
