### PR TITLE
Changed attribute code length to 14 characters.

### DIFF
--- a/modules/Bio/EnsEMBL/StopCodonReadthroughEdit.pm
+++ b/modules/Bio/EnsEMBL/StopCodonReadthroughEdit.pm
@@ -57,7 +57,7 @@ limitations under the License.
   It is believed the STOP codon is instead read as a 'sense' codon, i.e. encodes for an amino acid.
 
   The location of a STOP codon readthrough is indicated by an asterisk (*) in the post translation sequence.
-  This class edits the sequence to replace the asterisk (*) with an 'X' to make it similar to Uniprot representation.
+  This class edits the sequence to replace the asterisk (*) with an 'X' to make it similar to RefSeq representation.
 
 =head1 METHODS
 
@@ -92,7 +92,7 @@ sub new {
         -START   => $position,
         -END     => $position,
         -ALT_SEQ => 'X',
-        -CODE    => '_stop_codon_readthrough');
+        -CODE    => '_stop_codon_rt');
 
   return $stop_codon_rt_edit;
 

--- a/modules/Bio/EnsEMBL/Translation.pm
+++ b/modules/Bio/EnsEMBL/Translation.pm
@@ -1108,7 +1108,7 @@ sub get_all_SeqEdits {
 
   my $attribs;
   
-  $edits ||= ['initial_met', '_selenocysteine', 'amino_acid_sub', '_stop_codon_readthrough'];
+  $edits ||= ['initial_met', '_selenocysteine', 'amino_acid_sub', '_stop_codon_rt'];
   
 
   foreach my $edit(@{wrap_array($edits)}){
@@ -1149,7 +1149,7 @@ sub get_all_selenocysteine_SeqEdits {
 
 sub get_all_stop_codon_SeqEdits {
   my ($self) = @_;
-  return $self->get_all_SeqEdits(['_stop_codon_readthrough']);
+  return $self->get_all_SeqEdits(['_stop_codon_rt']);
 }
 
 =head2 modify_translation

--- a/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
@@ -20,4 +20,4 @@
 20	proj_parent_g	projection parent gene	Stable identifier of the parent gene this gene was projected from (projection between different species and/or assemblies).
 21	proj_parent_t	projection parent transcript	Stable identifier of the parent transcript this transcript was projected from (projection between different species and/or assemblies).
 22	mirna_arm	miRNA arm	Hairpin arm from which this miRNA has come from
-23	_stop_codon_readthrough	Stop Codon Readthrough	\N
+23	_stop_codon_rt	Stop Codon Readthrough	\N


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

ENSCORESW-3110- Feature to handle stop codon readthrough in amino acid sequence.

## Use case

The attribute code had to be modified to fit the column definition in attrib_type table. 

## Benefits

The attribute code when added to the production database will not fail any tests. 

## Possible Drawbacks

None

## Testing

None required. This is a followup to PR #372. The test case remains the same. 



