### PR TITLE
Backport MGI_Desc_Parser from ensembl-xref

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -87,9 +87,9 @@ sub run {
 
   my $input_file = Text::CSV->new({
     sep_char           => "\t",
-    empty_is_undef     => 1,
+    quote_char         => undef,
+    escape_char        => undef,
     strict             => 1,
-    allow_loose_quotes => 1,
   }) or confess "Cannot use file $file: " . Text::CSV->error_diag();
 
   my $xref_count = 0;

--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -1,9 +1,7 @@
-
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2019] EMBL-European Bioinformatics Institute
-
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,135 +16,126 @@ limitations under the License.
 
 =cut
 
+=head1 NAME
+
+XrefParser::MGI_Desc_Parser
+
+=head1 DESCRIPTION
+
+A parser class to parse the MGI (descriptions) source. Creates 'MISC' xref using MGI accession with description and
+also creates the synonyms extracted from the pipe seperated synonym_field
+
+-species = mus_musculus
+-species_id = 10090
+-data_uri = http://www.informatics.jax.org/downloads/reports/MRK_List2.rpt
+-file_format = TSV
+-columns = [accession chromosome position start end strand label status marker marker_type feature_type synonym_field]
+
+=head1 SYNOPSIS
+
+  my $parser = XrefParser::MGI_Desc_Parser->new($db->dbh);
+  $parser->run({
+    source_id  => 58,
+    species_id => 10090,
+    files      => ["MRK_List2.rpt"],
+  });
+
+=cut
+
 package XrefParser::MGI_Desc_Parser;
 
 use strict;
 use warnings;
 use Carp;
-use File::Basename;
+use Text::CSV;
 
