### PR TITLE
Store web_data without newlines

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
@@ -67,6 +67,7 @@ use strict;
 
 use Data::Dumper;
 $Data::Dumper::Terse = 1;
+$Data::Dumper::Indent = 0;
 
 @ISA = qw( Bio::EnsEMBL::DBSQL::BaseAdaptor);
 

--- a/modules/t/analysis.t
+++ b/modules/t/analysis.t
@@ -64,6 +64,9 @@ $analysis_ad->store($analysis);
 
 ok(defined $analysis->dbID() );
 
+# Check that web_data is stored without newlines
+unlike(retrieve_web_data($db, $analysis->dbID), '/\n/', "No newlines in stored web_data");
+
 # Need to explicitly delete cache, otherwise we just return that,
 # and don't actually extract the data from the table and truly verify storage.
 $analysis_ad->{_logic_name_cache} = {};
@@ -89,7 +92,7 @@ $analysis->logic_name("new_dummy");
 $analysis->description("new description");
 $analysis->display_label("new label");
 $analysis->displayable(0);
-$analysis->web_data("blahblah");
+$analysis->web_data({thing => 'blahblah'});
 my $dbID = $analysis->dbID();
 $analysis_ad->update($analysis);
 my $analysis_updated = $analysis_ad->fetch_by_dbID($dbID);
@@ -97,7 +100,10 @@ is($analysis_updated->logic_name(), "new_dummy", "Logic name is correct");
 is($analysis_updated->description(), "new description", "Description is correct");
 is($analysis_updated->display_label(), "new label", "Label is correct");
 is($analysis_updated->displayable(), 0, "Displayable is correct");
-is($analysis_updated->web_data(), "blahblah", "web_data is correct");
+is($analysis_updated->web_data->{thing}, "blahblah", "web_data is correct");
+
+# Check that web_data is stored without newlines
+unlike(retrieve_web_data($db, $dbID), '/\n/', "No newlines in updated web_data");
 
 # now try updating analysis that has no existing description
 $analysis = Bio::EnsEMBL::Analysis->new();
@@ -134,6 +140,14 @@ sub check_methods {
     }
   }
   return $all_implemented;
+}
+
+sub retrieve_web_data {
+  my ($db, $dbID) = @_;
+
+  my $sql_helper = $db->dbc->sql_helper;
+  my $sql = "SELECT web_data FROM analysis_description WHERE analysis_id = $dbID";
+  return $sql_helper->execute_single_result(-SQL => $sql);
 }
 
 done_testing();


### PR DESCRIPTION
## Description
This is a follow-up to #367, which enabled the API to store and update web_data. The format is a flattened hash, which is stored as a string in the database. That PR converted the hashes into strings with embedded newlines, which looks pretty, but was not intended, because historically this is not how the data has been stored. I'm not aware of newlines being problematic, but it's conceivable that, say, a regex somewhere might not work on a multiline string. This PR removes newlines from the stored web_data.

## Use case
Various Production and non-vert pipelines use this API functionality to propagate web_data from the production DB to core DBs.

## Benefits
Makes code fully consistent with previous functionality; avoids potential parsing problems.

## Possible Drawbacks
None I'm aware of.

## Testing
_Have you added/modified unit tests to test the changes?_
Yes, analysis.t

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes
