### PR TITLE
Make the Coveralls badge in the README work [release/97]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Ensembl Core API
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl.png?branch=master)][travis]
-[![Coverage Status](https://coveralls.io/repos/Ensembl/ensembl/badge.png)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=master)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=master)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
-[coveralls]: https://coveralls.io/r/Ensembl/ensembl
+[coveralls]: https://coveralls.io/github/Ensembl/ensembl
 
 


### PR DESCRIPTION
## Description

Update Coveralls URIs in README.md so to get the badge working. This is a backport of #385 to _release/97_ so that we aren't stuck with "coverage: unknown" on the main GitHub page of this repository all the way until the release of version 98.

## Use case

Our Coveralls badge as it is keeps saying "unknown" because it doesn't specify the branch in the URI, which apparently is necessary in case of Coveralls (and recommended for Travis as well). Moreover, the URI itself might be outdated.

## Benefits

Actually get the badge to work.

## Possible Drawbacks

Keeping it working for release branches will require updating the README as part of the release procedure.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, this is a change to documentation - and a quantitative one at that.