### PR TITLE
Deprecate Bio::EnsEMBL::DBSQL::GenomeContainer::get_total_length()

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,6 +8,10 @@ When a method is deprecated, a deprecation warning is thrown whenever the method
 The warning also contains instructions on replacing the deprecated method and when it will be removed.
 A year after deprecation (4 Ensembl releases), the method is removed from the API.
 
+### Removed in Ensembl Release 102 ###
+
+ - Bio::EnsEMBL::DBSQL::**GenomeContainer**::*get_total_length()*
+
 ### Removed in Ensembl Release 100 ###
 
  - Bio::EnsEMBL::DBFile::**FileAdaptor**::*get_filehandle()*

--- a/modules/Bio/EnsEMBL/DBSQL/GenomeContainer.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GenomeContainer.pm
@@ -72,7 +72,7 @@ use warnings;
 use Bio::EnsEMBL::Genome;
 use Bio::EnsEMBL::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::DBSQL::BaseAdaptor;
-use Bio::EnsEMBL::Utils::Exception qw( throw warning );
+use Bio::EnsEMBL::Utils::Exception qw( deprecate throw warning );
 use Bio::EnsEMBL::Utils::Scalar qw( assert_ref );
 
 use vars qw(@ISA);
@@ -489,6 +489,7 @@ sub get_ref_length {
 
 =head2 get_total_length
 
+  Deprecated. Please use get_ref_length(), i.e. the golden path, instead
   Arg [1]    : (optional) base pair length
   Example    : $total_length = $genome->get_total_length();
   Description: Getter/setter for the total length (number of base pairs) for the assembly currently used
@@ -500,8 +501,9 @@ sub get_ref_length {
 
 =cut
 
-sub get_total_length {
+sub get_total_length {  ## DEPRECATED
   my ($self, $total_length) = @_;
+  deprecate('GenomeContainer::get_total_length() is deprecated due to inaccuracy and will be removed in e102. Use golden path (GenomeContainer::get_ref_length()) instead');
   if (defined $total_length) {
     $self->{'total_length'} = $total_length;
   }

--- a/modules/t/genomeContainer.t
+++ b/modules/t/genomeContainer.t
@@ -148,10 +148,6 @@ $sql = "SELECT sum(length) FROM seq_region sr, seq_region_attrib sra, attrib_typ
 my $ref_length = $sql_helper->execute_single_result(-SQL => $sql); 
 is($ref_length, $genome->get_ref_length, "Reference length is correct");
 
-$sql = "SELECT sum(length(sequence)) FROM dna";
-my $total_length = $sql_helper->execute_single_result(-SQL => $sql);    
-is($total_length, $genome->get_total_length, "Total length is correct");
-
 #
 # Test transcript counts
 #


### PR DESCRIPTION
## Description

Deprecate Bio::EnsEMBL::DBSQL::GenomeContainer::get_total_length()

## Use case

Part of ENSINT-283. Web should stop using it already in e99 but let us play it safely on our end and follow the standard deprecation procedure.

## Benefits

The first step towards removing a method known to provide incorrect information for certain species.

## Possible Drawbacks

Test coverage will drop slightly (but will of course improve again once _get_total_length()_ has been removed). 

## Testing

_Have you added/modified unit tests to test the changes?_

Yes, removed the test of _get_total_length()_ from _genomeContainer.t_

_If so, do the tests pass/fail?_

They pass.

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected.
