### PR TITLE
schema_patcher.pl: Update location of ontology schema

### DIFF
--- a/misc-scripts/schema_patcher.pl
+++ b/misc-scripts/schema_patcher.pl
@@ -280,12 +280,12 @@ my %patches;
 
 # Get available patches.
 
-foreach my $thing ( [ 'ensembl',               'core',        'table.sql'   ],
-                    [ 'ensembl-compara',       'compara',     'table.sql'   ], 
-                    [ 'ensembl-funcgen',       'funcgen',     'table.sql'   ],
-                    [ 'ensembl-variation',     'variation',   'table.sql'   ],
-                    [ 'ensembl-production',    'production',  'table.sql'  ],
-                    [ 'ols-ensembl-loader',    'ontology',    'tables.sql'  ] )
+foreach my $thing ( [ 'ensembl',                 'core',       'table.sql'  ],
+                    [ 'ensembl-compara',         'compara',    'table.sql'  ],
+                    [ 'ensembl-funcgen',         'funcgen',    'table.sql'  ],
+                    [ 'ensembl-variation',       'variation',  'table.sql'  ],
+                    [ 'ensembl-production',      'production', 'table.sql'  ],
+                    [ 'ensembl-ontology-schema', 'ontology',   'tables.sql' ] )
 {
   my ($git_repo, $schema_type, $schema_file) = @{$thing};
 


### PR DESCRIPTION
## Description

Have the schema patcher look for ontology patches in _ensembl-ontology-schema_ rather than _ols-ensembl-loader_.

## Use case

During a recent discussion regarding the patching of test databases in _ensembl-rest_ it has been decided to hand the ontology schema from Production back to Infrastructure because said schema is much more closely tied with Core code than with OLS.

## Benefits

_ensembl-rest_ branch creation will be more straightforward because there will be one PR less to wait for and process.

## Possible Drawbacks

It will be up to Infra again to update ontology schema version every release.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected. Moreover, patching test databases for version 99 using the updated script correctly retrieves and applies patch_98_99_a.sql from the new repository.
