### PR TITLE
Add next-value buffering to Bio::EnsEMBL::Utils::Iterator

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/Iterator.pm
+++ b/modules/Bio/EnsEMBL/Utils/Iterator.pm
@@ -141,6 +141,26 @@ sub new {
 }
 
 
+=head2 _fetch_next_value_if_needed
+
+  Example    : $iterator->_fetch_next_value_if_needed
+  Description: Helper method used to fill the internal buffer with the next value of the iterator
+  Returntype : none
+  Exceptions : none
+  Caller     : general
+  Status     : Experimental
+
+=cut
+
+sub _fetch_next_value_if_needed {
+    my $self = shift;
+
+    unless (exists $self->{next}) {
+        $self->{next} = $self->{sub}->();
+    }
+}
+
+
 =head2 next
 
   Example    : $obj = $iterator->next
@@ -155,7 +175,7 @@ sub new {
 sub next {
     my $self = shift;
 
-    $self->{next} = $self->{sub}->() unless exists $self->{next};
+    $self->_fetch_next_value_if_needed();
 
     if (defined $self->{next}) {
         return delete $self->{next};
@@ -178,7 +198,7 @@ sub next {
 sub has_next {
     my $self = shift;
 
-    $self->{next} = $self->{sub}->() unless exists $self->{next};
+    $self->_fetch_next_value_if_needed();
 
     return defined $self->{next}; 
 }
@@ -199,7 +219,7 @@ sub has_next {
 sub peek {
     my $self = shift;
 
-    $self->{next} = $self->{sub}->() unless exists $self->{next};
+    $self->_fetch_next_value_if_needed();
 
     return $self->{next};
 }

--- a/modules/Bio/EnsEMBL/Utils/Iterator.pm
+++ b/modules/Bio/EnsEMBL/Utils/Iterator.pm
@@ -155,9 +155,12 @@ sub new {
 sub next {
     my $self = shift;
 
-    $self->{next} = $self->{sub}->() unless defined $self->{next};
-    
-    return delete $self->{next};
+    $self->{next} = $self->{sub}->() unless exists $self->{next};
+
+    if (defined $self->{next}) {
+        return delete $self->{next};
+    }
+    return;
 }
 
 =head2 has_next
@@ -175,7 +178,7 @@ sub next {
 sub has_next {
     my $self = shift;
 
-    $self->{next} = $self->{sub}->() unless defined $self->{next};
+    $self->{next} = $self->{sub}->() unless exists $self->{next};
 
     return defined $self->{next}; 
 }
@@ -196,7 +199,7 @@ sub has_next {
 sub peek {
     my $self = shift;
 
-    $self->{next} = $self->{sub}->() unless defined $self->{next};
+    $self->{next} = $self->{sub}->() unless exists $self->{next};
 
     return $self->{next};
 }

--- a/modules/t/iterator.t
+++ b/modules/t/iterator.t
@@ -33,6 +33,23 @@ $it = Bio::EnsEMBL::Utils::Iterator->new(sub {return 3});
 
 is($it->next, 3, "got expected value from iterator created from coderef");
 
+# check that the coderef is not called any more once it returns undef
+
+my $call_counter = 0;
+$it = Bio::EnsEMBL::Utils::Iterator->new(sub {
+        ++$call_counter;
+        if ($call_counter == 1) {
+            return 1;
+        } else {
+            return undef;
+        }
+    });
+
+is($it->next, 1, "got expected value from iterator created from coderef");
+is($it->next, undef, "got undef from iterator created from coderef once exhausted");
+is($it->next, undef, "got undef from iterator created from coderef once exhausted");
+is($call_counter, 2, 'Returned undef without calling the coderef any further');
+
 # from now on we create an iterator from an arrayref because it's simpler
 
 $it = Bio::EnsEMBL::Utils::Iterator->new([1,2,3]);


### PR DESCRIPTION
## Use case

I'm instantiating a Bio::EnsEMBL::Utils::Iterator with a simple sub that does this:
```perl
my $fetch_sub = sub {
    return $sth->fetchrow_arrayref;
}
```

Then, when I iterate I get this error:
```DBD::mysql::st fetchrow_arrayref failed: fetch() without execute()```

This is because `$iterator->has_next()` keeps on calling the coderef even though it has already returned _undef_ and DBD::mysql::st thinks enough is enough.

## Description

Here, I use _exists_ instead of _defined_ and I leave _undef_ in `$self->{next}` once it's been reached.

## Benefits

Can use DBI fetch methods in the iterator

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes