### PR TITLE
Registry: add support for versioned ncbi_taxonomy DBs + improve support for versioned metadata DBs

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -3103,7 +3103,7 @@ sub get_species_and_object_type {
 
     my @dbas = 
       sort { $a->dbc->host cmp $b->dbc->host || $a->dbc->port <=> $b->dbc->port } 
-      grep { $_->dbc->dbname ne 'ncbi_taxonomy' && $_->dbc->dbname ne 'ensembl_metadata' }
+      grep { $_->dbc->dbname !~ m{ \A ensembl_metadata | ncbi_taxonomy }msx }
       @{$self->get_all_DBAdaptors(%get_adaptors_args)};    
     
     foreach my $dba (@dbas) {

--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -2907,18 +2907,29 @@ sub version_check {
     if ( $dba->dbc()->dbname() =~ /^_test_db_/x ) {
       return 1;
     }
-    if ( $dba->dbc()->dbname() =~ /ensembl_metadata/x ) {
+
+    # ensembl_metadata was unversioned prior to release 96
+    if ( $dba->dbc()->dbname() eq 'ensembl_metadata' ) {
       return 1;
     }
+    # ncbi_taxonomy was unversioned prior to release 100
+    if ( $dba->dbc()->dbname() eq 'ncbi_taxonomy' ) {
+      return 1;
+    }
+
     if ( $dba->dbc()->dbname() =~ /(\d+)_\S+$/x ) {
       $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_compara_(\d+)/x ) {
       $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_help_(\d+)/x ) {
       $database_version = $1;
+    } elsif ( $dba->dbc()->dbname() =~ / ensembl_metadata_(\d+) /msx ) {
+      $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_ontology_(\d+)/x ) {
       $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_stable_ids_(\d+)/x ) {
+      $database_version = $1;
+    } elsif ( $dba->dbc()->dbname() =~ / ncbi_taxonomy_(\d+) /msx ) {
       $database_version = $1;
     } else {
       warn(


### PR DESCRIPTION
## Description

Extend the Registry so that it can detect taxonomy databases whose names contain the release number, with backward compatibility with unversioned databases but preference for versioned ones if both forms are present.

Additionally, add several bits of support for versioned metadata databases which failed to make it into #379.

## Use case

Starting with release 100 taxonomy databases in Ensembl will have been renamed from _ncbi_taxonomy_ to _ncbi_taxonomy_XY_, where _XY_ is the release number.

Our support for versioned metadata databases has been incomplete: on the one hand we did not include them in version checks, on the other they were not filtered out by certain methods which did filter out unversioned DBs.

## Benefits

Meet the requirements of ENSINT-312. Fewer bugs in support for versioned metadata DBs. 

## Possible Drawbacks

A slight increase in computational overhead in the Registry, primarily during initialisation. Note that much of this overhead stems from the fact we retain for the time being backward compatibility with the old naming convention, _i.e._ will eventually go away.

## Testing

_Have you added/modified unit tests to test the changes?_

No, the affected code is tied with specific database names and as such will not trigger for MultiTestDB databases.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected.
