### PR TITLE
Biotype so_term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ a.out
 *.obj
 *.class
 MultiTestDB.conf
+MultiTestDB.*.conf
 *.frozen.conf
 bioperl*.zip
 /modules/t/CLEAN.t

--- a/modules/Bio/EnsEMBL/Biotype.pm
+++ b/modules/Bio/EnsEMBL/Biotype.pm
@@ -86,6 +86,8 @@ use parent qw(Bio::EnsEMBL::Storable);
       string - the name of the biotype group (for ensembl)
   Arg [-SO_ACC] :
       string - the Sequence Ontology accession of this biotype
+  Arg [-SO_TERM] :
+      string - the Sequence Ontology term for the SO accession of this biotype
   Arg [-DESCRIPTION] :
       string - the biotype description
   Arg [-DB_TYPE] :
@@ -107,14 +109,15 @@ sub new {
 
   my $self = $class->SUPER::new();
 
-  my($dbID, $name, $object_type, $biotype_group, $so_acc, $description, $db_type, $attrib_type_id) =
-    rearrange([qw(BIOTYPE_ID NAME OBJECT_TYPE BIOTYPE_GROUP SO_ACC DESCRIPTION DB_TYPE ATTRIB_TYPE_ID)], @args);
+  my($dbID, $name, $object_type, $biotype_group, $so_acc, $so_term, $description, $db_type, $attrib_type_id) =
+    rearrange([qw(BIOTYPE_ID NAME OBJECT_TYPE BIOTYPE_GROUP SO_ACC SO_TERM DESCRIPTION DB_TYPE ATTRIB_TYPE_ID)], @args);
 
   $self->{'dbID'} = $dbID;
   $self->{'name'} = $name;
   $self->{'object_type'} = $object_type;
   $self->{'biotype_group'} = $biotype_group;
   $self->{'so_acc'} = $so_acc;
+  $self->{'so_term'} = $so_term;
   $self->{'description'} = $description;
   $self->{'db_type'} = $db_type;
   $self->{'attrib_type_id'} = $attrib_type_id;
@@ -213,6 +216,26 @@ sub so_acc {
   }
 
   return $self->{'so_acc'};
+}
+
+=head2 so_term
+
+  Arg [1]    : (optional) string $so_term
+  Example    : $feat->so_term();
+  Description: Getter/Setter for the Sequence Ontology term of this biotype.
+  Returntype : string
+  Exceptions : none
+
+=cut
+
+sub so_term {
+  my ( $self, $so_term ) = @_;
+
+  if ( defined($so_term) ) {
+    $self->{'so_term'} = $so_term;
+  }
+
+  return $self->{'so_term'};
 }
 
 =head2 object_type

--- a/modules/Bio/EnsEMBL/CDS.pm
+++ b/modules/Bio/EnsEMBL/CDS.pm
@@ -66,7 +66,10 @@ use Scalar::Util qw(weaken isweak);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0000316';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000316',
+  term => 'CDS',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
@@ -90,7 +90,7 @@ sub _tables {
 sub _columns {
   my $self = shift;
 
-  return ('b.biotype_id', 'b.name', 'b.object_type', 'b.db_type', 'b.attrib_type_id', 'b.description', 'b.biotype_group', 'b.so_acc');
+  return ('b.biotype_id', 'b.name', 'b.object_type', 'b.db_type', 'b.attrib_type_id', 'b.description', 'b.biotype_group', 'b.so_acc', 'b.so_term');
 }
 
 =head2 _objs_from_sth
@@ -107,9 +107,9 @@ sub _columns {
 sub _objs_from_sth {
   my ($self, $sth) = @_;
 
-  my ($dbID, $name, $object_type, $db_type, $attrib_type_id, $description, $biotype_group, $so_acc);
+  my ($dbID, $name, $object_type, $db_type, $attrib_type_id, $description, $biotype_group, $so_acc, $so_term);
 
-  $sth->bind_columns(\$dbID, \$name, \$object_type, \$db_type, \$attrib_type_id, \$description, \$biotype_group, \$so_acc);
+  $sth->bind_columns(\$dbID, \$name, \$object_type, \$db_type, \$attrib_type_id, \$description, \$biotype_group, \$so_acc, \$so_term);
 
   my @biotypes;
 
@@ -124,6 +124,7 @@ sub _objs_from_sth {
          'description'    => $description,
          'biotype_group'  => $biotype_group,
          'so_acc'         => $so_acc,
+         'so_term'        => $so_term,
       } )
     );
   }

