### PR TITLE
revert RefSeqGPFFParser to master branch version

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansRefSeqGPFFParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansRefSeqGPFFParser.pm
@@ -48,10 +48,10 @@ sub upload_xref_object_graphs {
 }
 
 sub xref_from_record {
-   my ($self, $entry, $type) = @_;
+   my ($self, $entry, @args) = @_;
    return &modify_xref_with_dependent(
       $SOURCE_IDS, $entry,
-      $self->SUPER::xref_from_record($entry, $type),
+      $self->SUPER::xref_from_record($entry, @args),
       $ACCESSION_FROM_ENTRY_PATTERN,
    );
 }

--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -354,19 +354,18 @@ sub test_refseq {
   }, "$type: Example record" , tmp_file_name => $file);
   test_parser("XrefParser::WormbaseCElegansRefSeqGPFFParser",$record, {
   }, "$type no entries without WormBase records" , tmp_file_name => $file);
-  # test_parser("XrefParser::WormbaseDirectParser", $wormbase_celegans_xrefs_head,
-  #     $wormbase_celegans_xrefs_expected_count, "$type test again to set up the next test",
-  # skip_clean => 1);
-  # test_parser("XrefParser::WormbaseCElegansRefSeqGPFFParser",$record,  {
-  #   %$wormbase_celegans_xrefs_expected_count,
-  #   xref => $wormbase_celegans_xrefs_expected_count->{xref}+1,
-  #   dependent_xref => 1,
-  # }, "$type RefSeq entries hang off INSDC entries", tmp_file_name => $file);
+  test_parser("XrefParser::WormbaseDirectParser", $wormbase_celegans_xrefs_head,
+      $wormbase_celegans_xrefs_expected_count, "$type test again to set up the next test",
+  skip_clean => 1);
+  test_parser("XrefParser::WormbaseCElegansRefSeqGPFFParser",$record, {
+    %$wormbase_celegans_xrefs_expected_count,
+    xref => $wormbase_celegans_xrefs_expected_count->{xref}+1,
+    dependent_xref => 1,
+  }, "$type RefSeq entries hang off INSDC entries", tmp_file_name => $file);
 }
 
-# FIXME
-test_refseq($refseq_protein_elegans_record, "peptide");
-test_refseq($refseq_mrna_elegans_record, "dna");
+test_refseq($refseq_protein_elegans_record, "protein");
+test_refseq($refseq_mrna_elegans_record, "mrna");
 
 done_testing();
 

--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -40,11 +40,6 @@ $database->populate(
   "with force please",
 );
 
-
-# UniProt species taxon codes happen to match species ids of the core database
-my $SPECIES_ID = 6239;
-my $SPECIES_NAME = "Caenorhabditis elegans";
-
 my %xref_tables_expected_empty_by_default = (
   checksum_xref=>0,
   coordinate_xref=>0,
@@ -58,7 +53,6 @@ my %xref_tables_expected_empty_by_default = (
   translation_direct_xref=>0,
   xref=>0,
 );
-
 my $tmp_dir = tempdir(CLEANUP=>1);
 sub store_in_temporary_file {
   my ($content, %opts) = @_;
@@ -68,7 +62,9 @@ sub store_in_temporary_file {
   close($fh);
   return $path;
 }
-
+# Happens to match the species id of the core database
+my $SPECIES_ID = 1;
+my $SPECIES_NAME = "Homo sapiens";
 sub test_parser {
   my ($parser, $content, $expected, $test_name, %opts) = @_;
   require_ok($parser);
@@ -184,7 +180,7 @@ my @recognised_sources = (
  "MEROPS; C26.956; -.",
 );
 for my $l (@recognised_sources) {
-  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR   $l/;
+  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR  $l/;
   test_parser("XrefParser::UniProtParser", $uniprot_elegans_record_extra_line,  {
     xref => 4,
     primary_xref => 1,
@@ -347,26 +343,25 @@ ORIGIN
 EOF
 sub test_refseq {
   my ($record, $type) = @_;
-  my $file = "RefSeq_${type}.gpff";
+  my $file = "something_that_says_$type";
   test_parser("XrefParser::RefSeqGPFFParser",$record, {
     xref =>1,
     primary_xref => 1,
   }, "$type: Example record" , tmp_file_name => $file);
   test_parser("XrefParser::WormbaseCElegansRefSeqGPFFParser",$record, {
   }, "$type no entries without WormBase records" , tmp_file_name => $file);
-  test_parser("XrefParser::WormbaseDirectParser", $wormbase_celegans_xrefs_head,
+
+  test_parser("XrefParser::WormbaseDirectParser", $wormbase_celegans_xrefs_head,  
       $wormbase_celegans_xrefs_expected_count, "$type test again to set up the next test",
   skip_clean => 1);
-  test_parser("XrefParser::WormbaseCElegansRefSeqGPFFParser",$record, {
+  test_parser("XrefParser::WormbaseCElegansRefSeqGPFFParser",$record,  {
     %$wormbase_celegans_xrefs_expected_count,
     xref => $wormbase_celegans_xrefs_expected_count->{xref}+1,
     dependent_xref => 1,
   }, "$type RefSeq entries hang off INSDC entries", tmp_file_name => $file);
 }
-
 test_refseq($refseq_protein_elegans_record, "protein");
 test_refseq($refseq_mrna_elegans_record, "mrna");
-
 done_testing();
 
 


### PR DESCRIPTION
## Description

RefSeqGPFFParser has been updated, but WormbaseCElegansRefSeqGPFFParser depends on it and has not been fully updated to be compatible with the changes.
Thus RefSeqGPFFParser is being reversed in this branch for merge with master to be possible.
The work done on RefSeqGPFFParser is still availabe on the ensembl-xref repo.

## Use case

See ENSCORESW-3221

## Benefits

Salvage more work from the 2018 xref sprint.

## Possible Drawbacks

none I can see

## Testing

_Have you added/modified unit tests to test the changes?_
no
_If so, do the tests pass/fail?_
yes
_Have you run the entire test suite and no regression was detected?_
yes
