### PR TITLE
ENSCORESW-3147: correctly capture all required fields from file

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
@@ -141,11 +141,17 @@ sub run_script {
   } else {
     my $file_io = $self->get_filehandle($file);
     if ( !defined $file_io ) {
-      print "ERROR: Can't open HGNC file $file\n";
+      print "ERROR: Can't open RFAM file $file\n";
       return 1;
     }
+    my $temp_line;
     while (my $line = $file_io->getline()) {
-      push(@lines, $line); 
+      if ($line =~ /\/\//) {
+        push @lines, $temp_line;
+        $temp_line = '';
+      } else {
+        $temp_line .= $line . "\n";
+      }
     }
   }
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The RFAM parser does not capture all required fields when run as part of the eHive xref pipeline. This is because the file is read line by line from disk, while the information for a single entry is split across multiple lines.
The proposed change groups the lines in logical blocks representing a single RFAM entry.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Since the move to the eHive-based xref pipeline, all RFAM xrefs are missing descriptions and their label is identical to the accession when it should not be.
The proposed fix ensures both label and description are stored in the database and can be displayed on the browser.
This was reported by a user who compared the same gene across two zebrafish assemblies, see
http://apr2018.archive.ensembl.org/Danio_rerio/Transcript/Summary?db=core;g=ENSDARG00000082665;r=25:8247670-8247787;t=ENSDART00000116947
versus
http://dec2017.archive.ensembl.org/Danio_rerio/Transcript/Summary?db=core;g=ENSDARG00000082665;r=25:8247670-8247787;t=ENSDART00000116947

## Benefits

_If applicable, describe the advantages the changes will have._
Useful information from RFAM is correctly stored and displayed to our users.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
The proposed fix is not the prettiest and results in storing multiple lines in memory. However, the RFAM file is small so this should not have a major impact on memory requirements.

## Testing

_Have you added/modified unit tests to test the changes?_
NA, the current xref pipeline does not have unit tests.
The pipeline was run with and without the fix though to ensure the data is captured correctly.

_If so, do the tests pass/fail?_
NA

_Have you run the entire test suite and no regression was detected?_
NA

