### PR TITLE
Backport Mim2GeneParser from ensembl-xref

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -1,8 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2019] EMBL-European Bioinformatics Institute
-
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -26,9 +25,7 @@ use strict;
 use warnings;
 
 use Carp;
-use File::Basename;
 use List::Util;
-use POSIX qw(strftime);
 use Readonly;
 use Text::CSV;
 
@@ -40,6 +37,49 @@ Readonly my $ERR_SOURCE_ID_NOT_FOUND => -1;
 
 Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 5;
 
+
+
+=head2 run
+
+  Arg [1]    : HashRef standard list of arguments from ParseSource
+  Example    : $m2g_parser->run({ ... });
+  Description: Extract mappings between OMIM genes and other gene
+               identifiers from a tab-delimited file downloaded from
+               the DBASS Web site, then insert corresponding links
+               into the xref database:
+                - for entries mapped to Ensembl genes, we create
+                  gene_direct_xref links;
+                - otherwise, if an entry is mapped to an EntrezGene ID
+                  that exists in the xref database we creare a
+                  dependent_xref link.
+               In either case we update info_type of OMIM xrefs
+               accordingly.
+
+               DEPENDENCIES: This parser must be run after:
+                - MIMParser - without existing OMIM entries this
+                  parser does nothing;
+                - EntrezGeneParser - otherwise there will be no
+                  dependent-xref links.
+
+               mim2gene.txt begins with several lines of comments
+               which start with a hash; the last of these comment
+               lines contains a tab-separated list of column names.
+
+               The rest of the file are the following columns:
+                1) OMIM number
+                2) OMIM entry type
+                3) EntrezGene ID
+                4) HGNC gene symbol
+                5) Ensembl gene ID
+               The former two are mandatory, the latter can be empty
+               strings.
+
+  Return type: none
+  Exceptions : throws on all processing errors
+  Caller     : ParseSource in the xref pipeline
+  Status     : Stable
+
+=cut
 
 sub run {
 
@@ -54,19 +94,19 @@ sub run {
        ( !defined $species_id ) or
        ( !defined $files ) )
   {
-    croak "Need to pass source_id, species_id and files as pairs";
+    confess "Need to pass source_id, species_id and files as pairs";
   }
 
   my $csv = Text::CSV->new({
                             sep_char => "\t",
                           })
-    || croak 'Failed to initialise CSV parser: ' . Text::CSV->error_diag();
+    || confess 'Failed to initialise CSV parser: ' . Text::CSV->error_diag();
 
   my $filename = @{$files}[0];
 
-  my $eg_io = $self->get_filehandle($filename);
-  if ( !defined $eg_io ) {
-    croak "Could not open file '${filename}'";
+  my $m2g_io = $self->get_filehandle($filename);
+  if ( !defined $m2g_io ) {
+    confess "Could not open file '${filename}'";
   }
 
   my $mim_gene_source_id =
@@ -78,7 +118,7 @@ sub run {
   if ( ( $mim_gene_source_id == $ERR_SOURCE_ID_NOT_FOUND )
        || ( $mim_morbid_source_id == $ERR_SOURCE_ID_NOT_FOUND )
        || ( $entrez_source_id == $ERR_SOURCE_ID_NOT_FOUND ) ) {
-    croak 'Failed to retrieve all source IDs';
+    confess 'Failed to retrieve all source IDs';
   }
 
   # This will be used to prevent insertion of duplicates
@@ -104,26 +144,31 @@ sub run {
                 );
 
  RECORD:
-  while ( my $line = $csv->getline( $eg_io ) ) {
+  while ( my $line = $csv->getline( $m2g_io ) ) {
 
-    my ( $is_comment, $is_header )
+    my ( $is_comment )
       = ( $line->[0] =~ m{
                            \A
                            ([#])?
-                           \s*
-                           (MIM[ ]Number)?  # FIXME: this is an assumption regarding header contents.
-                                            # See if $line has split to the right number of columns instead?
                        }msx );
     if ( $is_comment ) {
+      # At present we identify the header line among other comments by
+      # checking if it has the expected number of tab-delimited
+      # columns, which of course means we cannot identify header lines
+      # with too few or too many column names. However, this should be
+      # mostly harmless - something would have to be very, very wrong
+      # with the input file for the header to have the wrong number of
+      # column names without a change in the number of actual columns
+      # in data rows.
       if ( ( scalar @{ $line } == $EXPECTED_NUMBER_OF_COLUMNS )
-           && ( ! is_header_file_valid( $line ) ) ) {
-        croak "Malformed or unexpected header in Mim2Gene file '${filename}'";
+           && ( ! is_file_header_valid( @{ $line } ) ) ) {
+        confess "Malformed or unexpected header in Mim2Gene file '${filename}'";
       }
       next RECORD;
     }
 
     if ( scalar @{ $line } != $EXPECTED_NUMBER_OF_COLUMNS ) {
-      croak ' Line ' . $csv->record_number()
+      confess ' Line ' . $csv->record_number()
         . " of input file '${filename}' has an incorrect number of columns";
     }
 
@@ -159,7 +204,7 @@ sub run {
          && ( $type ne 'gene/phenotype' )
          && ( $type ne 'predominantly phenotypes' )
          && ( $type ne 'phenotype' ) ) {
-      croak "Unknown type $type for MIM Number '${omim_acc}' "
+      confess "Unknown type $type for MIM Number '${omim_acc}' "
         . "(${filename}:" . $csv->record_number() . ")";
     }
 
@@ -191,8 +236,8 @@ sub run {
 
   } ## end record loop
 
-  $csv->eof || croak 'Error parsing CSV: ' . $csv->error_diag();
-  $eg_io->close();
+  $csv->eof || confess 'Error parsing CSV: ' . $csv->error_diag();
+  $m2g_io->close();
 
   if ( $verbose ) {
     print 'Processed ' . $counters{'all_entries'} . " entries. Out of those\n"
@@ -208,9 +253,9 @@ sub run {
 
 =head2 is_file_header_valid
 
-  Arg [1]    : String file header line
-  Example    : if (!is_file_header_valid($header_line)) {
-                 croak 'Bad header';
+  Arg [1..N] : list of column names provided by Text::CSV::getline()
+  Example    : if ( ! is_file_header_valid( $csv->getline( $fh ) ) {
+                 confess 'Bad header';
                }
   Description: Verifies if the header of a Mim2Gene file follows expected
                syntax.
@@ -223,10 +268,8 @@ sub run {
 
 =cut
 
-sub is_header_file_valid {
-  my ( $header ) = @_;
-
-  my @fields_ok;
+sub is_file_header_valid {
+  my ( @header ) = @_;
 
   Readonly my @field_patterns
     => (
@@ -239,13 +282,13 @@ sub is_header_file_valid {
 
   my $header_field;
   foreach my $pattern (@field_patterns) {
-    $header_field = shift @{ $header };
+    $header_field = shift @header;
     # Make sure we run the regex match in scalar context
-    push @fields_ok, scalar ( $header_field =~ m{ $pattern }msx );
+    return 0 unless scalar ( $header_field =~ m{ $pattern }msx );
   }
 
-  # All fields must have matched
-  return List::Util::all { $_ } @fields_ok;
+  # If we have made it this far, all should be in order
+  return 1;
 }
 
 

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -26,16 +26,15 @@ use warnings;
 
 use Carp;
 use List::Util;
-use Readonly;
 use Text::CSV;
 
 use parent qw( XrefParser::BaseParser );
 
 
 # FIXME: this belongs in BaseParser
-Readonly my $ERR_SOURCE_ID_NOT_FOUND => -1;
+my $ERR_SOURCE_ID_NOT_FOUND = -1;
 
-Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 5;
+my $EXPECTED_NUMBER_OF_COLUMNS = 5;
 
 
 
@@ -271,8 +270,8 @@ sub run {
 sub is_file_header_valid {
   my ( @header ) = @_;
 
-  Readonly my @field_patterns
-    => (
+  my @field_patterns
+    = (
         qr{ \A [#]? \s* MIM[ ]Number }msx,
         qr{ MIM[ ]Entry[ ]Type }msx,
         qr{ Entrez[ ]Gene[ ]ID }msx,

--- a/misc-scripts/xref_mapping/t/mim2gene.t
+++ b/misc-scripts/xref_mapping/t/mim2gene.t
@@ -28,29 +28,28 @@ use Test::Warnings 'allow_warnings';
 
 use English '-no_match_vars';
 use FindBin '$Bin';
-use Readonly;
 
 use Xref::Test::TestDB;
 
 use XrefParser::Mim2GeneParser;
 
 
-Readonly my $SOURCE_ID_ENTREZGENE  => 23;
-Readonly my $SOURCE_ID_MIM2GENE    => 59;
-Readonly my $SOURCE_ID_OMIM_GENE   => 61;
-Readonly my $SOURCE_ID_OMIM_MORBID => 62;
-Readonly my $SPECIES_ID_HUMAN      => 9606;
+my $SOURCE_ID_ENTREZGENE  = 23;
+my $SOURCE_ID_MIM2GENE    = 59;
+my $SOURCE_ID_OMIM_GENE   = 61;
+my $SOURCE_ID_OMIM_MORBID = 62;
+my $SPECIES_ID_HUMAN      = 9606;
 
 # Increase this by 1 if/when BaseAdaptor::get_valid_codes() has begun to
 # consider synonyms
-Readonly my $NUMBER_OF_DIRECT_LINKS         => 4;
+my $NUMBER_OF_DIRECT_LINKS         = 4;
 # Increase this by 1 once the parser has been updated to insert
 # dependent links for entries which get direct ones as well, and by
 # another 1 if/when has begun to consider synonyms
-Readonly my $NUMBER_OF_DEPENDENT_LINKS      => 1;
+my $NUMBER_OF_DEPENDENT_LINKS      = 1;
 # Decrease this by 1 if/when BaseAdaptor::get_valid_codes() has begun to
 # consider synonyms
-Readonly my $NUMBER_OF_STILL_UNMAPPED_XREFS => 3;
+my $NUMBER_OF_STILL_UNMAPPED_XREFS = 3;
 
 my $db = Xref::Test::TestDB->new();
 

--- a/misc-scripts/xref_mapping/t/mim2gene.t
+++ b/misc-scripts/xref_mapping/t/mim2gene.t
@@ -1,0 +1,390 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+## no critic 'RequireFilenameMatchesPackage'
+package Bio::EnsEMBL::Xref::Test::Parser::Mim2GeneParser;
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::Warnings 'allow_warnings';
+
+use English '-no_match_vars';
+use FindBin '$Bin';
+use Readonly;
+
+use Xref::Test::TestDB;
+
+use XrefParser::Mim2GeneParser;
+
+
+Readonly my $SOURCE_ID_ENTREZGENE  => 23;
+Readonly my $SOURCE_ID_MIM2GENE    => 59;
+Readonly my $SOURCE_ID_OMIM_GENE   => 61;
+Readonly my $SOURCE_ID_OMIM_MORBID => 62;
+Readonly my $SPECIES_ID_HUMAN      => 9606;
+
+# Increase this by 1 if/when BaseAdaptor::get_valid_codes() has begun to
+# consider synonyms
+Readonly my $NUMBER_OF_DIRECT_LINKS         => 4;
+# Increase this by 1 once the parser has been updated to insert
+# dependent links for entries which get direct ones as well, and by
+# another 1 if/when has begun to consider synonyms
+Readonly my $NUMBER_OF_DEPENDENT_LINKS      => 1;
+# Decrease this by 1 if/when BaseAdaptor::get_valid_codes() has begun to
+# consider synonyms
+Readonly my $NUMBER_OF_STILL_UNMAPPED_XREFS => 3;
+
+my $db = Xref::Test::TestDB->new();
+
+# Add some dummy OMIM and EntrezGene xrefs with synonyms. Note that we
+# should *not* add corresponding source entries at this point yet, as
+# there is a test below which checks what happens if the parser cannot
+# retrieve appropriate source IDs.
+$db->schema->populate( 'Xref', [
+  [ qw{ xref_id accession source_id species_id info_type } ],
+  [  1, '100050', $SOURCE_ID_OMIM_MORBID, $SPECIES_ID_HUMAN, 'UNMAPPED' ], # unmapped
+  [  2, '100640', $SOURCE_ID_OMIM_GENE,   $SPECIES_ID_HUMAN, 'UNMAPPED' ], # both direct and dependent
+  [  3, '617386', $SOURCE_ID_OMIM_MORBID, $SPECIES_ID_HUMAN, 'UNMAPPED' ], # only dependent
+  [  4, '142830', $SOURCE_ID_OMIM_MORBID, $SPECIES_ID_HUMAN, 'UNMAPPED' ], # both direct and dependent
+  [  5, '142830', $SOURCE_ID_OMIM_GENE,   $SPECIES_ID_HUMAN, 'UNMAPPED' ], #  ditto
+  [  6, '987654', $SOURCE_ID_OMIM_GENE,   $SPECIES_ID_HUMAN, 'UNMAPPED' ], # only direct
+  [  7, '902100', $SOURCE_ID_OMIM_MORBID, $SPECIES_ID_HUMAN, 'UNMAPPED' ], # via synonym
+  [  8, '999999', $SOURCE_ID_OMIM_GENE,   $SPECIES_ID_HUMAN, 'UNMAPPED' ], # not referenced
+
+  [  9, '216',    $SOURCE_ID_ENTREZGENE,  $SPECIES_ID_HUMAN, 'DIRECT'   ], # <- 100640
+  [ 10, '643609', $SOURCE_ID_ENTREZGENE,  $SPECIES_ID_HUMAN, 'DIRECT'   ], # <- 617386
+  [ 11, '111111', $SOURCE_ID_ENTREZGENE,  $SPECIES_ID_HUMAN, 'DIRECT'   ], # not referenced
+  [ 12, '222222', $SOURCE_ID_ENTREZGENE,  $SPECIES_ID_HUMAN, 'DIRECT'   ], # <- via synonym
+] );
+$db->schema->populate( 'Synonym', [
+  [ qw{ xref_id synonym } ],
+  [  3, '121212' ],  # not referenced
+  [  7, '313370' ],  # only direct
+  [ 11, '3101'   ],  # not referenced
+  [ 12, '3106'   ],  # <- 142830
+  [ 99, '100680' ],  # moved/removed (should be ignored; use nonexistent xref_id to provoke an error if it is)
+] );
+
+my $config = $db->config();
+
+
+my $parser;
+
+subtest 'Missing required source IDs' => sub {
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+
+  # As BaseParser stands in August 2019, attempting to retrieve source
+  # ID for a source that is not present in the database merely
+  # produces a warning; it is up to the parsers themselves to abort.
+  # Seeing as the whole point of this test is to confirm that we *do*
+  # abort, simply ignore the warnings.
+  allow_warnings( 1 );
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-mini.txt" ],
+  }); },
+             qr{ \A Failed[ ]to[ ]retrieve[ ]all[ ]source[ ]IDs }msx,
+             'Throws on source IDs missing from DB' );
+  # IMPORTANT, this does not reset itself upon end of current scope
+  allow_warnings( 0 );
+
+};
+
+
+# We will need these later
+$db->schema->populate( 'Source', [
+  [ qw{ source_id name } ],
+  [ $SOURCE_ID_ENTREZGENE,  'EntrezGene' ],
+  [ $SOURCE_ID_OMIM_GENE,   'MIM_GENE' ],
+  [ $SOURCE_ID_OMIM_MORBID, 'MIM_MORBID' ],
+] );
+
+
+subtest 'Problems with input file' => sub {
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [],
+  }); },
+             qr{ \A No[ ]file[ ]name[ ] }msx,
+             'Throws on no file name' );
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-NONEXISTENT.txt" ],
+  }); },
+             qr{\A Could[ ]not[ ]find[ ]either[ ]' }msx,
+             'Throws on missing input file' );
+
+};
+
+subtest 'Malformed header' => sub {
+  my $QR_MALFORMED_HEADER = qr{ \A Malformed[ ]or[ ]unexpected[ ]header[ ] }msx;
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badHeader-wrongName1.txt" ],
+  }); },
+             $QR_MALFORMED_HEADER,
+             'Throws on wrong name of first column' );
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badHeader-wrongName2.txt" ],
+  }); },
+             $QR_MALFORMED_HEADER,
+             'Throws on wrong name of second column' );
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badHeader-wrongName3.txt" ],
+  }); },
+             $QR_MALFORMED_HEADER,
+             'Throws on wrong name of third column' );
+
+  # The fourth column is checked as well but since we do not use in
+  # the parser now, don't bother testing it
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badHeader-wrongName5.txt" ],
+  }); },
+             $QR_MALFORMED_HEADER,
+             'Throws on wrong name of fifth column' );
+
+};
+
+subtest 'Malformed data' => sub {
+  my $QR_WRONG_NUMBER_OF_COLUMNS
+    = qr{ [ ]has[ ]an[ ]incorrect[ ]number[ ]of[ ]columns[ ] }msx;
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badData-tooFewCols.txt" ],
+  }); },
+             $QR_WRONG_NUMBER_OF_COLUMNS,
+             'Throws on too few data columns' );
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badData-tooManyCols.txt" ],
+  }); },
+             $QR_WRONG_NUMBER_OF_COLUMNS,
+             'Throws on too many data columns' );
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  throws_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-badData-newEntryType.txt" ],
+  }); },
+             qr{ \A Unknown[ ]type[ ] }msx,
+             'Throws on an unknown OMIM entry type' );
+
+};
+
+subtest 'Successful inserts' => sub {
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  isa_ok( $parser, 'XrefParser::Mim2GeneParser',
+          'Instantiated Mim2Gene parser' );
+  lives_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-mini.txt" ],
+  }); }, 'Parsed Mim2Gene map without errors' );
+
+};
+
+subtest 'Direct-xrefs links' => sub {
+  my $rs;
+  my $matching_xref;
+  my $matching_link;
+
+  is( $db->schema->resultset('GeneDirectXref')->count,
+      $NUMBER_OF_DIRECT_LINKS,
+      'Expected number of direct-xref links' );
+
+  $rs = $db->schema->resultset('Xref')->search({
+    accession => '987654',
+    source_id => $SOURCE_ID_OMIM_GENE,
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->info_type, 'DIRECT',
+      'info_type of directly linked xref updated correctly' );
+
+  # Now let's have a closer look at the link
+  $rs = $db->schema->resultset('GeneDirectXref')->search({
+    general_xref_id => $matching_xref->xref_id,
+  });
+  $matching_link = $rs->next;
+  isnt( $matching_link, undef,
+        'Directly linked xref has a direct-xref link' );
+  is( $matching_link->ensembl_stable_id, 'ENSG00000000002',
+      'Link points to expected Ensembl gene stable ID' );
+  is( $matching_link->linkage_xref, undef,
+      "Link's linkage_xref is left undefined" );
+
+  # This may or may not change in the future
+  $rs = $db->schema->resultset('Synonym')->search({
+    synonym => '313370',
+  });
+  $matching_xref = $rs->next;
+  is( $rs = $db->schema->resultset('GeneDirectXref')->count({
+        general_xref_id => $matching_xref->xref_id,
+      }), 0, 'No direct-xref link assigned to a synonym' );
+
+};
+
+subtest 'Dependent-xref links' => sub {
+  my $rs;
+  my $matching_xref;
+  my $matching_link;
+
+  is( $db->schema->resultset('DependentXref')->count,
+      $NUMBER_OF_DEPENDENT_LINKS,
+      'Expected number of dependent-xref links' );
+
+  $rs = $db->schema->resultset('Xref')->search({
+    accession => '617386',
+    source_id => $SOURCE_ID_OMIM_MORBID,
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->info_type, 'DEPENDENT',
+      'info_type of indirectly linked xref updated correctly' );
+
+  # Now let's have a closer look at the link
+  $rs = $db->schema->resultset('DependentXref')->search({
+    dependent_xref_id => $matching_xref->xref_id,
+  });
+  $matching_link = $rs->next;
+  isnt( $matching_link, undef,
+        'Indirectly linked xref has a dependent-xref link' );
+  $rs = $db->schema->resultset('Xref')->search({
+    xref_id => $matching_link->master_xref_id,
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->accession, '643609',
+      'Dependent-xref link points to correct master accession' );
+  is( $matching_xref->source_id, $SOURCE_ID_ENTREZGENE,
+      'Master xref is an EntrezGene entry' );
+  is( $matching_link->linkage_source_id, $SOURCE_ID_OMIM_MORBID,
+      "Link's linkage_source_id is the dependent source_id" );
+  is( $matching_link->linkage_annotation, $matching_xref->source_id,
+      "Link's linkage_annotation is the master source_id" );
+
+  # These two will change once the parser has begun creating multiple
+  # links for such xrefs
+  $rs = $db->schema->resultset('Xref')->search({
+    accession => '100640',
+    source_id => $SOURCE_ID_OMIM_GENE,
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->info_type, 'DIRECT',
+      'info_type of xref with Mim2Gene entry with both links is DIRECT' );
+
+  $rs = $db->schema->resultset('DependentXref')->search({
+    dependent_xref_id => $matching_xref->xref_id,
+  });
+  $matching_link = $rs->next;
+  is( $matching_link, undef, 'No indirect link for an directly linked xref' );
+
+
+  # This may or may not change in the future
+  $rs = $db->schema->resultset('Synonym')->search({
+    synonym => '3106',
+  });
+  $matching_xref = $rs->next;
+  is( $rs = $db->schema->resultset('DependentXref')->count({
+        master_xref_id => $matching_xref->xref_id,
+      }), 0, 'No dependent-xref link assigned to an EntrezGene synonym' );
+
+};
+
+subtest 'Non-mapping entries' => sub {
+  my $rs;
+  my $matching_xref;
+
+  is( $db->schema->resultset('Xref')->count({
+        info_type => 'UNMAPPED',
+      }), $NUMBER_OF_STILL_UNMAPPED_XREFS,
+      'Expected number of still-unmapped xrefs' );
+
+  $rs = $db->schema->resultset('Xref')->search({
+    accession => '100050',
+    source_id => $SOURCE_ID_OMIM_MORBID,
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->info_type, 'UNMAPPED',
+      'info_type of xref with Mim2Gene entry without links left alone' );
+
+};
+
+subtest 'Replay safety' => sub {
+
+  $parser = XrefParser::Mim2GeneParser->new($db->dbh);
+  lives_ok( sub { $parser->run({
+    source_id  => $SOURCE_ID_MIM2GENE,
+    species_id => $SPECIES_ID_HUMAN,
+    files      => [ "$Bin/test-data/mim2gene-mini.txt" ],
+  }); }, 'Re-parsed Mim2Gene map without errors' );
+
+  is( $db->schema->resultset('GeneDirectXref')->count,
+      $NUMBER_OF_DIRECT_LINKS,
+      'No new direct-xref links inserted by the replay' );
+
+  is( $db->schema->resultset('DependentXref')->count,
+      $NUMBER_OF_DEPENDENT_LINKS,
+      'No new dependent-xref links inserted by the replay' );
+
+  is( $db->schema->resultset('Xref')->count({
+        info_type => 'UNMAPPED',
+      }), $NUMBER_OF_STILL_UNMAPPED_XREFS,
+      'Number of still-unmapped xrefs unchanged by the replay' );
+
+  # Ideally we would also make sure the replay has not modified
+  # existing entries, no quick way of doing so though.
+
+};
+
+
+done_testing();
+
+
+1;

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-newEntryType.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-newEntryType.txt
@@ -1,0 +1,2 @@
+# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+142830	frobnicator	3106	HLA-B	ENSG00000234745

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooFewCols.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooFewCols.txt
@@ -1,0 +1,2 @@
+# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+142830	gene	ENSG00000234745

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooManyCols.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooManyCols.txt
@@ -1,0 +1,2 @@
+# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+142830	gene/phenotype	3106	HLA-B	ENSG00000234745	fnord

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName1.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName1.txt
@@ -1,0 +1,2 @@
+# The Ultimate Answer	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+100640	gene	216	ALDH1A1	ENSG00000165092

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName2.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName2.txt
@@ -1,0 +1,2 @@
+# MIM Number	Exit Strategy	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+100640	gene	216	ALDH1A1	ENSG00000165092

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName3.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName3.txt
@@ -1,0 +1,2 @@
+# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Favourite Dish	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+100640	gene	216	ALDH1A1	ENSG00000165092

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName5.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName5.txt
@@ -1,0 +1,2 @@
+# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Stuff and things
+100640	gene	216	ALDH1A1	ENSG00000165092

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-mini.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-mini.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 1966-2018 Johns Hopkins University. Use of this file adheres to the terms specified at https://omim.org/help/agreement.
+# Generated: 2018-10-18
+# This file provides links between the genes in OMIM and other gene identifiers.
+# THIS IS NOT A TABLE OF GENE-PHENOTYPE RELATIONSHIPS.
+# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
+100050	predominantly phenotypes			
+100640	gene	216	ALDH1A1	ENSG00000165092
+100680	moved/removed			
+142830	gene/phenotype	3106	HLA-B	ENSG00000234745
+313370	gene			ENSG00000000001
+617386	predominantly phenotypes	643609	NR1H5P	
+987654	gene			ENSG00000000002


### PR DESCRIPTION
## Description

Port changes made to Mim2GeneParser in _ensembl-xref_, including unit tests, back to _ensembl:feature/xref_sprint_.

## Use case

See ENSCORESW-3218.

## Benefits

Salvage more work from the 2018 xref sprint.

## Possible Drawbacks

Increased test-suite run time (note: Travis does not automatically execute tests from _misc-scripts/xref_mapping_ yet).

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

They will pass once #413 has been merged.

_Have you run the entire test suite and no regression was detected?_

Yes (including tests from _misc-scripts/xref_mapping_), no regression detected.
