### PR TITLE
Test DB: add missing ontology patches [release/97]

### DIFF
--- a/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Apr  2 16:04:14 2019
+-- Created on Mon Jun 17 15:51:15 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -262,7 +262,7 @@ CREATE UNIQUE INDEX "name" ON "relation_type" ("name");
 CREATE TABLE "subset" (
   "subset_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "name" varchar(64) NOT NULL,
-  "definition" varchar(511) NOT NULL DEFAULT ''
+  "definition" varchar(1023) NOT NULL DEFAULT ''
 );
 
 CREATE UNIQUE INDEX "name02" ON "subset" ("name");

--- a/modules/t/test-genome-DBs/ontology/ontology/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/table.sql
@@ -177,7 +177,7 @@ CREATE TABLE `relation_type` (
 CREATE TABLE `subset` (
   `subset_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
-  `definition` varchar(511) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `definition` varchar(1023) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`subset_id`),
   UNIQUE KEY `name` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=18 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -196,13 +196,13 @@ CREATE TABLE `synonym` (
 CREATE TABLE `term` (
   `term_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `ontology_id` int(10) unsigned NOT NULL,
-  `subsets` text COLLATE utf8_unicode_ci,
+  `subsets` text COLLATE utf8_unicode_ci DEFAULT NULL,
   `accession` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
   `name` varchar(255) CHARACTER SET utf8 NOT NULL,
-  `definition` text CHARACTER SET utf8,
-  `is_root` int(11) NOT NULL DEFAULT '0',
-  `is_obsolete` int(11) NOT NULL DEFAULT '0',
-  `iri` text COLLATE utf8_unicode_ci,
+  `definition` text CHARACTER SET utf8 DEFAULT NULL,
+  `is_root` int(11) NOT NULL DEFAULT 0,
+  `is_obsolete` int(11) NOT NULL DEFAULT 0,
+  `iri` text COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`term_id`),
   UNIQUE KEY `accession` (`accession`),
   UNIQUE KEY `term_ontology_acc_idx` (`ontology_id`,`accession`),


### PR DESCRIPTION
The last patching of test databases in this repository missed ontology-DB patches because the patcher script has only just been updated to look for said patches in their new home. Make sure test databases are up to date before the release date.