### PR TITLE
Restore analysis adaptor's ability to store/update web_data

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
@@ -62,6 +62,8 @@ use Bio::EnsEMBL::Analysis;
 use Bio::EnsEMBL::DBSQL::BaseAdaptor;
 use Bio::EnsEMBL::Utils::Exception;
 
+use Data::Dumper;
+$Data::Dumper::Terse = 1;
 
 use vars qw(@ISA);
 use strict;
@@ -463,7 +465,7 @@ sub _store_description {
   my $display_label = $analysis->display_label();
   $display_label = '' unless defined $display_label; # SQLite doesn't ignore NOT NULL errors
 
-  my $web_data;
+  my $web_data = Dumper($analysis->web_data) if defined $analysis->web_data;
 
   $sth->bind_param(1,$dbID,SQL_INTEGER);
   $sth->bind_param(2,$display_label,SQL_VARCHAR);
@@ -534,14 +536,13 @@ sub update {
   # not already there
   $sth = $self->prepare("SELECT description FROM analysis_description WHERE analysis_id= ?");
   $sth->execute($a->dbID);
-  my $web_data; #this is an anonymous reference to a hash, will have to be dumped into string before writing to db
+  my $web_data = Dumper($a->web_data) if defined $a->web_data;
   if ($sth->fetchrow_hashref) { # update if exists
       $sth = $self->prepare
       ("UPDATE analysis_description SET description = ?, display_label = ?, displayable = ?, web_data = ? WHERE analysis_id = ?");
       $sth->bind_param(1,$a->description,SQL_LONGVARCHAR);     
       $sth->bind_param(2,$a->display_label(),SQL_VARCHAR);
       $sth->bind_param(3,$a->displayable,SQL_TINYINT);
-      #      print "after $web_data\n";
       $sth->bind_param(4,$web_data,SQL_LONGVARCHAR);
       $sth->bind_param(5,$a->dbID,SQL_INTEGER);
       $sth->execute();

--- a/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
@@ -62,11 +62,11 @@ use Bio::EnsEMBL::Analysis;
 use Bio::EnsEMBL::DBSQL::BaseAdaptor;
 use Bio::EnsEMBL::Utils::Exception;
 
-use Data::Dumper;
-$Data::Dumper::Terse = 1;
-
 use vars qw(@ISA);
 use strict;
+
+use Data::Dumper;
+$Data::Dumper::Terse = 1;
 
 @ISA = qw( Bio::EnsEMBL::DBSQL::BaseAdaptor);
 
@@ -465,7 +465,8 @@ sub _store_description {
   my $display_label = $analysis->display_label();
   $display_label = '' unless defined $display_label; # SQLite doesn't ignore NOT NULL errors
 
-  my $web_data = Dumper($analysis->web_data) if defined $analysis->web_data;
+  my $web_data;
+  $web_data = Dumper($analysis->web_data) if defined $analysis->web_data;
 
   $sth->bind_param(1,$dbID,SQL_INTEGER);
   $sth->bind_param(2,$display_label,SQL_VARCHAR);
@@ -536,7 +537,8 @@ sub update {
   # not already there
   $sth = $self->prepare("SELECT description FROM analysis_description WHERE analysis_id= ?");
   $sth->execute($a->dbID);
-  my $web_data = Dumper($a->web_data) if defined $a->web_data;
+  my $web_data;
+  $web_data = Dumper($a->web_data) if defined $a->web_data;
   if ($sth->fetchrow_hashref) { # update if exists
       $sth = $self->prepare
       ("UPDATE analysis_description SET description = ?, display_label = ?, displayable = ?, web_data = ? WHERE analysis_id = ?");

--- a/modules/t/analysis.t
+++ b/modules/t/analysis.t
@@ -64,6 +64,9 @@ $analysis_ad->store($analysis);
 
 ok(defined $analysis->dbID() );
 
+# Need to explicitly delete cache, otherwise we just return that,
+# and don't actually extract the data from the table and truly verify storage.
+$analysis_ad->{_logic_name_cache} = {};
 
 my $analysis_out = $analysis_ad->fetch_by_logic_name('dummy_analysis');
 
@@ -94,7 +97,7 @@ is($analysis_updated->logic_name(), "new_dummy", "Logic name is correct");
 is($analysis_updated->description(), "new description", "Description is correct");
 is($analysis_updated->display_label(), "new label", "Label is correct");
 is($analysis_updated->displayable(), 0, "Displayable is correct");
-is($analysis_updated->web_data(), undef, "web_data is wiped on update");
+is($analysis_updated->web_data(), "blahblah", "web_data is correct");
 
 # now try updating analysis that has no existing description
 $analysis = Bio::EnsEMBL::Analysis->new();


### PR DESCRIPTION
## Description
When the 'evil eval' for making hashes out of strings was removed from the main adaptor code, it was added to the AnalysisAdaptor, to cater for the last remaining usage in the API, analysis.web_data. At this time the inverse operation was also removed, for stringifying a hash to be inserted or updated in the database. I believe this to be incorrect; there is a test for correct storage of web_data, but due to a bug in the test, it was not working properly; storage in the db was never tested, because data would always be retrieved from a cache instead.

Note that this relates to https://github.com/Ensembl/ensembl/pull/351, and effectively reverts the code changes there; it is not intended (or useful) for an update to delete web_data from the object.

## Use case
As a general principle, 'store' functions should store all of an object's data, rather than silently omit bits. In particular, EG and Production pipelines extract analysis data from the production db and insert it into core dbs, via the API - without this fix, the web_data is always set to NULL, which causes problems down the road. This is mitigated for some teams by the practice of synchronising production and core dbs, but others (VectorBase, WormBase) do not do this.
I think it is better practice for pipelines to add all of the analysis data when the relevant pipeline is run, rather than relying on a script to be run at a later date to synchronise from the production db; this change supports that practice.

## Benefits
'store' and 'update' methods (and consequently EG and Production pipelines) work as expected.

## Possible Drawbacks
None I can think of.

## Testing
_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes
