### PR TITLE
Enable VGNC xrefs for felis_catus, macaca_mulatta and microcebus_murinus

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -502,6 +502,33 @@ priority        = 1
 parser          = VGNCParser
 data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
 
+[source VGNC::felis_catus]
+# Used by felis_catus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::macaca_mulatta]
+# Used by macaca_mulatta
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::microcebus_murinus]
+# Used by microcebus_murinus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
 [source HGNC::homo_sapiens#01]
 # Used by homo_sapiens
 name            = HGNC
@@ -1890,6 +1917,18 @@ source          = VGNC::equus_caballus
 [species pan_troglodytes]
 taxonomy_id     = 9598
 source          = VGNC::pan_troglodytes
+
+[species felis_catus]
+taxonomy_id     = 9685
+source          = VGNC::felis_catus
+
+[species macaca_mulatta]
+taxonomy_id     = 9544
+source          = VGNC::macaca_mulatta
+
+[species microcebus_murinus]
+taxonomy_id     = 30608
+source          = VGNC::microcebus_murinus
 
 [species ciona_intestinalis]
 taxonomy_id     = 7719


### PR DESCRIPTION
## Description

Enable production of VGNC xrefs for additional three species: cat, macaque, mouse lemur. See ENSCORESW-3173.

## Use case

VGNC has recently begun to provide data for these three species and have requested Ensembl to enable production of corresponding xrefs.

## Benefits

More VGNC xrefs in Ensembl.

## Possible Drawbacks

Increased run time of the xref pipeline. That said, a single run of VGNCParser takes in the order of seconds so it will not be a large increase.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected. I have also run VGNCParser in standalone mode on the three new species and the output seems to make sense.