### PR TITLE
Bugfix/feature so term 97

### DIFF
--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -3054,6 +3054,7 @@ my %region_so_mapping = (
   Example     : $slice_so_acc = $slice->feature_so_acc;
   Description : This method returns a string containing the SO accession number of the slice, based on the coordinate system name.
   Returns     : string (Sequence Ontology accession number)
+
 =cut
 
 sub feature_so_acc {
@@ -3061,6 +3062,23 @@ sub feature_so_acc {
 
   # return the region SO acc, or Slice acc
   return $region_so_mapping{$self->coord_system_name} // 'SO:0000001';
+}
+
+=head2 feature_so_term
+
+  Description: This method returns a string containing the SO term of the slice, based on the coordinate system name
+               Define constant SEQUENCE_ONTOLOGY in classes that require it, or override it for multiple possible values for a class.
+  Returntype : String (Sequence Ontology term)
+  Exceptions : Thrown if caller SEQUENCE_ONTOLOGY is undefined and is not a Bio::EnsEMBL::Slice
+
+=cut
+
+sub feature_so_term {
+  my ($self) = shift;
+
+  return defined($region_so_mapping{$self->coord_system_name}) ?
+         $self->coord_system_name :
+         'region';
 }
 
 =head2 summary_as_hash

--- a/modules/t/slice.t
+++ b/modules/t/slice.t
@@ -57,6 +57,7 @@ is($slice->end, $END, "Slice end is $END");
 is($slice->seq_region_length, 62842997, "Slice length is correct");
 is($slice->adaptor, $slice_adaptor, "Slice has adaptor $slice_adaptor");
 is($slice->feature_so_acc, 'SO:0000340', 'Slice feature SO acc is correct (chromosome)');
+is($slice->feature_so_term, 'chromosome', 'Slice feature SO term is correct (chromosome)');
 
 #
 #TEST - Slice::new
@@ -221,6 +222,7 @@ is($clone->start, 1001, "Expanded clone start is correct if forced");
 is($clone->end(), $len + 1000, "Expanded clone end is correct if forced");
 
 is($clone->feature_so_acc, 'SO:0000001', 'Clone feature SO acc is correct (region)');
+is($clone->feature_so_term, 'region', 'Clone feature SO term is correct (region)');
 
 #
 # Test constrain_to_seq_region


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Adds feature_so_term() method to Slice, as was done with Feature.

## Use case

This is required by methods in Bio::EnsEMBL::Utils::IO::GFFSerializer, among others

## Benefits



## Possible Drawbacks

Allows fetching SO terms for slices, along with SO accession numbers, as can be done with features

## Testing

Yes

_If so, do the tests pass/fail?_

Pass

_Have you run the entire test suite and no regression was detected?_

On master