-use base qw( XrefParser::BaseParser );
+use parent qw( XrefParser::BaseParser );
+
+my $EXPECTED_NUMBER_OF_COLUMNS = 12;
+
+
+
+=head2
+
+The run method does the actual parsing and creation of xrefs and synonyms.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+=cut
 
 sub run {
 
   my ($self, $ref_arg) = @_;
-  my $source_id    = $ref_arg->{source_id};
-  my $species_id   = $ref_arg->{species_id};
-  my $files        = $ref_arg->{files};
-  my $verbose      = $ref_arg->{verbose};
-  my $dbi          = $ref_arg->{dbi};
-  $dbi = $self->dbi unless defined $dbi;
+  my $source_id  = $ref_arg->{source_id};
+  my $species_id = $ref_arg->{species_id};
+  my $files      = $ref_arg->{files};
+  my $verbose    = $ref_arg->{verbose} // 0;
+  my $dbi        = $ref_arg->{dbi} // $self->dbi;
 
-  if((!defined $source_id) or (!defined $species_id) or (!defined $files) ){
-    croak "Need to pass source_id, species_id and files as pairs";
+  if ( ( !defined $source_id ) or
+       ( !defined $species_id ) or
+       ( !defined $files ) ) {
+    confess 'Need to pass source_id, species_id and files as pairs';
   }
-  $verbose |=0;
 
   my $file = @{$files}[0];
 
   my $mgi_io = $self->get_filehandle($file);
-
   if ( !defined $mgi_io ) {
-    croak "ERROR: Could not open $file\n";
+    confess "Could not open $file\n";
   }
+
+  my $input_file = Text::CSV->new({
+    sep_char           => "\t",
+    empty_is_undef     => 1,
+    strict             => 1,
+    allow_loose_quotes => 1,
+  }) or confess "Cannot use file $file: " . Text::CSV->error_diag();
 
   my $xref_count = 0;
   my $syn_count  = 0;
   my %acc_to_xref;
 
-
-    my $header = $mgi_io->getline(); #discard header line
-
-    chomp($header);
-    # crude emergency check for potentially altered file format.
-    my $header_template = qq(MGI Accession ID\tChr\tcM Position\tgenome coordinate start\tgenome coordinate end\tstrand\tMarker Symbol\tStatus\tMarker Name\tMarker Type\tFeature Type\tMarker Synonyms (pipe-separated));
-    if ($header ne $header_template) {die "File header has altered from format parser expects. Check MGI "};
-      
-    while ( my $line = $mgi_io->getline() ) {
-
-        chomp($line);
-        my ($accession, $chromosome, $position, $start, $end, $strand,$label, 
-            $status, $marker, $marker_type, $feature_type, $synonym_field) = split(/\t/,$line);
-            
-        $position =~ s/^\s+// if ($position);
-
-        my @synonyms = split(/\|/,$synonym_field) if ($synonym_field);
-        
-	
-        my $desc;
-	if ($marker) {
-	    $desc = $marker;
-	}
-        
-        $acc_to_xref{$accession} = $self->add_xref({ acc        => $accession,
-    	                           		             label      => $label,
-    					                             desc       => $desc,
-    					                             source_id  => $source_id,
-    					                             species_id => $species_id,
-                                                                     dbi        => $dbi,
-    					                             info_type  => "MISC"} );
-        if($verbose and !$desc){
-    	   print "$accession has no description\n";
-        }
-        $xref_count++;
-            
-        if(defined($acc_to_xref{$accession})){
-           
-            foreach my $syn (@synonyms) {
-                $self->add_synonym($acc_to_xref{$accession}, $syn, $dbi);
-                $syn_count++;
-            }
-            
-        }
-        
-    }
-      
-    $mgi_io->close();
-      
-    print $xref_count." MGI Description Xrefs added\n" if($verbose);
-    print $syn_count." synonyms added\n" if($verbose);
-
-  # expected columns
-  my @expected_columns =
-    qw(accession chromosome position start end strand label status marker marker_type feature_type synonym_field);
-
   # read header
-  my $header = $input_file->getline($mgi_io);
-  if ( scalar @{$header} != scalar @expected_columns ) {
-    croak "input file $file has an incorrect number of columns";
+  my @header_fields = $input_file->header($mgi_io);
+  if ( scalar @header_fields != $EXPECTED_NUMBER_OF_COLUMNS ) {
+    confess "Header of input file $file has an incorrect number of columns";
   }
-  $input_file->column_names( \@expected_columns );
 
-  while ( my $data = $input_file->getline_hr($mgi_io) ) {
-    my $accession = $data->{'accession'};
-    my $marker = defined( $data->{'marker'} ) ? $data->{'marker'} : undef;
-    $acc_to_xref{$accession} = $self->add_xref(
-      {
-        acc        => $accession,
-        label      => $data->{'label'},
-        desc       => $marker,
-        source_id  => $source_id,
-        species_id => $species_id,
-        dbi        => $dbi,
-        info_type  => "MISC"
-      }
-    );
+  while ( my $data = $input_file->getline($mgi_io) ) {
+    my $accession = $data->[0];
+    my $marker = $data->[8];
+
+    $acc_to_xref{$accession} = $self->add_xref({
+      acc        => $accession,
+      label      => $data->[6],
+      desc       => $marker,
+      source_id  => $source_id,
+      species_id => $species_id,
+      dbi        => $dbi,
+      info_type  => 'MISC',
+    });
     if ( $verbose && !$marker ) {
       print "$accession has no description\n";
     }
-    $xref_count++;
-    my @synonyms;
-    if ( defined( $acc_to_xref{$accession} ) ) {
-      @synonyms = split( /\|/, $data->{'synonym_field'} )
-        if ( $data->{'synonym_field'} );
+    $xref_count += 1;
+
+    if ( defined $acc_to_xref{$accession} ) {
+      my @synonyms;
+      my $synonym_field = $data->[11];
+      if ( $synonym_field ) {
+        @synonyms = split qr{ [|] }msx, $synonym_field;
+      }
       foreach my $syn (@synonyms) {
         $self->add_synonym( $acc_to_xref{$accession}, $syn, $dbi );
-        $syn_count++;
+        $syn_count += 1;
       }
     }
-  }
+
+  } ## end while ( my $data = $input_file...)
+
   $mgi_io->eof
-    or croak "Error parsing file $file: " . $input_file->error_diag();
+    || confess "Error parsing file $file: " . $input_file->error_diag();
   $mgi_io->close();
 
   if ($verbose) {
@@ -155,7 +144,7 @@ sub run {
   }
 
   return 0;    #successful
-}
+} ## end sub run
+
 
 1;
-

--- a/misc-scripts/xref_mapping/t/mgi_desc.t
+++ b/misc-scripts/xref_mapping/t/mgi_desc.t
@@ -1,0 +1,73 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+
+use FindBin '$Bin';
+
+use Xref::Test::TestDB;
+
+my $db     = Xref::Test::TestDB->new();
+
+use_ok 'XrefParser::MGI_Desc_Parser';
+
+my $parser = XrefParser::MGI_Desc_Parser->new($db->dbh);
+isa_ok( $parser, 'XrefParser::MGI_Desc_Parser' );
+
+$parser->run({
+  source_id  => 58,
+  species_id => 10090,
+  files      => ["$Bin/test-data/MGIdesc_mini.rpt"],
+});
+
+# check xrefs
+ok(
+  $db->schema->resultset('Xref')->check_direct_xref(
+    {
+      accession   => 'MGI:1341858',
+      label       => '03B03F',
+      description => 'DNA segment, 03B03F (Research Genetics)',
+      source_id   => 58,
+      species_id  => 10090,
+      info_type   => 'MISC'
+    }
+  ),
+  'Sample mouse misc description Xref has been inserted'
+);
+
+is( $db->schema->resultset('Xref')->count, 10, "All 10 rows were inserted in to Xref" );
+
+# check synonym
+ok(
+  $db->schema->resultset('Synonym')->check_synonym(
+    {
+      xref_id => 10,
+      synonym => "Ecrg4"
+    }
+  ),
+  'Synonym Ecrg4 has been inserted'
+);
+
+is( $db->schema->resultset('Synonym')->count, 2, "Inserted two synonyms" );
+
+done_testing();

--- a/misc-scripts/xref_mapping/t/test-data/MGIdesc_mini.rpt
+++ b/misc-scripts/xref_mapping/t/test-data/MGIdesc_mini.rpt
@@ -1,0 +1,11 @@
+MGI Accession ID	Chr	cM Position	genome coordinate start	genome coordinate end	strand	Marker Symbol	Status	Marker Name	Marker Type	Feature Type	Marker Synonyms (pipe-separated)
+MGI:1341858	5	  syntenic				03B03F	O	DNA segment, 03B03F (Research Genetics)	BAC/YAC end	BAC/YAC end	
+MGI:1341869	5	  syntenic				03B03R	O	DNA segment, 03B03R (Research Genetics)	BAC/YAC end	BAC/YAC end	
+MGI:1337005	11	  syntenic				03.MMHAP34FRA.seq	O	DNA segment, 03.MMHAP34FRA.seq	DNA Segment	DNA segment	
+MGI:1918911	7	  29.36	45567795	45575176	-	0610005C13Rik	O	RIKEN cDNA 0610005C13 gene	Gene	antisense lncRNA gene	
+MGI:1923503	7	  syntenic	74818818	74853813	-	0610006L08Rik	O	RIKEN cDNA 0610006L08 gene	Gene	lincRNA gene	
+MGI:1925547	UN	       N/A				0610008J02Rik	O	RIKEN cDNA 0610008J02 gene	Gene	unclassified gene	
+MGI:1913300	11	  31.26	51685386	51688874	-	0610009B22Rik	O	RIKEN cDNA 0610009B22 gene	Gene	protein coding gene	
+MGI:3698435	2	  18.90	26445605	26457995	+	0610009E02Rik	O	RIKEN cDNA 0610009E02 gene	Gene	unclassified non-coding RNA gene	
+MGI:1918921	16	  syntenic	91947326	91947785		0610009F21Rik	O	RIKEN cDNA 0610009F21 gene	Gene	unclassified gene	
+MGI:1926146	1	  23.44	43730602	43742564	+	1500015O10Rik	O	RIKEN cDNA 1500015O10 gene	Gene	protein coding gene	Ecrg4|augurin


### PR DESCRIPTION
## Description

Port changes made to MGI_Desc_Parser in _ensembl-xref_, including unit tests, back to _ensembl:feature/xref_sprint_.

## Use case

See ENSCORESW-3216. Originally worked on by Prem.

## Benefits

Salvage more work from the 2018 xref sprint.

## Possible Drawbacks

Increased test-suite run time (note: Travis does not automatically execute tests from _misc-scripts/xref_mapping_ yet).

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

They pass.

_Have you run the entire test suite and no regression was detected?_

Yes (including tests from _misc-scripts/xref_mapping_), no regression detected.
