### PR TITLE
Prevent ChecksumParser from losing one xref per input file

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
@@ -47,6 +47,7 @@ sub run {
   }
   $verbose ||=0;
 
+  # FIXME: this will fail if the input file is in a read-only directory (ENSCORESW-3197)
   my $target_file = $files->[0].'.mysqlinput';
   my $input_fh = $self->get_filehandle($files->[0]);
   if(-f $target_file) {

--- a/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
@@ -28,6 +28,7 @@ package XrefParser::ChecksumParser;
 use strict;
 use warnings;
 use Carp;
+use English qw( -no_match_vars );
 use IO::File;
 use base qw( XrefParser::BaseParser );
 
@@ -52,7 +53,8 @@ sub run {
     print "Target file '${target_file}' already exists; removing\n" if $verbose;
     unlink $target_file;
   }
-  my $output_fh = IO::File->new($target_file, 'w');
+  my $output_fh = IO::File->new($target_file, 'w')
+    || croak "Failed to open ${target_file} for writing: ${OS_ERROR}";
   
   $self->_transfer_contents($input_fh, $output_fh, $source_id);
   

--- a/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
@@ -71,7 +71,13 @@ sub _transfer_contents {
   while(my $line = <$input_fh>) {
     chomp $line;
     my ($upi, $checksum) = split(/\s+/, $line);
-    my @output = ($counter++, $source_id, $upi, $checksum);
+
+    # Use an ID one higher than the last. Obvious? Perhaps - except before
+    # the commit adding this comment the code only incremented $counter
+    # AFTER using it.
+    $counter += 1;
+
+    my @output = ($counter, $source_id, $upi, $checksum);
     print $output_fh join("\t", @output);
     print $output_fh "\n";
   }


### PR DESCRIPTION
## Description

Shift the numbering of checksum xrefs to be inserted by ChecksumParser by one. Also, check if the temporary output file has successfully been opened before attempting to use it.

## Use case

The way ChecksumParser calculates values of _checksum_xref_id_ now causes it to lose one such xref per input file; see the commit message for details. May or may not be related to ENSCORESW-3196.

## Benefits

Will stop losing RNAcentral and UniParc xrefs.

## Possible Drawbacks

None.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, ChecksumParser is not covered by the test suite.
