### PR TITLE
bugfix: should be sprintf here, as printf returns 1

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -238,7 +238,7 @@ sub load_all {
         throw("No registry configuration to load, and no default could be guessed.\n");
       }
     } elsif ($throw_if_missing and !(-e $config_file)) {
-      throw(printf("Configuration file '%s' does not exist. Registry configuration not loaded.\n", $config_file ));
+      throw(sprintf("Configuration file '%s' does not exist. Registry configuration not loaded.\n", $config_file ));
     }
 
     $verbose  ||= 0;

--- a/modules/t/registry.t
+++ b/modules/t/registry.t
@@ -144,7 +144,7 @@ warns_like(
     q{Warns that the species doesn't exist},
 );
 
-dies_ok { $reg->load_all('i really hope there is no file named this way', undef, undef, undef, 1) } 'Pointing to a non-existing file should throw an error (if the option is switched on)';
+throws_ok { $reg->load_all('i really hope there is no file named this way', undef, undef, undef, 1) } qr/Configuration file .* does not exist. Registry configuration not loaded/, 'Pointing to a non-existing file should throw an error (if the option is switched on)';
 is($reg->load_all('i really hope there is no file named this way'), 0, 'Pointing to a non-existing file does not throw an error if the option is switched off');
 
 dies_ok { $reg->add_DBAdaptor() } 'add_DBAdaptor() must get a valid species';


### PR DESCRIPTION
## Use case

This line currently throws the error message `1`. That's not informative

## Description

The line is meant to call `sprintf`, not `printf`

## Benefits

Clear error message

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes