### PR TITLE
Enable VGNC xrefs for callithrix_jacchus and papio_anubis [release/99]

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -502,6 +502,15 @@ priority        = 1
 parser          = VGNCParser
 data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
 
+[source VGNC::callithrix_jacchus]
+# Used by callithrix_jacchus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
 [source VGNC::felis_catus]
 # Used by felis_catus
 name            = VGNC
@@ -522,6 +531,15 @@ data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene
 
 [source VGNC::microcebus_murinus]
 # Used by microcebus_murinus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::papio_anubis]
+# Used by papio_anubis
 name            = VGNC
 download        = Y
 order           = 29
@@ -1918,6 +1936,10 @@ source          = VGNC::equus_caballus
 taxonomy_id     = 9598
 source          = VGNC::pan_troglodytes
 
+[species callithrix_jacchus]
+taxonomy_id     = 9483
+source          = VGNC::callithrix_jacchus
+
 [species felis_catus]
 taxonomy_id     = 9685
 source          = VGNC::felis_catus
@@ -1929,6 +1951,10 @@ source          = VGNC::macaca_mulatta
 [species microcebus_murinus]
 taxonomy_id     = 30608
 source          = VGNC::microcebus_murinus
+
+[species papio_anubis]
+taxonomy_id     = 9555
+source          = VGNC::papio_anubis
 
 [species ciona_intestinalis]
 taxonomy_id     = 7719


### PR DESCRIPTION
## Description

Enable production of VGNC xrefs for additional two species: marmoset, olive baboon.

## Use case

VGNC has recently begun to provide data for these species and have requested Ensembl to enable production of corresponding xrefs.

## Benefits

More VGNC xrefs in Ensembl.

## Possible Drawbacks

Increased run time of the xref pipeline. That said, a single run of VGNCParser takes in the order of seconds so it will not be a large increase.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected.