### PR TITLE
Fix fetch_all_by_outward_search

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
@@ -1440,18 +1440,19 @@ sub fetch_nearest_by_Feature {
 
 sub fetch_all_by_outward_search {
   my $self = shift;
-   my ($ref_feature, $respect_strand, $opposite_strand, $downstream, $upstream, $search_range,
+  my ($ref_feature, $respect_strand, $opposite_strand, $downstream, $upstream, $start_search_range,
        $limit,$not_overlapping,$five_prime,$three_prime, $max_range) =
         rearrange([qw(FEATURE SAME_STRAND OPPOSITE_STRAND DOWNSTREAM UPSTREAM RANGE LIMIT NOT_OVERLAPPING FIVE_PRIME THREE_PRIME MAX_RANGE)], @_);
   my $factor = 1;
   $limit ||= 1;
-  $search_range ||= 1000;
+  $start_search_range ||= 1000;
+  my $current_search_range = $start_search_range;
   $max_range ||= 10000;
   my @results;
-  while (scalar @results < $limit && $search_range <= $max_range) {
-    $search_range = $search_range * $factor;
+  while (scalar @results < $limit && $current_search_range <= $max_range) {
+    $current_search_range = $start_search_range * $factor;
     @results = @{ 
-      $self->fetch_all_nearest_by_Feature(-RANGE => $search_range, 
+      $self->fetch_all_nearest_by_Feature(-RANGE => $current_search_range,
                                           -FEATURE => $ref_feature, 
                                           -SAME_STRAND => $respect_strand, 
                                           -OPPOSITE_STRAND => $opposite_strand,

--- a/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
@@ -1449,9 +1449,9 @@ sub fetch_all_by_outward_search {
   my $current_search_range = $start_search_range;
   $max_range ||= 10000;
   my @results;
-  while (scalar @results < $limit && $current_search_range <= $max_range) {
+  while (scalar @results < $limit && $current_search_range < $max_range) {
     $current_search_range = $start_search_range * $factor;
-    @results = @{ 
+    @results = @{
       $self->fetch_all_nearest_by_Feature(-RANGE => $current_search_range,
                                           -FEATURE => $ref_feature, 
                                           -SAME_STRAND => $respect_strand, 

--- a/modules/t/getNearestFeature.t
+++ b/modules/t/getNearestFeature.t
@@ -179,7 +179,8 @@ cmp_ok(scalar(@results), '==', 5, 'Upstream of reverse stranded feature gives al
 # Test iterative search
 
 @results = @{ $sfa->fetch_all_by_outward_search(-FEATURE => $a, -LIMIT => 5, -RANGE => 10, -MAX_RANGE => 140)};
-cmp_ok($results[3]->[0]->display_id, 'eq', 'c', 'Check for a feature found outside its initial search range');
+cmp_ok($results[2]->[0]->display_id, 'eq', 'b', 'Check for closest feature in initial search range');
+ok(! defined $results[3], 'Feature $c is not found because it is out of the MAX_RANGE';
 
 
 ################################ NJs Tests ################################

--- a/modules/t/getNearestFeature.t
+++ b/modules/t/getNearestFeature.t
@@ -179,6 +179,7 @@ cmp_ok(scalar(@results), '==', 5, 'Upstream of reverse stranded feature gives al
 # Test iterative search
 
 @results = @{ $sfa->fetch_all_by_outward_search(-FEATURE => $a, -LIMIT => 5, -RANGE => 10, -MAX_RANGE => 140)};
+print_what_you_got(\@results);
 cmp_ok($results[2]->[0]->display_id, 'eq', 'b', 'Check for closest feature in initial search range');
 ok(! defined $results[3], 'Feature $c is not found because it is out of the MAX_RANGE';
 

--- a/modules/t/getNearestFeature.t
+++ b/modules/t/getNearestFeature.t
@@ -181,7 +181,7 @@ cmp_ok(scalar(@results), '==', 5, 'Upstream of reverse stranded feature gives al
 @results = @{ $sfa->fetch_all_by_outward_search(-FEATURE => $a, -LIMIT => 5, -RANGE => 10, -MAX_RANGE => 140)};
 print_what_you_got(\@results);
 cmp_ok($results[2]->[0]->display_id, 'eq', 'b', 'Check for closest feature in initial search range');
-ok(! defined $results[3], 'Feature $c is not found because it is out of the MAX_RANGE';
+ok(! defined $results[3], 'Feature $c is not found because it is out of the MAX_RANGE');
 
 
 ################################ NJs Tests ################################

--- a/modules/t/getNearestFeature.t
+++ b/modules/t/getNearestFeature.t
@@ -178,7 +178,7 @@ cmp_ok(scalar(@results), '==', 5, 'Upstream of reverse stranded feature gives al
 
 # Test iterative search
 
-@results = @{ $sfa->fetch_all_by_outward_search(-FEATURE => $a, -LIMIT => 5, -RANGE => 10, -MAX_RANGE => 160)};
+@results = @{ $sfa->fetch_all_by_outward_search(-FEATURE => $a, -LIMIT => 5, -RANGE => 10, -MAX_RANGE => 140)};
 cmp_ok($results[3]->[0]->display_id, 'eq', 'c', 'Check for a feature found outside its initial search range');
 
 


### PR DESCRIPTION
## Description

Fixed _fetch_all_by_outward_search()_ to expand the search window in increments of the RANGE value. IN the current implementation the search range is increased exponentially instead of linearly. This has now been fixed by storing the initial RANGE value.

## Use case
Currently, calling this function with RANGE=10,000 and MAX_RANGE=500,000 will do the search in the following ranges: 10000, 20000, 60000, 240000 and 1200000. This pull request changes this behaviour to search in ranges from 10000 to 50000 in increments of 10000.

## Testing

Have you added/modified unit tests to test the changes?

Yes.

If so, do the tests pass/fail?

They pass.





