### PR TITLE
Backport XenopusJamboreeParser from ensembl-xref

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
@@ -138,7 +138,7 @@ sub parse_description {
   my ( $desc ) = @_;
 
   # Remove some provenance information encoded in the description
-  $desc =~ s{ \[ .* \] }{}msx;
+  $desc =~ s{ \s* \[ .* \] }{}msx;
 
   # Remove labels of type 5 of 14 from the description
   $desc =~ s{ , \s+\d+\s+ of \s+\d+ }{}msx;

--- a/misc-scripts/xref_mapping/t/test-data/xenopusjamboree.txt
+++ b/misc-scripts/xref_mapping/t/test-data/xenopusjamboree.txt
@@ -8,3 +8,5 @@ XB-GENE-478113	nsa2	NSA2, ribosome biogenesis homolog	ENSXETG00000005077
 XB-GENE-478121	csnk1a1	casein kinase 1 alpha 1	ENSXETG00000020861
 XB-GENE-478131	hoxc6	homeobox C6	ENSXETG00000023479
 XB-GENE-478141	hba1	hemoglobin subunit alpha 1	ENSXETG00000025664
+XB-GENE-940866	rtp3c	receptor (chemosensory) transporter protein 3 gene C [provisional]	ENSXETG00000019753
+XB-GENE-981482	or1e2l	conserved hypothetical olfactory receptor, 8 of 17	ENSXETG00000026609

--- a/misc-scripts/xref_mapping/t/test-data/xenopusjamboree.txt
+++ b/misc-scripts/xref_mapping/t/test-data/xenopusjamboree.txt
@@ -1,0 +1,10 @@
+XB-GENE-478054	trnt1	tRNA nucleotidyl transferase, CCA-adding, 1	ENSXETG00000025091
+XB-GENE-478064	foxh1.2	forkhead box H1, gene 2	ENSXETG00000005286
+XB-GENE-478074	nr5a2	nuclear receptor subfamily 5 group A member 2	ENSXETG00000000314
+XB-GENE-478084	tbx1	T-box 1	ENSXETG00000006304
+XB-GENE-478094	nr1d1	nuclear receptor subfamily 1 group D member 1	ENSXETG00000024397
+XB-GENE-478104	nucb1	nucleobindin 1	ENSXETG00000021229
+XB-GENE-478113	nsa2	NSA2, ribosome biogenesis homolog	ENSXETG00000005077
+XB-GENE-478121	csnk1a1	casein kinase 1 alpha 1	ENSXETG00000020861
+XB-GENE-478131	hoxc6	homeobox C6	ENSXETG00000023479
+XB-GENE-478141	hba1	hemoglobin subunit alpha 1	ENSXETG00000025664

--- a/misc-scripts/xref_mapping/t/xenopus.t
+++ b/misc-scripts/xref_mapping/t/xenopus.t
@@ -1,0 +1,76 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+
+use FindBin '$Bin';
+
+use Xref::Test::TestDB;
+
+my $db = Xref::Test::TestDB->new();
+
+use_ok 'XrefParser::XenopusJamboreeParser';
+
+my $parser = XrefParser::XenopusJamboreeParser->new($db->dbh);
+
+isa_ok( $parser, 'XrefParser::XenopusJamboreeParser' );
+
+$parser->run({
+  source_id  => 150,
+  species_id => 8364,
+  files      => ["$Bin/test-data/xenopusjamboree.txt"],
+});
+
+ok(
+ $db->schema->resultset('Xref')->check_direct_xref(
+  {
+   accession   => "XB-GENE-478054",
+   label       => 'trnt1',
+   description => 'tRNA nucleotidyl transferase, CCA-adding, 1',
+   source_id   => 150,
+   species_id  => 8364
+  }
+ ),
+ 'Sample frog direct Xref has been inserted'
+);
+
+# Test if all the rows were inserted
+is($db->schema->resultset('Xref')->count, 10, "All 10 rows were inserted");
+
+# Test the description parsing
+my $input_desc = "Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14";
+my $expected_desc = "Putative ortholog of g2/mitotic-specific cyclin B3";
+is(XrefParser::XenopusJamboreeParser::parse_description($input_desc), $expected_desc, "Desc parsing ok");
+
+done_testing();
+

--- a/misc-scripts/xref_mapping/t/xenopus.t
+++ b/misc-scripts/xref_mapping/t/xenopus.t
@@ -75,7 +75,7 @@ subtest 'Description parsing' => sub {
     accession => 'XB-GENE-940866',
   });
   $matching_xref = $rs->next;
-  is( $matching_xref->description, 'receptor (chemosensory) transporter protein 3 gene C ',
+  is( $matching_xref->description, 'receptor (chemosensory) transporter protein 3 gene C',
       'Provenance information correctly removed from descriptions');
 
   $rs = $db->schema->resultset('Xref')->search({

--- a/misc-scripts/xref_mapping/t/xenopus.t
+++ b/misc-scripts/xref_mapping/t/xenopus.t
@@ -67,10 +67,25 @@ ok(
 # Test if all the rows were inserted
 is($db->schema->resultset('Xref')->count, 12, "All 12 rows were inserted");
 
-# Test the description parsing
-my $input_desc = "Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14";
-my $expected_desc = "Putative ortholog of g2/mitotic-specific cyclin B3";
-is(XrefParser::XenopusJamboreeParser::parse_description($input_desc), $expected_desc, "Desc parsing ok");
+subtest 'Description parsing' => sub {
+  my $rs;
+  my $matching_xref;
+
+  $rs = $db->schema->resultset('Xref')->search({
+    accession => 'XB-GENE-940866',
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->description, 'receptor (chemosensory) transporter protein 3 gene C ',
+      'Provenance information correctly removed from descriptions');
+
+  $rs = $db->schema->resultset('Xref')->search({
+    accession => 'XB-GENE-981482',
+  });
+  $matching_xref = $rs->next;
+  is( $matching_xref->description, 'conserved hypothetical olfactory receptor',
+      '"X of Y" labels correctly removed from descriptions' );
+
+};
 
 done_testing();
 

--- a/misc-scripts/xref_mapping/t/xenopus.t
+++ b/misc-scripts/xref_mapping/t/xenopus.t
@@ -65,7 +65,7 @@ ok(
 );
 
 # Test if all the rows were inserted
-is($db->schema->resultset('Xref')->count, 10, "All 10 rows were inserted");
+is($db->schema->resultset('Xref')->count, 12, "All 12 rows were inserted");
 
 # Test the description parsing
 my $input_desc = "Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14";


### PR DESCRIPTION
## Description

Port changes made to XenopusJamboreeParser in _ensembl-xref_, including unit tests, back to _ensembl:feature/xref_sprint_.

## Use case

See ENSCORESW-3223. Originally worked on by Prem.

## Benefits

Salvage more work from the 2018 xref sprint.

## Possible Drawbacks

Increased test-suite run time (note: Travis does not automatically execute tests from _misc-scripts/xref_mapping_ yet).

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

They pass.

_Have you run the entire test suite and no regression was detected?_

Yes (including tests from _misc-scripts/xref_mapping_), no regression detected.
