### PR TITLE
Travis: reactivate warnings about different API and schema versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ install:
   - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
 
 before_script:
-  # This should probably be removed on release branches
-  - touch "$HOME/.ensemblapi_no_version_check"
+  - rm -f "$HOME/.ensemblapi_no_version_check"
 
 script: "./travisci/harness.sh"
 


### PR DESCRIPTION
## Description

On Travis, make sure the home-directory file instructing the Registry to globally disable version checks is absent before launching the test suite.

## Use case

Since the Operations meeting on 2019-08-27 the bumping of Ensembl API and DB-schema version numbers has been an Ensembl-wide policy. Therefore, have Travis take notice of possible discrepancies in this respect.

## Benefits

Version mismatches will be easier to spot.

## Possible Drawbacks

If Core version bumps happen before other teams have published theirs, there will be a (hopefully short) time window of expected mismatches.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, the change in question only affects Travis builds.
On which note, with the test DBs on master not having been fully patched to 99 yet the expected outcome of this change is for Travis to *fail*.