### PR TITLE
Feature/baseparser throw on unknown source

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -144,7 +144,7 @@ sub get_filehandle
 # Arg[1] source name
 # Arg[2] priority description
 #
-# Returns source_id or -1 if not found
+# Returns source_id, or throws if not found
 #############################################
 sub get_source_id_for_source_name {
   my ($self, $source_name,$priority_desc, $dbi) = @_;
@@ -164,11 +164,11 @@ sub get_source_id_for_source_name {
   if (@row) {
     $source_id = $row[0];
   } else {
-    carp "WARNING: There is no entity $source_name in the source-table of the xref database.\n";
-    carp "WARNING:. The external db name ($source_name) is hardcoded in the parser\n";
-    carp "WARNING: Couldn't get source ID for source name $source_name\n";
-
-    $source_id = '-1';
+    my $msg = "No source_id for source_name='${source_name}'";
+    if ( defined $priority_desc ) {
+      $msg .= "priority_desc='${priority_desc}'";
+    }
+    confess $msg;
   }
   $sth->finish();
   return $source_id;

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -26,9 +26,6 @@ use Carp;
 use parent qw( XrefParser::BaseParser );
 
 
-# FIXME: this belongs in BaseParser
-my $ERR_SOURCE_ID_NOT_FOUND = -1;
-
 my $QR_TI_FIELD_TERMINATORS
   = qr{
          (?:                # The TI field spans from *FIELD* TI until:
@@ -122,10 +119,6 @@ sub run {
   my $morbid_source_id =
     $self->get_source_id_for_source_name( "MIM_MORBID", undef, $dbi );
   push @sources, $morbid_source_id;
-  if ( ( $gene_source_id == $ERR_SOURCE_ID_NOT_FOUND )
-       || ( $morbid_source_id == $ERR_SOURCE_ID_NOT_FOUND ) ) {
-    confess 'Failed to retrieve MIM source IDs';
-  }
 
   my %TYPE_SINGLE_SOURCES = (
     q{*} => $gene_source_id,

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -31,9 +31,6 @@ use Text::CSV;
 use parent qw( XrefParser::BaseParser );
 
 
-# FIXME: this belongs in BaseParser
-my $ERR_SOURCE_ID_NOT_FOUND = -1;
-
 my $EXPECTED_NUMBER_OF_COLUMNS = 5;
 
 
@@ -114,11 +111,6 @@ sub run {
     $self->get_source_id_for_source_name( 'MIM_MORBID', undef, $dbi );
   my $entrez_source_id =
     $self->get_source_id_for_source_name( 'EntrezGene', undef, $dbi );
-  if ( ( $mim_gene_source_id == $ERR_SOURCE_ID_NOT_FOUND )
-       || ( $mim_morbid_source_id == $ERR_SOURCE_ID_NOT_FOUND )
-       || ( $entrez_source_id == $ERR_SOURCE_ID_NOT_FOUND ) ) {
-    confess 'Failed to retrieve all source IDs';
-  }
 
   # This will be used to prevent insertion of duplicates
   $self->get_dependent_mappings( $mim_gene_source_id, $dbi );

--- a/misc-scripts/xref_mapping/t/mim2gene.t
+++ b/misc-scripts/xref_mapping/t/mim2gene.t
@@ -24,7 +24,7 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
-use Test::Warnings 'allow_warnings';
+use Test::Warnings;
 
 use English '-no_match_vars';
 use FindBin '$Bin';
@@ -90,22 +90,13 @@ my $parser;
 subtest 'Missing required source IDs' => sub {
 
   $parser = XrefParser::Mim2GeneParser->new($db->dbh);
-
-  # As BaseParser stands in August 2019, attempting to retrieve source
-  # ID for a source that is not present in the database merely
-  # produces a warning; it is up to the parsers themselves to abort.
-  # Seeing as the whole point of this test is to confirm that we *do*
-  # abort, simply ignore the warnings.
-  allow_warnings( 1 );
   throws_ok( sub { $parser->run({
     source_id  => $SOURCE_ID_MIM2GENE,
     species_id => $SPECIES_ID_HUMAN,
     files      => [ "$Bin/test-data/mim2gene-mini.txt" ],
   }); },
-             qr{ \A Failed[ ]to[ ]retrieve[ ]all[ ]source[ ]IDs }msx,
+             qr{ \A No[ ]source_id[ ]for[ ]source_name=' }msx,
              'Throws on source IDs missing from DB' );
-  # IMPORTANT, this does not reset itself upon end of current scope
-  allow_warnings( 0 );
 
 };
 

--- a/misc-scripts/xref_mapping/t/omim.t
+++ b/misc-scripts/xref_mapping/t/omim.t
@@ -24,7 +24,7 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
-use Test::Warnings 'allow_warnings';
+use Test::Warnings;
 
 use English '-no_match_vars';
 use FindBin '$Bin';
@@ -182,22 +182,13 @@ subtest 'parse_ti()' => sub {
 subtest 'Missing required source IDs' => sub {
 
   $parser = XrefParser::MIMParser->new($db->dbh);
-
-  # As BaseParser stands in August 2019, attempting to retrieve source
-  # ID for a source that is not present in the database merely
-  # produces a warning; it is up to the parsers themselves to abort.
-  # Seeing as the whole point of this test is to confirm that we *do*
-  # abort, simply ignore the warnings.
-  allow_warnings( 1 );
   throws_ok( sub { $parser->run({
     source_id  => $SOURCE_ID_OMIM,
     species_id => $SPECIES_ID_HUMAN,
     files      => [ "$Bin/test-data/omim-mini.txt" ],
   }); },
-             qr{ \A Failed[ ]to[ ]retrieve[ ]MIM[ ]source[ ]IDs }msx,
+             qr{ \A No[ ]source_id[ ]for[ ]source_name=' }msx,
              'Throws on source IDs missing from DB' );
-  # IMPORTANT, this does not reset itself upon end of current scope
-  allow_warnings( 0 );
 
 };
 


### PR DESCRIPTION
## Description

Have _BaseParser::get_source_id_by_source_name()_ throw an exception rather than return -1 in the event of being unable to find a matching source ID. Backport from _ensembl-xref_.

## Use case

I have yet to see a parser which continues happily if it cannot get the ID of a source, therefore each and every one of the parsers I have seen implemented some variant of "if -1, abort". Moreover, the warning message produced before returning -1 has not exactly been helpful.

## Benefits

More consistent behaviour of xref parsers, simpler backporting from _ensembl-xref_.

## Possible Drawbacks

Xref parsers currently being backported which have not been merged into _feature/xref_sprint_ yet and use _BaseParser::get_source_id_by_source_name()_ will have to be adapted back to _ensembl-xref_-like behaviour, especially if their respective unit tests check what exception is thrown upon failure to retrieve a source ID.

## Testing

_Have you added/modified unit tests to test the changes?_

I have updated the expected exception message in _omim.t_ and _mim2gene.t_, which at present are the only two files affected.

_If so, do the tests pass/fail?_

They pass.

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected.
