### PR TITLE
Feature/baseparser synonym columns

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -447,7 +447,7 @@ sub upload_xref_object_graphs {
     my $xref_sth = $dbi->prepare('INSERT INTO xref (accession,version,label,description,source_id,species_id, info_type) VALUES(?,?,?,?,?,?,?)');
     my $pri_insert_sth = $dbi->prepare('INSERT INTO primary_xref VALUES(?,?,?,?)');
     my $pri_update_sth = $dbi->prepare('UPDATE primary_xref SET sequence=? WHERE xref_id=?');
-    my $syn_sth = $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
+    my $syn_sth = $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
     my $xref_update_label_sth = $dbi->prepare('UPDATE xref SET label=? WHERE xref_id=?');
     my $xref_update_descr_sth = $dbi->prepare('UPDATE xref SET description=? WHERE xref_id=?');
     my $pair_sth = $dbi->prepare('INSERT INTO pairs VALUES(?,?,?)');
@@ -1245,7 +1245,7 @@ sub add_to_syn_for_mult_sources{
   my ($self, $acc, $sources, $syn, $species_id, $dbi) = @_;
 
   $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
+  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
 
   foreach my $source_id (@{$sources}){
     my $xref_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
@@ -1266,7 +1266,7 @@ sub add_to_syn{
   my ($self, $acc, $source_id, $syn, $species_id, $dbi) = @_;
 
   $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
+  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
   my $xref_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
   if(defined $xref_id){
     $add_synonym_sth->execute( $xref_id, $syn )
@@ -1288,7 +1288,7 @@ sub add_synonym{
   my ($self, $xref_id, $syn, $dbi) = @_;
 
   $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth = $dbi->prepare_cached('INSERT IGNORE INTO synonym VALUES(?,?)');
+  my $add_synonym_sth = $dbi->prepare_cached('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
   
   $add_synonym_sth->execute( $xref_id, $syn ) 
     or croak( $dbi->errstr()."\n $xref_id\n $syn\n\n" );

--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -101,6 +101,9 @@ sub get_filehandle
     }
 
     if ( !-e $file_name ) {
+        if ( ! -e $alt_file_name ) {
+            confess "Could not find either '$file_name' or '$alt_file_name'";
+        }
         carp(   "File '$file_name' does not exist, "
               . "will try '$alt_file_name'" );
         $file_name = $alt_file_name;


### PR DESCRIPTION
## Description

BaseParser: All inserts into 'synonym' now explicitly specify target columns.

## Use case

Part of the 2018 xref sprint has been devoted to making the xref database schema a bit more self-constrained so that it could in principle work with database engines other than MyISAM. One of the changes made here has been the addition of an internal key column to the table 'synonym'. Make sure inserts into that table do not get confused by the possible presence of a new column.

## Benefits

Inserts into 'synonym' will work with both original (as still found in _table.sql_) and improved (as found in the xref-parser test suite) xref database schema.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes and no - there are tests for this but they are not present in the repository yet, they will be added once MIMParser has been backported from _ensembl-xref_.

_If so, do the tests pass/fail?_

They failed before the change and pass afterwards.

_Have you run the entire test suite and no regression was detected?_

Yes, no regressions detected.
