### PR TITLE
ENSCORESW-3132: Limited implementation of Intervals with start > end …

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Immutable.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Immutable.pm
@@ -62,6 +62,9 @@ be added to or removed from the tree during its life cycle.
 
 Implementation heavily inspired by https://github.com/tylerkahn/intervaltree-python
 
+This implementation does not support Intervals having a start > end - i.e.
+intervals spanning the origin of a circular chromosome.
+
 =head1 METHODS
 
 =cut
@@ -297,6 +300,9 @@ sub _divide_intervals {
   my ($s_center, $s_left, $s_right) = ([], [], []);
   
   foreach my $interval (@{$intervals}) {
+    if ($interval->spans_origin) {
+      throw "Cannot build a tree containing an interval that spans the origin";
+    }
     if ($interval->end < $x_center) {
       push @{$s_left}, $interval;
     } elsif ($interval->start > $x_center) {

--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable/PP.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable/PP.pm
@@ -48,6 +48,7 @@ use Carp;
 
 use Bio::EnsEMBL::Utils::Tree::Interval::Mutable::Node;
 use Bio::EnsEMBL::Utils::Interval;
+use Bio::EnsEMBL::Utils::Exception qw(throw);
 
 =head2 new
 
@@ -108,7 +109,7 @@ sub size {
   Example     : $tree->insert(Bio::EnsEMBL::Utils::Interval->new(10, 20, 'data'));
   Description : Insert an interval in the tree
   Returntype  : scalar (1), upon success
-  Exceptions  : none
+  Exceptions  : thrown if Interval spans origin (has start > end)
   Caller      : general
 
 =cut
@@ -116,6 +117,9 @@ sub size {
 sub insert {
   my ($self, $i) = @_;
   
+  if ($i->spans_origin) {
+    throw "Cannot insert an interval that spans the origin into a mutable tree";
+  }
   # base case: empty tree, assign new node to root
   unless (defined $self->root) {
     $self->root(Bio::EnsEMBL::Utils::Tree::Interval::Mutable::Node->new($self, $i));

--- a/modules/t/interval_tree_immutable.t
+++ b/modules/t/interval_tree_immutable.t
@@ -25,8 +25,6 @@ use_ok 'Bio::EnsEMBL::Utils::Interval';
 
 throws_ok { Bio::EnsEMBL::Utils::Interval->new() } qr/specify.+?boundaries/, 'Throws with no arguments';
 throws_ok { Bio::EnsEMBL::Utils::Interval->new(1) } qr/specify.+?boundaries/, 'Throws with an undefined argument';
-throws_ok { Bio::EnsEMBL::Utils::Interval->new(10, 1) } qr/start.+?end/, 'Throws with invalid arguments';
-throws_ok { Bio::EnsEMBL::Utils::Interval->new(100, 10) } qr/start.+?end/, 'Throws with invalid arguments';
 
 # degenerate (point) case
 my $i = Bio::EnsEMBL::Utils::Interval->new(10, 10);
@@ -36,26 +34,81 @@ ok($i->is_point, 'interval is point');
 
 # a normal interval, start < end
 $i = Bio::EnsEMBL::Utils::Interval->new(100, 200);
+# an interval spanning the origin, start > end
+my $i_span = Bio::EnsEMBL::Utils::Interval->new(200,100);
+
 isa_ok($i, 'Bio::EnsEMBL::Utils::Interval');
+isa_ok($i_span, 'Bio::EnsEMBL::Utils::Interval');
+
+is($i->spans_origin, 0, 'spans_origin false for non-spanning interval');
+is($i_span->spans_origin, 1, 'spans_origin true for spanning interval');
+
 is($i->start, 100, 'start position');
 is($i->end, 200, 'end position');
+is($i_span->start, 200, 'spanning start position');
+is($i_span->end, 100, 'spanning end position');
+
 ok(!$i->is_empty, 'interval not empty');
 ok(!$i->is_point, 'interval\'s not a point');
+ok(!$i_span->is_empty, 'interval not empty');
+ok(!$i_span->is_point, 'interval\'s not a point');
+
 ok($i->contains(100) && $i->contains(200) && $i->contains(150), 'interval contains points');
 ok(!$i->contains(99) && !$i->contains(201), 'interval does not contain points');
+ok($i_span->contains(100) && $i_span->contains(200) && $i_span->contains(250), 'spanning interval contains points');
+ok(!$i_span->contains(101) && !$i_span->contains(199), 'spanning interval does not contain points');
+
 # check is_right_of/is_left_of with point/interval
 ok(!$i->is_right_of && !$i->is_left_of, 'interval is not left/right of nothing');
+ok(!$i_span->is_right_of && !$i_span->is_left_of, 'spanning interval is not left/right of nothing');
+
 ok($i->is_right_of(99), 'interval right of point');
 ok(!$i->is_right_of(100) && !$i->is_right_of(150) && !$i->is_right_of(201), 'interval not right of point');
 ok($i->is_left_of(201), 'interval left of point');
 ok(!$i->is_left_of(99) && !$i->is_left_of(150) && !$i->is_left_of(200), 'interval not left of point');
+throws_ok { $i_span->is_right_of(150) }
+  qr/is_right_of not defined for an interval that spans the origin/,
+  'exception calling is_right_of with a spanning interval and a point';
+throws_ok { $i_span->is_left_of(150) }
+  qr/is_left_of not defined for an interval that spans the origin/,
+  'exception calling is_left_of with a spanning interval and a point';
+
 my $j = Bio::EnsEMBL::Utils::Interval->new(50, 99);
 my $k = Bio::EnsEMBL::Utils::Interval->new(50, 150);
 my $l = Bio::EnsEMBL::Utils::Interval->new(201, 250);
+my $m = Bio::EnsEMBL::Utils::Interval->new(101, 199);
+my $n_span = Bio::EnsEMBL::Utils::Interval->new(201,100);
+
+# non-spanning with non-spanning query
 ok($i->is_right_of($j), 'interval right of another');
 ok(!$i->is_right_of($k) && !$i->is_right_of($l), 'interval not right of others');
 ok($i->is_left_of($l), 'interval left of another');
 ok(!$i->is_left_of($j) && !$i->is_left_of($k), 'interval not left of others');
+
+# non-spanning with spanning query
+throws_ok { $i->is_right_of($n_span) }
+  qr/is_right_of not defined for an interval that spans the origin/,
+  'exception calling is_right_of with a spanning interval';
+throws_ok { $i->is_left_of($n_span) }
+  qr/is_left_of not defined for an interval that spans the origin/,
+  'exception calling is_left_of with a spanning interval';
+
+# spanning with non-spanning query
+throws_ok { $i_span->is_right_of($m) }
+  qr/is_right_of not defined for an interval that spans the origin/,
+  'exception calling is_right_of with a spanning interval';
+throws_ok { $i_span->is_left_of($m) }
+  qr/is_left_of not defined for an interval that spans the origin/,
+  'exception calling is_left_of with a spanning interval';
+
+# spanning with spanning query
+throws_ok { $i_span->is_right_of($n_span) }
+  qr/is_right_of not defined for an interval that spans the origin/,
+  'exception calling is_right_of with a spanning interval';
+throws_ok { $i_span->is_left_of($n_span) }
+  qr/is_left_of not defined for an interval that spans the origin/,
+  'exception calling is_left_of with a spanning interval';
+
 
 # check interval data
 $j = Bio::EnsEMBL::Utils::Interval->new(100, 200, [100, 200]);
@@ -64,16 +117,30 @@ is_deeply($j->data, [100, 200], 'interval data');
 # check intersection with other intervals
 $k = Bio::EnsEMBL::Utils::Interval->new(50, 150);
 ok($i->intersects($k), 'intervals intersect');
+ok($i_span->intersects($k), 'spanning interval and interval intersect');
 $k = Bio::EnsEMBL::Utils::Interval->new(150, 250);
 ok($i->intersects($k), 'intervals intersect');
 $k = Bio::EnsEMBL::Utils::Interval->new(50, 99);
 ok(!$i->intersects($k), 'intervals do not intersect');
 $k = Bio::EnsEMBL::Utils::Interval->new(201, 250);
 ok(!$i->intersects($k), 'intervals do not intersect');
+$k = Bio::EnsEMBL::Utils::Interval->new(101,199);
+ok(!$i_span->intersects($k), 'spanning interval and interval do not intersect');
+ok($i_span->intersects($n_span), 'two spanning intervals intersect');
+ok($i->intersects($n_span), 'interval and spanning interval intersect');
+my $o_span = Bio::EnsEMBL::Utils::Interval->new(201,99);
+ok(!$i->intersects($o_span), 'interval and spanning interval do not intersect');
 
 use_ok 'Bio::EnsEMBL::Utils::Tree::Interval::Immutable::Node';
 
 use_ok 'Bio::EnsEMBL::Utils::Tree::Interval::Immutable';
+
+my $intervals_with_span = [ Bio::EnsEMBL::Utils::Interval->new(20, 30),
+                            Bio::EnsEMBL::Utils::Interval->new(30, 20)];
+
+throws_ok { my $impossible_tree = Bio::EnsEMBL::Utils::Tree::Interval::Immutable->new($intervals_with_span) }
+  qr/Cannot build a tree containing an interval that spans the origin/,
+  'exception when building an interval tree with an interval that spans the origin';
 
 my $intervals = [ Bio::EnsEMBL::Utils::Interval->new(121626874, 122092717),
 		  Bio::EnsEMBL::Utils::Interval->new(121637917, 121658918),

--- a/modules/t/interval_tree_mutable.t
+++ b/modules/t/interval_tree_mutable.t
@@ -123,6 +123,11 @@ is($search_result->[0]->data, 'data1', 'Search result');
 is($search_result->[1]->data, 'data2', 'Search result');
 
 $tree = Bio::EnsEMBL::Utils::Tree::Interval::Mutable->new();
+throws_ok { $tree->insert(make_interval(200, 100, 'spanning_interval')) }
+  qr/Cannot insert an interval that spans the origin into a mutable tree/,
+  'exception when trying to insert an interval that spans the origin';
+
+$tree = Bio::EnsEMBL::Utils::Tree::Interval::Mutable->new();
 map { $tree->insert($_) } @{$intervals};
 is($tree->size(), scalar @{$intervals}, 'Tree size');
 $search_result = $tree->search(121779004, 121779004);


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Changes to Bio::EnsEMBL::Utils::Interval allowing intervals with a start > end (e.g. spanning the origin of a circular chromosome). This is a quick, simple implementation that allows origin-spanning intervals to be created without throwing an exception. These intervals will identify themselves as origin-spanning, and will react sensibly if queried for overlap or relative position.

Note that the current implementation of IntevalTrees cannot handle an origin-spanning Interval. The current short-term solution is to throw an exception when an origin-spanning interval is put into one of these trees. This is sub-optimal, and the IntervalTree implementations should be updated to handle origin-spanning Intervals with urgency.

## Use case

The new Mapper implementation (see PR #332 ) uses Intervals and Interval Trees that do not handle origin-spanning intervals. It is not possible to even create such an interval, so several scripts that load origin-spanning features have been breaking as a result. Although this fix is quite basic, at least features with start > end can be loaded and worked with in a limited way.

## Benefits

Features with a start > end can be handled in a limited way again

## Possible Drawbacks

This is a very quick and simple implementation, and focuses mostly on Intervals, not how they are handled by IntervalTrees. As a result, although origin-spanning intervals can now be created and subjected to basic queries, the IntervalTrees that handle more complex interval operations are still not able to handle these intervals. The short-term solution is to throw exceptions when an origin-spanning interval is an operand in an operation that the current IntervalTree implementations cannot handle. The IntervalTree implementations will need to be improved to handle more operations with origin-spanning Intervals soon.

Note that the C implementation of IntervalTreeMutable (called through XS) will need to be updated in a separate PR.

## Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes

