### PR TITLE
cpanfile: require Try::Tiny

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';
 requires 'Config::IniFiles';
+requires 'Try::Tiny';
 
 test_requires 'Test::Warnings';
 test_requires 'Test::Differences';


### PR DESCRIPTION
## Description

Add Try::Tiny to the cpanfile.

## Use case

It is used by Bio::EnsEMBL::Feature and it is not a core module. The reason Travis has not caught it seems to be that it comes with the Perl installations they provide.

## Benefits

Bio::EnsEMBL::Feature will not throw 'Cannot locate Try::Tiny' exceptions even on systems with minimal Perl installations.

## Possible Drawbacks

None.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, on a system with highly minimal Perl installation (an official perl-5.14 image from Docker Hub). No regression detected.
