### PR TITLE
The ontology schema patches have been moved from ensembl/misc_scripts…

### DIFF
--- a/misc-scripts/schema_patcher.pl
+++ b/misc-scripts/schema_patcher.pl
@@ -285,7 +285,7 @@ foreach my $thing ( [ 'ensembl',               'core',        'table.sql'   ],
                     [ 'ensembl-funcgen',       'funcgen',     'table.sql'   ],
                     [ 'ensembl-variation',     'variation',   'table.sql'   ],
                     [ 'ensembl-production',    'production',  'table.sql'  ],
-                    [ 'ensembl',               'ontology',    'tables.sql'  ] )
+                    [ 'ols-ensembl-loader',    'ontology',    'tables.sql'  ] )
 {
   my ($git_repo, $schema_type, $schema_file) = @{$thing};
 
@@ -687,12 +687,7 @@ sub _sql_dir {
     $directories = curdir() unless $directories;
     $git_dir = catdir($directories, updir(), updir());
   }
-  my $sql_dir;
-  if ($schema_type eq 'ontology') {
-    $sql_dir = rel2abs(canonpath( catdir( $git_dir, $git_repo, 'misc-scripts', 'ontology', 'sql' ) ));
-  } else {
-    $sql_dir = rel2abs(canonpath( catdir( $git_dir, $git_repo, 'sql' ) ));
-  }
+  my $sql_dir = rel2abs(canonpath( catdir( $git_dir, $git_repo, 'sql' ) ));
   my $schema_location = catfile($sql_dir, $schema_file);
   if(! -f $schema_location) {
     if($opt_verbose) {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The ontology schema patches have been moved from ensembl/misc_scripts/ontology/sql to ols-ensembl-loader/sql

## Use case

The script is broken at the moment: "No SQL directory found for Git repo ensembl, ontology schema type"

## Benefits

The script will work again and will look at the right place for ontology sqls

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_
No
_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

