### PR TITLE
ENSCORESW-3224: Backport ZFINDescParser

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
@@ -75,11 +75,11 @@ sub run {
   my $files        = $ref_arg->{files};
   my $verbose      = $ref_arg->{verbose} // 0;
 
-  if ( (!defined $source_id) or (!defined $species_id) or (!defined $files) ) {
+  if ( (!defined $source_id) || (!defined $species_id) || (!defined $files) ) {
     confess "Need to pass source_id, species_id and files as pairs";
   }
 
-  my $file = shift @{$files};
+  my $file = @{$files}[0];
 
 #e.g.
 #ZDB-GENE-050102-6       WITHDRAWN:zgc:92147     WITHDRAWN:zgc:92147     0

--- a/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
@@ -76,7 +76,7 @@ sub run {
   my $verbose      = $ref_arg->{verbose} // 0;
 
   if ( (!defined $source_id) or (!defined $species_id) or (!defined $files) ) {
-    croak "Need to pass source_id, species_id and files as pairs";
+    confess "Need to pass source_id, species_id and files as pairs";
   }
 
   my $file = shift @{$files};
@@ -93,14 +93,14 @@ sub run {
   my $file_io = $self->get_filehandle($file);
 
   if ( !defined $file_io ) {
-    croak "Can't open ZFIN file $file\n";
+    confess "Can't open ZFIN file $file\n";
   }
 
   my $input_file = Text::CSV->new({
     sep_char       => "\t",
     empty_is_undef => 1,
     binary         => 1
-  }) or croak "Cannot use file $file: " . Text::CSV->error_diag ();
+  }) or confess "Cannot use file $file: " . Text::CSV->error_diag ();
 
 
   # 2 extra columns are ignored
@@ -124,7 +124,7 @@ sub run {
     }
   }
 
-  $input_file->eof or croak "Error parsing file $file: " . $input_file->error_diag();
+  $input_file->eof or confess "Error parsing file $file: " . $input_file->error_diag();
   $file_io->close();
 
   if($verbose){

--- a/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
@@ -15,7 +15,42 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=head1 NAME
+
+Bio::EnsEMBL::Xref::Parser::ZFINDescParser
+
+=head1 DESCRIPTION
+
+A parser class to parse the ZFIN file for descriptions.
+
+-species = danio_rerio
+-species_id = 7955
+-data_uri = ftp://zfin.org/pub/transfer/MEOW/zfin_genes.txt
+-file_format = TSV
+-columns = [acc desc label ignored ignored]
+
+=head1 SYNOPSIS
+
+  my $parser = Bio::EnsEMBL::Xref::Parser::ZFINDescParser->new(
+    source_id  => 149,
+    species_id => 7955,
+    files      => ['zfin_genes.txt'],
+    xref_dba   => $xref_dba
+  );
+
+  $parser->run();
+
 =cut
+
+
 
 package XrefParser::ZFINDescParser;
 
@@ -26,6 +61,11 @@ use Text::CSV;
 
 use parent qw( XrefParser::BaseParser );
 
+=head2 run
+  Description: Runs the ZFINDescParser
+  Return type: N/A
+  Caller     : internal
+=cut
 
 sub run {
   my ($self, $ref_arg) = @_;

--- a/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
@@ -93,14 +93,14 @@ sub run {
   my $file_io = $self->get_filehandle($file);
 
   if ( !defined $file_io ) {
-    confess "Can't open ZFIN file $file\n";
+    confess "Can't open ZFINDesc file '$file'\n";
   }
 
   my $input_file = Text::CSV->new({
     sep_char       => "\t",
     empty_is_undef => 1,
     binary         => 1
-  }) or confess "Cannot use file $file: " . Text::CSV->error_diag ();
+  }) or confess "Cannot use file '$file': " . Text::CSV->error_diag();
 
 
   # 2 extra columns are ignored
@@ -128,7 +128,7 @@ sub run {
   $file_io->close();
 
   if($verbose){
-    print "$count ZFIN xrefs added, $withdrawn withdrawn entries ignored\n";
+    print "$count ZFINDesc xrefs added, $withdrawn withdrawn entries ignored\n";
   }
 
   return 0;

--- a/misc-scripts/xref_mapping/t/test-data/zfin_desc.txt
+++ b/misc-scripts/xref_mapping/t/test-data/zfin_desc.txt
@@ -1,0 +1,9 @@
+ZDB-GENE-030131-3003	HNF1 homeobox Bb	hnf1bb	21	ZDB-REFCROSS-990707-1
+ZDB-GENE-030131-1077	hepatocyte nuclear factor 4, alpha	hnf4a	23	ZDB-REFCROSS-000320-1
+ZDB-GENE-040718-488	WD repeat domain, phosphoinositide interacting 2	wipi2	0	
+ZDB-GENE-070117-2473	wirbel	wir	0	
+ZDB-GENE-000710-5	WITHDRAWN:cripto	WITHDRAWN:cripto	0	
+ZDB-GENE-030516-5	WITHDRAWN:sb:cb476	WITHDRAWN:sb:cb476	0	
+ZDB-GENE-030131-8698	WITHDRAWN:wu:fa94g04	WITHDRAWN:wu:fa94g04	0
+ZDB-GENE-070117-2162	lawrence welk	wlk	0	
+ZDB-GENE-040426-2161	wntless Wnt ligand secretion mediator	wls	2	ZDB-REFCROSS-000320-1

--- a/misc-scripts/xref_mapping/t/zfin_desc.t
+++ b/misc-scripts/xref_mapping/t/zfin_desc.t
@@ -1,0 +1,85 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use FindBin '$Bin';
+use lib "$Bin/";
+
+use Xref::Test::TestDB;
+use XrefParser::ZFINDescParser;
+
+use_ok 'Xref::Test::TestDB';
+
+my $db = Xref::Test::TestDB->new();
+
+my $config = $db->config;
+
+use_ok 'XrefParser::ZFINDescParser';
+
+my $parser = XrefParser::ZFINDescParser->new($db->dbh);
+
+isa_ok( $parser, 'XrefParser::ZFINDescParser' );
+
+$parser->run( {
+  files      => [ "$Bin/test-data/zfin_desc.txt" ],
+  verbose    => 1,
+  species_id => 7955,
+  source_id  => 149
+} );
+
+ok(
+  $db->schema->resultset('Xref')->check_direct_xref({
+    accession   => 'ZDB-GENE-030131-3003',
+    label       => 'hnf1bb',
+    description => 'HNF1 homeobox Bb',
+    source_id   => 149,
+    species_id  => 7955,
+    info_type   => 'MISC'
+  }),
+ 'Sample zebrafish direct Xref has been inserted'
+);
+
+# Test if all the rows were inserted
+is($db->schema->resultset('Xref')->count, 6, "All 6 rows were inserted");
+
+my $parser_no_file = XrefParser::ZFINDescParser->new($db->dbh);
+
+throws_ok{
+  $parser_no_file->run( {
+    files      => [ ],
+    verbose    => 1,
+    species_id => 7955,
+    source_id  => 149
+  } );
+} qr/No file name/, 'No file provided throws error' ;
+
+done_testing();


### PR DESCRIPTION

## Description

Port changes made to ZFINDescParser in ensembl-xref, including unit tests, back to ensembl:feature/xref_sprint. 

## Use case

see ENSCORESW-3224

## Benefits

Salvage more work from the 2018 xref sprint.

## Possible Drawbacks

Increased test-suite run time (note: Travis does not automatically execute tests from misc-scripts/xref_mapping yet).

## Testing

yes

_If so, do the tests pass/fail?_

pass

_Have you run the entire test suite and no regression was detected?_

yes