--- a/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
@@ -54,7 +54,10 @@ use Bio::EnsEMBL::Utils::Exception qw(throw);
 
 @ISA = qw( Bio::EnsEMBL::BaseAlignFeature );
 
-use constant SO_ACC => 'SO:0000347';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000347',
+  term => 'nucleotide_match',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
@@ -51,7 +51,10 @@ use vars qw(@ISA);
 
 @ISA = qw( Bio::EnsEMBL::BaseAlignFeature );
 
-use constant SO_ACC => 'SO:0000349';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000349',
+  term => 'protein_match',
+};
 
 =head2 _hit_unit
 

--- a/modules/Bio/EnsEMBL/Exon.pm
+++ b/modules/Bio/EnsEMBL/Exon.pm
@@ -80,8 +80,10 @@ use Bio::EnsEMBL::DBSQL::SupportingFeatureAdaptor;
 use vars qw(@ISA);
 @ISA = qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0000147';
-
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000147',
+  term => 'exon',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1449,9 +1449,9 @@ sub get_nearest_Gene {
 =head2 feature_so_acc
 
   Description: This method returns a string containing the SO accession number of the feature
-               Define constant SO_ACC in classes that require it, or override it for multiple possible values for a class.
+               Define constant SEQUENCE_ONTOLOGY in classes that require it, or override it for multiple possible values for a class.
   Returntype : String (Sequence Ontology accession number)
-  Exceptions : Thrown if caller SO_ACC is undefined and is not a Bio::EnsEMBL::Feature
+  Exceptions : Thrown if caller SEQUENCE_ONTOLOGY is undefined and is not a Bio::EnsEMBL::Feature
 
 =cut
 
@@ -1463,14 +1463,41 @@ sub feature_so_acc {
 
   # Get the caller class SO acc
   try {
-    $so_acc = $ref->SO_ACC;
+    $so_acc = $ref->SEQUENCE_ONTOLOGY->{'acc'};
   };
- 
+
   unless ($so_acc || $ref eq 'Bio::EnsEMBL::Feature' ) {
-    throw( "constant SO_ACC in ${ref} is not defined");
+    throw( "constant SEQUENCE_ONTOLOGY in ${ref} is not defined");
   }
 
   return $so_acc // 'SO:0000001';
+}
+
+=head2 feature_so_term
+
+  Description: This method returns a string containing the SO term of the feature
+               Define constant SEQUENCE_ONTOLOGY in classes that require it, or override it for multiple possible values for a class.
+  Returntype : String (Sequence Ontology term)
+  Exceptions : Thrown if caller SEQUENCE_ONTOLOGY is undefined and is not a Bio::EnsEMBL::Feature
+
+=cut
+
+sub feature_so_term {
+  my ($self) = @_;
+
+  my $ref = ref $self;
+  my $so_term;
+
+  # Get the caller class SO acc
+  try {
+    $so_term = $ref->SEQUENCE_ONTOLOGY->{'term'};
+  };
+
+  unless ($so_term || $ref eq 'Bio::EnsEMBL::Feature' ) {
+    throw( "constant SEQUENCE_ONTOLOGY in ${ref} is not defined");
+  }
+
+  return $so_term // 'region';
 }
 
 =head2 summary_as_hash

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1466,7 +1466,7 @@ sub feature_so_acc {
     $so_acc = $ref->SEQUENCE_ONTOLOGY->{'acc'};
   };
 
-  unless ($so_acc || $ref eq 'Bio::EnsEMBL::Feature' ) {
+  if (!$so_acc && $ref ne 'Bio::EnsEMBL::Feature' ) {
     throw( "constant SEQUENCE_ONTOLOGY in ${ref} is not defined");
   }
 
@@ -1493,7 +1493,7 @@ sub feature_so_term {
     $so_term = $ref->SEQUENCE_ONTOLOGY->{'term'};
   };
 
-  unless ($so_term || $ref eq 'Bio::EnsEMBL::Feature' ) {
+  if (!$so_term && $ref ne 'Bio::EnsEMBL::Feature' ) {
     throw( "constant SEQUENCE_ONTOLOGY in ${ref} is not defined");
   }
 

--- a/modules/Bio/EnsEMBL/Gene.pm
+++ b/modules/Bio/EnsEMBL/Gene.pm
@@ -73,7 +73,10 @@ use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 
 use parent qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0000704';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000704',
+  term => 'gene',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/KaryotypeBand.pm
+++ b/modules/Bio/EnsEMBL/KaryotypeBand.pm
@@ -82,7 +82,10 @@ use Bio::EnsEMBL::Utils::Exception qw(warning);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0000341';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000341',
+  term => 'chromosome_band',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/MiscFeature.pm
+++ b/modules/Bio/EnsEMBL/MiscFeature.pm
@@ -125,7 +125,10 @@ use vars qw(@ISA);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0001411';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0001411',
+  term => 'biological_region',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/RepeatFeature.pm
+++ b/modules/Bio/EnsEMBL/RepeatFeature.pm
@@ -82,7 +82,10 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 
 use base qw/Bio::EnsEMBL::Feature/;
 
-use constant SO_ACC => 'SO:0000657';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000657',
+  term => 'repeat_region',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/SimpleFeature.pm
+++ b/modules/Bio/EnsEMBL/SimpleFeature.pm
@@ -69,7 +69,10 @@ use Scalar::Util qw(weaken isweak);
 
 @ISA = qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0001411';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0001411',
+  term => 'biological_region',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -77,7 +77,10 @@ use Bio::EnsEMBL::Utils::Scalar qw( assert_ref );
 
 use parent qw(Bio::EnsEMBL::Feature);
 
-use constant SO_ACC => 'SO:0000673';
+use constant SEQUENCE_ONTOLOGY => {
+  acc  => 'SO:0000673',
+  term => 'transcript',
+};
 
 =head2 new
 

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -223,12 +223,6 @@ sub type {
 
 # package variable to minimize duplication
 my %utr_type_so_mapping = (
- 'five_prime_utr'  => 'SO:0000204',
- 'three_prime_utr' => 'SO:0000205'
-);
-
-# package variable to minimize duplication
-my %utr_type_so_mapping = (
  'five_prime_utr'  => {
     acc  => 'SO:0000204',
     term => 'five_prime_UTR',

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -227,6 +227,18 @@ my %utr_type_so_mapping = (
  'three_prime_utr' => 'SO:0000205'
 );
 
+# package variable to minimize duplication
+my %utr_type_so_mapping = (
+ 'five_prime_utr'  => {
+    acc  => 'SO:0000204',
+    term => 'five_prime_UTR',
+  },
+ 'three_prime_utr' => {
+    acc  => 'SO:0000205',
+    term => 'three_prime_UTR',
+  }
+);
+
 =head2 feature_so_acc
 
   Example    : print $utr->feature_so_acc;
@@ -240,7 +252,23 @@ sub feature_so_acc {
   my $self = shift;
 
   # return UTR type SO acc, or UTR acc
-  return $utr_type_so_mapping{$self->type} // 'SO:0000203';
+  return $utr_type_so_mapping{$self->type}->{'acc'} // 'SO:0000203';
+}
+
+=head2 feature_so_term
+
+  Example    : print $utr->feature_so_term;
+  Description: This method returns a string containing the SO accession term of the UTR, based on type.
+               Overrides Bio::EnsEMBL::Feature::feature_so_term
+  Returntype : string (Sequence Ontology term)
+
+=cut
+
+sub feature_so_term {
+  my $self = shift;
+
+  # return UTR type SO acc, or UTR acc
+  return $utr_type_so_mapping{$self->type}->{'term'} // 'UTR';
 }
 
 =head2 summary_as_hash

--- a/modules/t/MultiTestDB.mysql.conf
+++ b/modules/t/MultiTestDB.mysql.conf
@@ -1,0 +1,9 @@
+
+{
+  'port'   => '3306',
+  'driver' => 'mysql',
+  'user'   => 'test_user',
+  'db_version' => 93,
+  'pass'   => 'passwd',
+  'host'   => 'localhost'
+}

--- a/modules/t/MultiTestDB.mysql.conf
+++ b/modules/t/MultiTestDB.mysql.conf
@@ -1,9 +1,0 @@
-
-{
-  'port'   => '3306',
-  'driver' => 'mysql',
-  'user'   => 'test_user',
-  'db_version' => 93,
-  'pass'   => 'passwd',
-  'host'   => 'localhost'
-}

--- a/modules/t/MultiTestDB.sqlite.conf
+++ b/modules/t/MultiTestDB.sqlite.conf
@@ -1,0 +1,5 @@
+{
+  'driver' => 'SQLite',
+  'dbdir'  => '/home/tgrego/temp/',
+  'user'   => 'test_user',
+}

--- a/modules/t/MultiTestDB.sqlite.conf
+++ b/modules/t/MultiTestDB.sqlite.conf
@@ -1,5 +1,0 @@
-{
-  'driver' => 'SQLite',
-  'dbdir'  => '/home/tgrego/temp/',
-  'user'   => 'test_user',
-}

--- a/modules/t/biotype.t
+++ b/modules/t/biotype.t
@@ -52,19 +52,21 @@ is($biotype1->object_type, 'gene', 'Biotype is from Gene object');
 is($biotype1->name, 'protein_coding', 'Biotype name is protein_coding');
 is($biotype1->biotype_group, 'coding', 'Biotype group is coding');
 is($biotype1->so_acc, 'SO:0001217', 'Biotype protein_coding refers to SO:0001217');
+is($biotype1->so_term, 'protein_coding_gene', 'Biotype protein_coding refers to SO term protein_coding_gene');
 throws_ok { $biotype1->so_acc('test') } qr/so_acc must be a Sequence Ontology accession/, 'so_acc() requires a SO acc like string';
 throws_ok { $biotype1->object_type('test') } qr/object_type must be gene or transcript/, 'object_type() must be gene or transcript';
 
 # test transcript biotype object
 my $transcript = $gene->canonical_transcript;
 debug("transcript biotype");
-is($transcript->biotype, 'protein_coding', "Trancript biotype is protein_coding");
+is($transcript->biotype, 'protein_coding', "Transcript biotype is protein_coding");
 my $biotype2 = $transcript->get_Biotype;
 ok($biotype2->isa("Bio::EnsEMBL::Biotype"), "Biotype object retrieved successfully");
 is($biotype2->object_type, 'transcript', 'Biotype is from Transcript object');
 is($biotype2->name, 'protein_coding', 'Biotype name is protein_coding');
 is($biotype2->biotype_group, 'coding', 'Biotype group is coding');
 is($biotype2->so_acc, 'SO:0000234', 'Biotype protein_coding refers to SO:0000234');
+is($biotype2->so_term, 'mRNA', 'Biotype protein_coding refers to SO term mRNA');
 ok($transcript->set_Biotype('new_biotype'), "Can successfully set new_biotype");
 throws_ok { $gene->set_Biotype() } qr/No argument provided/, 'set_Biotype() requires an argument';
 
@@ -77,6 +79,7 @@ is($biotype3->object_type, 'gene', 'Biotype is from Gene object');
 is($biotype3->name, 'tRNA', 'Biotype name is tRNA');
 is($biotype3->biotype_group, 'snoncoding', 'Biotype group is snoncoding');
 is($biotype3->so_acc, 'SO:0001263', 'Biotype tRNA refers to SO:0001263');
+is($biotype3->so_term, 'ncRNA_gene', 'Biotype protein_coding refers to SO term ncRNA_gene');
 
 # set biotype with term not in database
 debug("set biotype with term not in db");
@@ -87,6 +90,7 @@ is($biotype4->object_type, 'gene', 'Biotype is from Gene object');
 is($biotype4->name, 'dummy', 'Biotype name is dummy');
 is($biotype4->biotype_group, undef, 'Biotype group is not set');
 is($biotype4->so_acc, undef, 'Biotype SO acc is not set');
+is($biotype4->so_term, undef, 'Biotype SO term is not set');
 throws_ok { $gene->set_Biotype() } qr/No argument provided/, 'set_Biotype() requires an argument';
 
 # test fetch biotypes of object_type gene
@@ -95,7 +99,7 @@ my $biotypes1 = $biotype_adaptor->fetch_all_by_object_type('gene');
 is(ref $biotypes1, 'ARRAY', 'Got an array');
 is(scalar @{$biotypes1}, '2', 'of size 2');
 is_deeply($biotypes1, [$biotype1, $biotype3], 'with the correct objects');
-my $warning1 = warning { 
+my $warning1 = warning {
   $biotypes1 = $biotype_adaptor->fetch_all_by_object_type('none') };
 like( $warning1,
     qr/No objects retrieved. Check if object_type 'none' is correct./,

--- a/modules/t/cds.t
+++ b/modules/t/cds.t
@@ -35,11 +35,10 @@ ok($db);
 
 my $stable_id = 'ENST00000217347';
 my $transcript_adaptor = $db->get_TranscriptAdaptor();
-my $transcript = 
-  $transcript_adaptor->fetch_by_stable_id($stable_id);
+my $transcript = $transcript_adaptor->fetch_by_stable_id($stable_id);
 
 
-my @cds = @{ $transcript->get_all_CDS() };  
+my @cds = @{ $transcript->get_all_CDS() };
 my @exons = @{ $transcript->get_all_translateable_Exons() };
 my $n = scalar(@cds);
 
@@ -50,6 +49,7 @@ for (my $i = 0; $i < $n; $i++) {
 
 is($cds[0]->start, $transcript->coding_region_start, "First cds is coding start");
 is($cds[$n-1]->end, $transcript->coding_region_end, "Last cds is coding end");
-is($cds[0]->feature_so_acc, 'SO:0000316', 'CDS feature SO acc is correct (CDS)');;
+is($cds[0]->feature_so_acc, 'SO:0000316', 'CDS feature SO acc is correct (CDS)');
+is($cds[0]->feature_so_term, 'CDS', 'CDS feature SO term is correct (CDS)');;
 
 done_testing();

--- a/modules/t/dnaDnaAlignFeature.t
+++ b/modules/t/dnaDnaAlignFeature.t
@@ -159,5 +159,6 @@ ok($f);
 
 
 is($dnaf->feature_so_acc, 'SO:0000347', 'DnaDnaAlignFeature feature SO acc is correct (nucleotide_match)');
+is($dnaf->feature_so_term, 'nucleotide_match', 'DnaDnaAlignFeature feature SO term is correct (nucleotide_match)');
 
 done_testing();

--- a/modules/t/dnaPepAlignFeature.t
+++ b/modules/t/dnaPepAlignFeature.t
@@ -116,6 +116,7 @@ ok($dnaf->end == 16);
 ok( scalar($dnaf->ungapped_features) == 2);
 
 is($dnaf->feature_so_acc, 'SO:0000349', 'dnaPepAlignFeature feature SO acc is correct (protein_match)');
+is($dnaf->feature_so_term, 'protein_match', 'dnaPepAlignFeature feature SO term is correct (protein_match)');
 
 #
 # 12 Test retrieval from database

--- a/modules/t/exon.t
+++ b/modules/t/exon.t
@@ -114,6 +114,7 @@ allow_warnings(0) if $db->dbc->driver() eq 'SQLite';
 ok($exon->dbID() && $exon->adaptor == $exonad);
 
 is($exon->feature_so_acc, 'SO:0000147', 'Exon feature SO acc is correct (exon)');
+is($exon->feature_so_term, 'exon', 'Exon feature SO term is correct (exon)');
 
 # now test fetch_by_dbID
 

--- a/modules/t/feature.t
+++ b/modules/t/feature.t
@@ -68,6 +68,8 @@ ok($feature->strand == $strand);
 ok($feature->analysis == $analysis);
 ok($feature->slice == $slice);
 is($feature->feature_so_acc, 'SO:0000001', 'Feature feature SO acc is correct (feature)');
+is($feature->feature_so_term, 'region', 'Feature feature SO term is correct (feature)');
+
 
 #
 # Test setters

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -99,6 +99,7 @@ debug("Gene display xref id: " . $gene->display_xref->dbID);
 ok($gene->display_xref->dbID() == 128324);
 
 is($gene->feature_so_acc, 'SO:0000704', 'Gene feature SO acc is correct (gene)');
+is($gene->feature_so_term, 'gene', 'Gene feature SO term is correct (gene)');
 
 # test the getters and setters
 ok(test_getter_setter($gene, "external_name", "banana"));

--- a/modules/t/karyotypeBand.t
+++ b/modules/t/karyotypeBand.t
@@ -58,6 +58,7 @@ ok($kb->name() eq $name);
 ok($kb->slice == $slice);
 ok($kb->display_id eq $name);
 is($kb->feature_so_acc, 'SO:0000341', 'KaryotypeBand feature SO acc is correct (chromosome_band)');
+is($kb->feature_so_term, 'chromosome_band', 'KaryotypeBand feature SO term is correct (chromosome_band)');
 
 #
 # test getter/setters

--- a/modules/t/miscFeature.t
+++ b/modules/t/miscFeature.t
@@ -32,6 +32,7 @@ my $mf = Bio::EnsEMBL::MiscFeature->new(-START => 10,
 
 ok($mf->start() == 10 && $mf->end() == 100);
 is($mf->feature_so_acc, 'SO:0001411', 'MiscFeature feature SO acc is correct (biological_region)');
+is($mf->feature_so_term, 'biological_region', 'MiscFeature feature SO term is correct (biological_region)');
 
 
 #

--- a/modules/t/predictionTranscript.t
+++ b/modules/t/predictionTranscript.t
@@ -132,6 +132,7 @@ $exon->strand( 1 );
 $pt->add_Exon($exon);
 
 is($exon->feature_so_acc, 'SO:0000147', 'PredictionExon feature SO acc is correct (exon)');
+is($exon->feature_so_term, 'exon', 'PredictionExon feature SO term is correct (exon)');
 
 #check that transcript start + end updated
 ok( $pt->end() == 50 );

--- a/modules/t/repeatFeature.t
+++ b/modules/t/repeatFeature.t
@@ -87,6 +87,7 @@ ok($rf->score == $score);
 ok($rf->repeat_consensus == $repeat_consensus);
 
 is($rf->feature_so_acc, 'SO:0000657', 'RepeatFeature feature SO acc is correct (repeat_region)');
+is($rf->feature_so_term, 'repeat_region', 'RepeatFeature feature SO term is correct (repeat_region)');
 
 #
 # Test Getter/Setters

--- a/modules/t/simpleFeature.t
+++ b/modules/t/simpleFeature.t
@@ -151,6 +151,7 @@ my $ids = $sfa->list_dbIDs();
 ok (@{$ids});
 
 is($feat->feature_so_acc, 'SO:0001411', 'SimpleFeature feature SO acc is correct (biological_region)');
+is($feat->feature_so_term, 'biological_region', 'SimpleFeature feature SO term is correct (biological_region)');
 
 ok($feat->display_id eq $feat->display_label);
 

--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:04 2019
+-- Created on Tue Feb 12 15:00:15 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -127,3 +127,4 @@
 127	\N	patch	patch_94_95_c.sql|ox_key_update
 128	\N	patch	patch_95_96_a.sql|schema_version
 129	\N	patch	patch_96_97_a.sql|schema_version
+130	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=130 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=131 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:08 2019
+-- Created on Tue Feb 12 15:00:19 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/homo_sapiens/core/biotype.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/biotype.txt
@@ -1,3 +1,3 @@
-64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0001217
-65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0000234
-87	tRNA	gene	core,otherfeatures,presite	76	\N	snoncoding	SO:0001263
+64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0001217	protein_coding_gene
+65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0000234	mRNA
+87	tRNA	gene	core,otherfeatures,presite	76	\N	snoncoding	SO:0001263	ncRNA_gene

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -106,3 +106,4 @@
 173	\N	patch	patch_94_95_c.sql|ox_key_update
 174	\N	patch	patch_95_96_a.sql|schema_version
 175	\N	patch	patch_96_97_a.sql|schema_version
+176	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM AUTO_INCREMENT=88 DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=176 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=177 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:11 2019
+-- Created on Tue Feb 12 15:00:22 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -106,3 +106,4 @@
 155	\N	patch	patch_94_95_c.sql|ox_key_update
 156	\N	patch	patch_95_96_a.sql|schema_version
 157	\N	patch	patch_96_97_a.sql|schema_version
+158	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=158 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=159 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:14 2019
+-- Created on Tue Feb 12 15:00:25 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -111,3 +111,4 @@
 2118	\N	patch	patch_94_95_c.sql|ox_key_update
 2119	\N	patch	patch_95_96_a.sql|schema_version
 2120	\N	patch	patch_96_97_a.sql|schema_version
+2121	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2121 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2122 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:15 2019
+-- Created on Tue Feb 12 15:00:26 2019
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:18 2019
+-- Created on Tue Feb 12 15:00:29 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -67,3 +67,4 @@
 160	\N	patch	patch_94_95_c.sql|ox_key_update
 161	\N	patch	patch_95_96_a.sql|schema_version
 162	\N	patch	patch_96_97_a.sql|schema_version
+163	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:21 2019
+-- Created on Tue Feb 12 15:00:32 2019
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:24 2019
+-- Created on Tue Feb 12 15:00:36 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -184,3 +184,4 @@
 1696	\N	patch	patch_94_95_c.sql|ox_key_update
 1697	\N	patch	patch_95_96_a.sql|schema_version
 1698	\N	patch	patch_96_97_a.sql|schema_version
+1699	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1699 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1700 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:27 2019
+-- Created on Tue Feb 12 15:00:40 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/nameless/core/meta.txt
+++ b/modules/t/test-genome-DBs/nameless/core/meta.txt
@@ -105,3 +105,4 @@
 159	\N	patch	patch_94_95_c.sql|ox_key_update
 160	\N	patch	patch_95_96_a.sql|schema_version
 161	\N	patch	patch_96_97_a.sql|schema_version
+162	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -479,7 +480,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=162 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:29 2019
+-- Created on Tue Feb 12 15:00:43 2019
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:32 2019
+-- Created on Tue Feb 12 15:00:46 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -160,3 +160,4 @@
 240	\N	patch	patch_94_95_c.sql|ox_key_update
 241	\N	patch	patch_95_96_a.sql|schema_version
 242	\N	patch	patch_96_97_a.sql|schema_version
+243	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=243 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=244 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Feb 12 11:45:35 2019
+-- Created on Tue Feb 12 15:00:49 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -142,7 +142,8 @@ CREATE TABLE "biotype" (
   "attrib_type_id" integer,
   "description" text,
   "biotype_group" enum,
-  "so_acc" varchar(64)
+  "so_acc" varchar(64),
+  "so_term" varchar(1023)
 );
 
 CREATE UNIQUE INDEX "name_type_idx" ON "biotype" ("name", "object_type");

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -180,3 +180,4 @@
 222	\N	patch	patch_94_95_c.sql|ox_key_update
 223	\N	patch	patch_95_96_a.sql|schema_version
 224	\N	patch	patch_96_97_a.sql|schema_version
+225	\N	patch	patch_96_97_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -479,7 +480,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=225 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=226 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -163,6 +163,7 @@ is( $tr->coding_region_start(), 85834, 'Correct coding region start' );
 is( $tr->coding_region_end(), 108631, 'Correct coding region end' );
 
 is( $tr->feature_so_acc, 'SO:0000673', 'Transcript feature SO acc is correct (transcript)' );
+is( $tr->feature_so_term, 'transcript', 'Transcript feature SO term is correct (transcript)' );
 
 my @pepcoords = $tr->pep2genomic( 10, 20 );
 is( $pepcoords[0]->start(), 85861, 'Correct translation start' );

--- a/modules/t/utr.t
+++ b/modules/t/utr.t
@@ -78,8 +78,9 @@ sub try_utrs {
     is($five_utrs[0]->seq_region_start, $transcript->seq_region_start, "Five prime seq_region_starts at transcript seq_region_start");
     is($three_utrs[$three-1]->seq_region_end, $transcript->seq_region_end, "Three prime seq_region_ends at transcript seq_region_end");
     is($five_utrs[0]->feature_so_acc, 'SO:0000204', 'UTR feature SO acc is correct (five_prime_utr)');
+    is($five_utrs[0]->feature_so_term, 'five_prime_UTR', 'UTR feature SO term is correct (five_prime_utr)');
     is($three_utrs[0]->feature_so_acc, 'SO:0000205', 'UTR feature SO acc is correct (three_prime_utr)');
-
+    is($three_utrs[0]->feature_so_term, 'three_prime_UTR', 'UTR feature SO term is correct (three_prime_utr)');
 }
 
 sub try_utrs_reverse {

--- a/sql/patch_96_97_b.sql
+++ b/sql/patch_96_97_b.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_96_97_b.sql
+#
+# Title: Add so_term column to biotype table.
+#
+# Description:
+#   Update biotype table to include a new so_term column.
+
+-- Add new column so_term
+ALTER TABLE biotype ADD COLUMN so_term VARCHAR(1023) AFTER so_acc;
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_96_97_b.sql|biotype_so_term');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -316,6 +316,8 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_96_97_a.sql|schema_version');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_96_97_b.sql|biotype_so_term');
 
 /**
 @table meta_coord
@@ -2182,6 +2184,7 @@ CREATE TABLE external_db (
 @column description             Description.
 @column biotype_group           Group, e.g. 'coding', 'pseudogene', 'snoncoding', 'lnoncoding', 'mnoncoding', 'LRG', 'undefined', 'no_group'
 @column so_acc                  Sequence Ontology accession of the biotype.
+@column so_term                 Sequence Ontology term of the biotype.
 
 @see attrib_type
 
@@ -2197,6 +2200,7 @@ CREATE TABLE biotype (
   description     TEXT,
   biotype_group   ENUM('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   so_acc          VARCHAR(64),
+  so_term         VARCHAR(1023),
   PRIMARY KEY (biotype_id),
   UNIQUE KEY name_type_idx (name, object_type)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
This adds so_term column to the biotype column and to the Biotype objects.
Production master_biotype table needs updating (https://github.com/Ensembl/ensembl-production/pull/218)
Core Features have also been updated to include feature_so_term method, in the likelihood of feature_so_acc. Features of compara, regulation and variation need updating through separate pull requests to follow. 

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Biotype objects will now report the so_term in addition to the so_acc, thus an ontology database dependency is avoided. Features will also report the so_term.

## Benefits

_If applicable, describe the advantages the changes will have._
Improved Biotype objects and no need for ontology database to look up so terms.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
A bit more data in the biotype table.

## Testing

_Have you added/modified unit tests to test the changes?_
yes

_If so, do the tests pass/fail?_
pass

_Have you run the entire test suite and no regression was detected?_
yes
