### PR TITLE
revert RefSeqCoordinateParser to master branch version

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
@@ -22,327 +22,406 @@ package XrefParser::RefSeqCoordinateParser;
 use strict;
 use warnings;
 use Carp;
-use Readonly;
+use DBI;
+
+use base qw( XrefParser::BaseParser );
 use Bio::EnsEMBL::Registry;
 
-use parent qw( XrefParser::BaseParser );
-
-
-# Refseq sources to consider. Prefixes not in this list will be ignored
-Readonly my $REFSEQ_SOURCES => {
-    NM => 'RefSeq_mRNA',
-    NR => 'RefSeq_ncRNA',
-    XM => 'RefSeq_mRNA_predicted',
-    XR => 'RefSeq_ncRNA_predicted',
-    NP => 'RefSeq_peptide',
-    XP => 'RefSeq_peptide_predicted',
-};
-
-# Only scores higher than the threshold will be stored for transcripts
-Readonly my $TRANSCRIPT_SCORE_THRESHOLD => 0.75;
-
-# Only scores higher than the threshold will be stored translatable transcripts
-Readonly my $TL_TRANSCRIPT_SCORE_THRESHOLD => 0.75;
-
-# If Biotypes do not match, score will be multiplied with the penalty
-Readonly my $PENALTY => 0.9;
-
-
 sub run_script {
-  my ($self, $ref_arg) = @_;
 
+  my ($self, $ref_arg) = @_;
   my $source_id    = $ref_arg->{source_id};
   my $species_id   = $ref_arg->{species_id};
   my $species_name = $ref_arg->{species};
   my $file         = $ref_arg->{file};
+  my $verbose      = $ref_arg->{verbose};
   my $db           = $ref_arg->{dba};
-  my $dbi          = $ref_arg->{dbi} // $self->dbi;
-  my $verbose      = $ref_arg->{verbose} // 0;
+  my $dbi          = $ref_arg->{dbi};
+  $dbi = $self->dbi unless defined $dbi;
 
-  # initial param validation step
   if((!defined $source_id) or (!defined $species_id) or (!defined $file) ){
     croak "Need to pass source_id, species_id and file as pairs";
   }
+  $verbose |=0;
 
-  my $file_params = $self->parse_file_string($file);
+  my $peptide_source_id = $self->get_source_id_for_source_name('RefSeq_peptide', 'otherfeatures', $dbi);
+  my $mrna_source_id = $self->get_source_id_for_source_name('RefSeq_mRNA', 'otherfeatures', $dbi);
+  my $ncrna_source_id = $self->get_source_id_for_source_name('RefSeq_ncRNA', 'otherfeatures', $dbi);
 
-  # project or db param validation
-  unless ( defined $db || ( ($file_params->{project} eq 'ensembl') || ($file_params->{project} eq 'ensemblgenomes') ) ) {
-    croak "Missing or unsupported project value (supported values: ensembl, ensemblgenomes), or missing db value.";
+  my $pred_peptide_source_id =
+    $self->get_source_id_for_source_name('RefSeq_peptide_predicted', 'otherfeatures', $dbi);
+  my $pred_mrna_source_id =
+    $self->get_source_id_for_source_name('RefSeq_mRNA_predicted','otherfeatures', $dbi);
+  my $pred_ncrna_source_id =
+    $self->get_source_id_for_source_name('RefSeq_ncRNA_predicted', 'otherfeatures', $dbi);
+
+  if($verbose){
+    print "RefSeq_peptide source ID = $peptide_source_id\n";
+    print "RefSeq_mRNA source ID = $mrna_source_id\n";
+    print "RefSeq_ncRNA source ID = $ncrna_source_id\n";
+    print "RefSeq_peptide_predicted source ID = $pred_peptide_source_id\n";
+    print "RefSeq_mRNA_predicted source ID = $pred_mrna_source_id\n" ;
+    print "RefSeq_ncRNA_predicted source ID = $pred_ncrna_source_id\n" ;
   }
 
-  # set default values
-  $file_params->{user}   //= 'ensro';
-  $file_params->{port}   //= '3306';
-  $file_params->{ofuser} //= 'ensro';
-  $file_params->{ofport} //= '3306';
+  my $user = "ensro";
+  my $host;
+  my $port = 3306;
+  my $dbname;
+  my $pass;
+  my $transcript_score_threshold = 0.75;
+  my $tl_transcript_score_threshold = 0.75;
+  my $project;
 
-  # get RefSeq source ids
-  while (my ($source_prefix, $source_name) = each %{$REFSEQ_SOURCES}) {
-    $self->{source_ids}->{$source_name} = $self->get_source_id_for_source_name( $source_name, 'otherfeatures' , $dbi )
+# Grep the project name, should be ensembl or ensemblgenomes
+  if($file =~ /project[=][>](\S+?)[,]/){
+    $project = $1;
   }
 
-  if ($verbose) {
-    for my $source_name (sort values %{$REFSEQ_SOURCES}) {
-      print "$source_name source ID = $self->{source_ids}->{$source_name}\n";
-    }
+# If specified, get core database connection details
+  if($file =~ /host[=][>](\S+?)[,]/){
+    $host = $1;
+  }
+  if($file =~ /port[=][>](\S+?)[,]/){
+    $port =  $1;
+  }
+  if($file =~ /dbname[=][>](\S+?)[,]/){
+    $dbname = $1;
+  }
+  if($file =~ /pass[=][>](\S+?)[,]/){
+    $pass = $1;
+  }
+  if($file =~ /user[=][>](\S+?)[,]/){
+    $user = $1;
   }
 
-  # get the species name
-  my %id2name = $self->species_id2name($dbi);
-  $species_name //= shift @{$id2name{$species_id}};
+  my $ofuser = 'ensro';
+  my $ofhost;
+  my $ofport = 3306;
+  my $ofdbname;
+  my $ofpass;
 
-  # prepare registry and core/otherfeatures dba
+# If specified, get otherfeatures database connection details
+  if($file =~ /ofhost[=][>](\S+?)[,]/){
+    $ofhost = $1;
+  }
+  if($file =~ /ofuser[=][>](\S+?)[,]/){
+    $ofuser = $1;
+  }
+  if($file =~ /ofport[=][>](\S+?)[,]/){
+    $ofport =  $1;
+  }
+  if($file =~ /ofdbname[=][>](\S+?)[,]/){
+    $ofdbname = $1;
+  }
+  if($file =~ /ofpass[=][>](\S+?)[,]/){
+    $ofpass = $1;
+  }
+ 
   my $registry = "Bio::EnsEMBL::Registry";
-  my ($core_dba, $otherf_dba);
 
-  # for ensembl project, use provided connection details or default to staging
-  if ( $file_params->{project} eq 'ensembl' ) {
-    if (!defined $file_params->{host}) {
-      $file_params->{host} = 'mysql-ens-sta-1';
-      $file_params->{port} = '4519';
-      $file_params->{user} = 'ensro';
+  #get the species name
+  my %id2name = $self->species_id2name($dbi);
+  if (defined $species_name) { push @{$id2name{$species_id}}, $species_name; }
+  if (!defined $id2name{$species_id}) { next; }
+  $species_name = $id2name{$species_id}[0];
+
+  my $core_dba;
+  my $otherf_dba;
+
+  if (defined $project && $project eq 'ensembl') {
+# Can use user-defined database
+      if (defined $host) {
+          $core_dba = Bio::EnsEMBL::DBSQL::DBAdaptor->new(
+              '-host'     => $host,
+              '-user'     => $user,
+              '-pass'     => $pass,
+              '-dbname'   => $dbname,
+              '-port'     => $port,
+              '-species'  => $species_name.$host,
+              '-group'    => 'core',
+       );
+      } else {
+# Else, database should be on staging
+      $registry->load_registry_from_multiple_dbs(
+          {
+              -host    => 'mysql-ens-sta-1',
+	      '-port'    => 4519,
+              -user    => 'ensro',
+          },
+       );
+      $core_dba = $registry->get_DBAdaptor($species_name,'core');
+      }
+      if (defined $ofhost) {
+# Can use user-defined database
+          $otherf_dba = Bio::EnsEMBL::DBSQL::DBAdaptor->new(
+              '-host'     => $ofhost,
+              '-user'     => $ofuser,
+              '-pass'     => $ofpass,
+              '-port'     => $ofport,
+              '-dbname'   => $ofdbname,
+              '-species'  => $species_name,
+              '-group'    => 'otherfeatures',
+       );
+       $otherf_dba->dnadb($core_dba);
+      } else {
+# Else database should be on staging
+      $registry->load_registry_from_multiple_dbs( 
+	  {
+	      -host    => 'mysql-ens-sta-1',
+	      '-port'    => 4519,
+	      -user    => 'ensro',
+	  },
+       );
+      $otherf_dba = $registry->get_DBAdaptor($species_name, 'otherfeatures') if !defined($ofhost);
+      if (defined $otherf_dba) { $otherf_dba->dnadb($core_dba); }
     }
-    $registry->load_registry_from_db(
-      '-host' => $file_params->{host},
-      '-port' => $file_params->{port},
-      '-user' => $file_params->{user},
-    );
-    $core_dba = $registry->get_DBAdaptor($species_name, 'core');
-    if (!defined $file_params->{ofhost}) {
-      $file_params->{ofhost} = 'mysql-ens-sta-1';
-      $file_params->{ofport} = '4519';
-      $file_params->{ofuser} = 'ensro';
-    }
-    $registry->load_registry_from_db(
-      '-host' => $file_params->{ofhost},
-      '-port' => $file_params->{ofport},
-      '-user' => $file_params->{ofuser},
-    );
-    $otherf_dba = $registry->get_DBAdaptor($species_name, 'otherfeatures');
-    $otherf_dba->dnadb($core_dba);
-  # for ensemblgenomes project, use staging and ignore any connection details provided
-  } elsif ( $file_params->{project} eq 'ensemblgenomes' ) {
-    $registry->load_registry_from_multiple_dbs( {
-      '-host' => 'mysql-eg-staging-1.ebi.ac.uk',
-      '-port' => '4160',
-      '-user' => 'ensro',
-    }, {
-      '-host' => 'mysql-eg-staging-2.ebi.ac.uk',
-      '-port' => '4275',
-      '-user' => 'ensro',
-    } );
-    $core_dba = $registry->get_DBAdaptor($species_name, 'core');
-    $otherf_dba = $registry->get_DBAdaptor($species_name, 'otherfeatures');
-  # if no project but db provided, use that
-  } else {
+      
+
+  } elsif (defined $project && $project eq 'ensemblgenomes') {
+      $registry->load_registry_from_multiple_dbs( 
+	  {
+	      -host     => 'mysql-eg-staging-1.ebi.ac.uk',
+	      -port     => 4160,
+	      -user     => 'ensro',
+	  },
+	  {
+	      -host     => 'mysql-eg-staging-2.ebi.ac.uk',
+	      -port     => 4275,
+	      -user     => 'ensro',
+	  },
+ 
+      );
+      $core_dba = $registry->get_DBAdaptor($species_name,'core');
+      $otherf_dba = $registry->get_DBAdaptor($species_name, 'otherfeatures');     
+
+  } elsif (defined $db) {
     $otherf_dba = $db;
     $core_dba = $db->dnadb();
+  } else {
+      die("Missing or unsupported project value. Supported values: ensembl, ensemblgenomes");
   }
 
-  # Not all species have an otherfeatures database, error if not found
+## Not all species have an otherfeatures database, skip if not found
   if (!$otherf_dba) {
-    warn "No otherfeatures database found for species '$species_name'. Skipping\n";
+    print STDERR "No otherfeatures database for $species_name, skipping import for refseq_import data\n";
     return;
   }
 
-  # Cache EntrezGene IDs and source ID where available
-  my $entrez_ids = $self->get_valid_codes('EntrezGene', $species_id, $dbi);
-  $self->{source_ids}->{EntrezGene} = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
+## Add link to EntrezGene IDs where available
+  my (%entrez_ids) = %{ $self->get_valid_codes("EntrezGene", $species_id, $dbi) };
   my $entrez_source_id = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
+  my $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)");
 
   my $sa = $core_dba->get_SliceAdaptor();
   my $sa_of = $otherf_dba->get_SliceAdaptor();
   my $chromosomes_of = $sa_of->fetch_all('toplevel', undef, 1);
 
-  # Fetch analysis object for refseq
+# Fetch analysis object for refseq
   my $aa_of = $otherf_dba->get_AnalysisAdaptor();
-
-  # Not all species have refseq_import data, exit if not found
-  if (!defined $aa_of->fetch_by_logic_name('refseq_import')->logic_name) {
-    warn "No data found for RefSeq_import. Skipping\n";
+  my $logic_name;
+  foreach my $ana(@{ $aa_of->fetch_all() }) {
+    if ($ana->logic_name =~ /refseq_import/) {
+      $logic_name = $ana->logic_name;
+    }
+  }
+## Not all species have refseq_import data, skip if not found
+  if (!defined $logic_name) {
+    print STDERR "No data found for RefSeq_import, skipping import\n";;
     return;
   }
 
-  # Iterate over chromosomes in otherfeatures database
-  foreach my $chromosome_of (@{$chromosomes_of}) {
+  foreach my $chromosome_of (@$chromosomes_of) {
     my $chr_name = $chromosome_of->seq_region_name();
-    my $genes_of = $chromosome_of->get_all_Genes('refseq_import', undef, 1);
+    my $genes_of = $chromosome_of->get_all_Genes($logic_name, undef, 1);
 
-    # For each gene in that chromosome in otherfeatures database
-    foreach my $gene_of (@{$genes_of}) {
+    while (my $gene_of = shift @$genes_of) {
       my $transcripts_of = $gene_of->get_all_Transcripts();
 
-      # Create a range registry for all the exons of the refseq transcript
-      TRANSCRIPT_OF:
-      foreach my $transcript_of (sort { $a->start <=> $b->start } @{$transcripts_of}) {
-        my $id;
-        # RefSeq accessions are now stored as xrefs rather than
-        # stable ids as it used to be in the past. This means
-        # priority is given to the display_id, and fall back to stable_id
-        # for backwards compatibility.
-        if (defined $transcript_of->display_xref ) {
-          $id = $transcript_of->display_xref->display_id;
-        } elsif (defined $transcript_of->stable_id) {
-          $id = $transcript_of->stable_id;
-        }
-
-        # Skip non supported and missing accessions
-        unless ( exists $REFSEQ_SOURCES->{substr($id, 0, 2)} ) {
-          next TRANSCRIPT_OF;
-        }
-
-        my $transcript_result;
-        my $tl_transcript_result;
-
+# Create a range registry for all the exons of the refseq transcript
+      foreach my $transcript_of (sort { $a->start() <=> $b->start() } @$transcripts_of) {
+	my ($id, $tl_id);
+	# We're moving to RefSeq accessions being stored as xrefs rather than
+	# stable ids. But we also need to maintain backwards compatbility.
+	# If it's the new kind, where there's a display_xref use that,
+	# otherwise fall back to using the stable_id. But also check if we
+	# have neither, then skip the record.
+	if (defined $transcript_of->display_xref ) {
+	  $id = $transcript_of->display_xref->display_id;
+	} elsif (defined $transcript_of->stable_id) {
+	  $id = $transcript_of->stable_id;
+	} else {
+	  # Skip non conventional accessions
+	  next;
+	}
+        if ($id !~ /^[NXMR]{2}_[0-9]+/)  { next; }
+        my %transcript_result;
+        my %tl_transcript_result;
+        if (!defined $id) { next; }
         my $exons_of = $transcript_of->get_all_Exons();
-        my $rr_exons_of = Bio::EnsEMBL::Mapper::RangeRegistry->new();
+        my $rr1 = Bio::EnsEMBL::Mapper::RangeRegistry->new();
         my $tl_exons_of = $transcript_of->get_all_translateable_Exons();
-        my $rr_tl_exons_of = Bio::EnsEMBL::Mapper::RangeRegistry->new();
+        my $rr3 = Bio::EnsEMBL::Mapper::RangeRegistry->new();
 
-        # register $exons_of on $rr_exons_of
-        $self->compute_exons({
-          exons              => $exons_of,
-          check_and_register => $rr_exons_of
-        });
+        foreach my $exon_of (@$exons_of) {
+          my $start_of = $exon_of->seq_region_start();
+          my $end_of = $exon_of->seq_region_end();
+          $rr1->check_and_register( 'exon', $start_of, $end_of );
+        }
 
-        # register $tl_exons_of on $rr_tl_exons_of
-        $self->compute_exons({
-          exons              => $tl_exons_of,
-          check_and_register => $rr_tl_exons_of
-        });
+        foreach my $tl_exon_of (@$tl_exons_of) {
+          my $tl_start_of = $tl_exon_of->seq_region_start();
+          my $tl_end_of = $tl_exon_of->seq_region_end();
+          $rr3->check_and_register( 'exon', $tl_start_of, $tl_end_of );
+        }
 
-        # Fetch slice in core database which overlaps refseq transcript
+# Fetch slice in core database which overlaps refseq transcript
         my $chromosome = $sa->fetch_by_region('toplevel', $chr_name, $transcript_of->seq_region_start, $transcript_of->seq_region_end);
         my $transcripts = $chromosome->get_all_Transcripts(1);
 
-        # Create a range registry for all the exons of the ensembl transcript
-        TRANSCRIPT:
-        foreach my $transcript(@{$transcripts}) {
-          # make sure it's the same strand
-          if ($transcript->strand != $transcript_of->strand) {
-            next TRANSCRIPT;
-          }
+# Create a range registry for all the exons of the ensembl transcript
+        foreach my $transcript(@$transcripts) {
+          if ($transcript->strand != $transcript_of->strand) { next; }
           my $exons = $transcript->get_all_Exons();
-          my $rr_exons = Bio::EnsEMBL::Mapper::RangeRegistry->new();
+          my $rr2 = Bio::EnsEMBL::Mapper::RangeRegistry->new();
+          my $rr4 = Bio::EnsEMBL::Mapper::RangeRegistry->new();
+          my $exon_match = 0;
           my $tl_exons = $transcript->get_all_translateable_Exons();
-          my $rr_tl_exons = Bio::EnsEMBL::Mapper::RangeRegistry->new();
+          my $tl_exon_match = 0;
 
-          # register $exons on $rr_exons, overlap with $rr_exons_of
-          my $exon_match = $self->compute_exons({
-            exons              => $exons,
-            check_and_register => $rr_exons,
-            overlap            => $rr_exons_of
-          });
+          foreach my $exon (@$exons) {
+            my $start = $exon->seq_region_start();
+            my $end = $exon->seq_region_end();
+            my $overlap = $rr1->overlap_size('exon', $start, $end);
+            $exon_match += $overlap/($end - $start + 1);
+            $rr2->check_and_register('exon', $start, $end);
+          }
 
-          # register $tl_exons on $rr_tl_exons, overlap with $rr_tl_exons_of
-          my $tl_exon_match = $self->compute_exons({
-            exons              => $tl_exons,
-            check_and_register => $rr_tl_exons,
-            overlap            => $rr_tl_exons_of
-          });
+          foreach my $tl_exon (@$tl_exons) {
+            my $tl_start = $tl_exon->seq_region_start();
+            my $tl_end = $tl_exon->seq_region_end();
+            my $tl_overlap = $rr3->overlap_size('exon', $tl_start, $tl_end);
+            $tl_exon_match += $tl_overlap/($tl_end - $tl_start + 1);
+            $rr4->check_and_register('exon', $tl_start, $tl_end);
+          }
 
-          # $exons_of overlap with $rr_exons
-          my $exon_match_of = $self->compute_exons({
-            exons   => $exons_of,
-            overlap => $rr_exons
-          });
+          my $exon_match_of = 0;
+          my $tl_exon_match_of = 0;
 
-          # $tl_exons_of overlap with $rr_tl_exons
-          my $tl_exon_match_of = $self->compute_exons({
-            exons   => $tl_exons_of,
-            overlap => $rr_tl_exons
-          });
+# Look for oeverlap between the two sets of exons
+          foreach my $exon_of (@$exons_of) {
+            my $start_of = $exon_of->seq_region_start();
+            my $end_of = $exon_of->seq_region_end();
+            my $overlap_of = $rr2->overlap_size('exon', $start_of, $end_of);
+            $exon_match_of += $overlap_of/($end_of - $start_of + 1);
+          }
 
-          # Comparing exon matching with number of exons to give a score
-          my $score = ( ($exon_match_of + $exon_match)) / (scalar(@{$exons_of}) + scalar(@{$exons}) );
+          foreach my $tl_exon_of (@$tl_exons_of) {
+            my $tl_start_of = $tl_exon_of->seq_region_start();
+            my $tl_end_of = $tl_exon_of->seq_region_end();
+            my $tl_overlap_of = $rr4->overlap_size('exon', $tl_start_of, $tl_end_of);
+            $tl_exon_match_of += $tl_overlap_of/($tl_end_of - $tl_start_of + 1);
+          }
+
+# Comparing exon matching with number of exons to give a score
+          my $score = ( ($exon_match_of + $exon_match)) / (scalar(@$exons_of) + scalar(@$exons) );
           my $tl_score = 0;
-          if (scalar(@{$tl_exons_of}) > 0) {
-            $tl_score = ( ($tl_exon_match_of + $tl_exon_match)) / (scalar(@{$tl_exons_of}) + scalar(@{$tl_exons}) );
+          if (scalar(@$tl_exons_of) > 0) {
+            $tl_score = ( ($tl_exon_match_of + $tl_exon_match)) / (scalar(@$tl_exons_of) + scalar(@$tl_exons) );
           }
           if ($transcript->biotype eq $transcript_of->biotype) {
-            $transcript_result->{$transcript->stable_id} = $score;
-            $tl_transcript_result->{$transcript->stable_id} = $tl_score;
+            $transcript_result{$transcript->stable_id} = $score;
+            $tl_transcript_result{$transcript->stable_id} = $tl_score;
           } else {
-            $transcript_result->{$transcript->stable_id} = $score * $PENALTY;
-            $tl_transcript_result->{$transcript->stable_id} = $tl_score * $PENALTY;
+            $transcript_result{$transcript->stable_id} = $score * 0.90;
+            $tl_transcript_result{$transcript->stable_id} = $tl_score * 0.90;
           }
         }
 
-        my ($best_id, $best_score, $best_tl_score) = $self->compute_best_scores($transcript_result, $tl_transcript_result);
-
-        # If a best match was defined for the refseq transcript, store it as direct xref for ensembl transcript
-        if ($best_id) {
-          my ($acc, $version) = split(/\./x, $id);
-
-          my $source = $self->source_id_from_acc($acc);
-
-          next TRANSCRIPT unless defined $source;
-
-          my $xref_id = $self->add_xref({
-            acc        => $acc,
-            version    => $version,
-            label      => $id,
-            source_id  => $source,
-            species_id => $species_id,
-            dbi        => $dbi,
-            info_type  => 'DIRECT'
-          });
-          $self->add_direct_xref($xref_id, $best_id, 'Transcript', undef, $dbi);
-
-          my $entrez_id;
-          # RefSeq accessions are now stored as xrefs rather than
-          # stable ids as it used to be in the past. This means
-          # priority is given to the display_id, and fall back to stable_id
-          # for backwards compatibility.
-          if (defined $gene_of->display_xref) {
-            $entrez_id = $gene_of->display_xref->display_id;
-          } elsif (defined $gene_of->stable_id) {
-            $entrez_id = $gene_of->stable_id;
+        my $best_score = 0;
+        my $best_tl_score = 0;
+        my $best_id;
+        my ($score, $tl_score);
+# Comparing the scores based on coding exon overlap
+# If there is a stale mate, chose best exon overlap score
+        foreach my $tid (sort { $transcript_result{$b} <=> $transcript_result{$a} } keys(%transcript_result)) {
+          $score = $transcript_result{$tid};
+          $tl_score = $tl_transcript_result{$tid};
+          if ($score > $transcript_score_threshold || $tl_score > $tl_transcript_score_threshold) {
+            if ($tl_score >= $best_tl_score) {
+              if ($tl_score > $best_tl_score) {
+                $best_id = $tid;
+                $best_score = $score;
+                $best_tl_score = $tl_score;
+              } elsif ($tl_score == $best_tl_score) {
+                if ($score > $best_score) {
+                  $best_id = $tid;
+                  $best_score = $score;
+                }
+              }
+            } elsif ($score >= $best_score) {
+              $best_id = $tid;
+              $best_score = $score;
+            }
           }
+        }
 
-          my $tl_of = $transcript_of->translation();
+# If a best match was defined for the refseq transcript, store it as direct xref for ensembl transcript
+        if ($best_id) {
+          my ($acc, $version) = split(/\./, $id);
+	  $version =~ s/\D//g if $version;
+          my $source_id;
+          $source_id = $mrna_source_id if $acc =~ /^NM_/;
+          $source_id = $ncrna_source_id if $acc =~ /^NR_/;
+          $source_id = $pred_mrna_source_id if $acc =~ /^XM_/;
+          $source_id = $pred_ncrna_source_id if $acc =~ /^XR_/;
+          # Accession should be of format NM_/XM_/NR_/XR_ otherwise it is not valid
+          if (!defined $source_id) { next; }
+          my $xref_id = $self->add_xref({ acc => $acc,
+                                          version => $version,
+                                          label => $id,
+                                          desc => undef,
+                                          source_id => $source_id,
+                                          species_id => $species_id,
+                                          dbi => $dbi,
+                                          info_type => 'DIRECT' });
+          $self->add_direct_xref($xref_id, $best_id, "Transcript", "", $dbi);
+
+	  my $t_of = $transcript_of;
+          my $g_of = $t_of->get_Gene();
+          my $entrez_id = $g_of->stable_id();
+          my $tl_of = $t_of->translation();
           my $ta = $core_dba->get_TranscriptAdaptor();
           my $t = $ta->fetch_by_stable_id($best_id);
           my $tl = $t->translation();
 
-          # Add link between Ensembl gene and EntrezGene
-          if (defined $entrez_ids->{$entrez_id} ) {
-            foreach my $dependent_xref_id (@{$entrez_ids->{$entrez_id}}) {
-              $self->add_dependent_xref({
-                master_xref_id => $xref_id,
-                acc            => $dependent_xref_id,
-                source_id      => $self->source_id_from_name('EntrezGene'),
-                species_id     => $species_id,
-                dbi            => $dbi
-              });
+# Add link between Ensembl gene and EntrezGene
+          if (defined $entrez_ids{$entrez_id} ) {
+            foreach my $dependent_xref_id (@{$entrez_ids{$entrez_id}}) {
+              $add_dependent_xref_sth->execute($xref_id, $dependent_xref_id);
             }
           }
 
-          # Also store refseq protein as direct xref for ensembl translation, if translation exists
+# Also store refseq protein as direct xref for ensembl translation, if translation exists
           if (defined $tl && defined $tl_of) {
             if ($tl_of->seq eq $tl->seq) {
-              my $tl_id = $tl_of->stable_id();
+              $tl_id = $tl_of->stable_id();
               my @xrefs = grep {$_->{dbname} eq 'GenBank'} @{$tl_of->get_all_DBEntries};
               if(scalar @xrefs == 1) {
                 $tl_id = $xrefs[0]->primary_id();
               }
-              my ($tl_acc, $tl_version) = split(/\./xms, $tl_id);
-
-              my $tl_source = $self->source_id_from_acc($tl_acc);
-
-              next TRANSCRIPT unless defined $tl_source;
-
-              my $tl_xref_id = $self->add_xref({
-                acc        => $tl_acc,
-                version    => $tl_version,
-                label      => $tl_id,
-                source_id  => $tl_source,
-                species_id => $species_id,
-                dbi        => $dbi,
-                info_type  => 'DIRECT'
-              });
-              $self->add_direct_xref($tl_xref_id, $tl->stable_id(), 'Translation', undef, $dbi);
+              ($acc, $version) = split(/\./, $tl_id);
+              $source_id = $peptide_source_id;
+              $source_id = $pred_peptide_source_id if $acc =~ /^XP_/;
+              my $tl_xref_id = $self->add_xref({ acc => $acc,
+                                              version => $version,
+                                              label => $tl_id,
+                                              desc => undef,
+                                              source_id => $source_id,
+                                              species_id => $species_id,
+                                              dbi => $dbi,
+                                              info_type => 'DIRECT' });
+              $self->add_direct_xref($tl_xref_id, $tl->stable_id(), "Translation", "", $dbi);
             }
           }
         }
@@ -350,118 +429,6 @@ sub run_script {
     }
   }
   return 0;
-}
-
-
-
-# parses the input string $file into an hash
-# string $file is in the format as the example:
-# script:project=>ensembl,host=>ens-staging1,dbname=>homo_sapiens_core_70_37,ofhost=>ens-staging1,...
-# string until : is ignored, hash is built with keys=>values provided
-sub parse_file_string {
-  my ($self, $file_string) = @_;
-
-  $file_string =~ s/\A\w+://x;
-
-  my @param_pairs = split( /,/x, $file_string );
-
-  my $params;
-
-  # set provided values
-  foreach my $pair ( @param_pairs ) {
-    my ($key, $value) = split( /=>/x, $pair );
-    $params->{$key} = $value;
-  }
-
-  return $params;
-}
-
-# params hash can provide 3 keyed params: exons, check_and_register and overlap
-# exons is the array ref of the exons to process
-# check_and_register may contain a range registry to check_and_register the exons there
-# overlap may contain a range registry to calculate the overlap of the exons there
-# returns the exon_match, which is always 0 if no overlap requested
-sub compute_exons {
-  my ($self, $params) = @_;
-
-  my $exon_match = 0;
-
-  foreach my $exon (@{$params->{exons}}) {
-    if (defined $params->{check_and_register}) {
-      $params->{check_and_register}->check_and_register( 'exon', $exon->seq_region_start, $exon->seq_region_end );
-    }
-    if (defined $params->{overlap}) {
-      my $overlap = $params->{overlap}->overlap_size('exon', $exon->seq_region_start, $exon->seq_region_end);
-      $exon_match += $overlap / ($exon->seq_region_end - $exon->seq_region_start + 1);
-    }
-  }
-
-  return $exon_match;
-}
-
-# requires transcript_result and tl_transcript_result hashrefs
-# returns the best_id, best_score and best_tl_score
-sub compute_best_scores {
-  my ($self, $transcript_result, $tl_transcript_result) = @_;
-
-  my $best_score = 0;
-  my $best_tl_score = 0;
-  my $best_id;
-
-  # Comparing the scores based on coding exon overlap
-  # If there is a stale mate, chose best exon overlap score
-  foreach my $tid (sort { $transcript_result->{$b} <=> $transcript_result->{$a} } keys(%{$transcript_result})) {
-    my $score = $transcript_result->{$tid};
-    my $tl_score = $tl_transcript_result->{$tid};
-    if ($score > $TRANSCRIPT_SCORE_THRESHOLD || $tl_score > $TL_TRANSCRIPT_SCORE_THRESHOLD) {
-      if ($tl_score > $best_tl_score) {
-        $best_id = $tid;
-        $best_score = $score;
-        $best_tl_score = $tl_score;
-      } elsif ($tl_score == $best_tl_score) {
-        if ($score > $best_score) {
-          $best_id = $tid;
-          $best_score = $score;
-        }
-      } elsif ($score >= $best_score) {
-        $best_id = $tid;
-        $best_score = $score;
-      }
-    }
-  }
-
-  return ($best_id, $best_score, $best_tl_score);
-}
-
-# returns the source id for a source name, requires $self->{source_ids} to have been populated
-sub source_id_from_name {
-  my ($self, $name) = @_;
-
-  my $source_id;
-
-  if ( exists $self->{source_ids}->{$name} ) {
-    $source_id = $self->{source_ids}->{$name};
-  } elsif ( $self->{verbose} ) {
-    warn "WARNING: can't get source ID for name '$name'\n";
-  }
-
-  return $source_id;
-}
-
-# returns the source id for a RefSeq accession, requires $self->{source_ids} to have been populated
-sub source_id_from_acc {
-  my ($self, $acc) = @_;
-
-  my $source_id;
-  my $prefix = substr($acc, 0, 2);
-
-  if ( exists $REFSEQ_SOURCES->{$prefix} ) {
-    $source_id = $self->source_id_from_name( $REFSEQ_SOURCES->{$prefix} );
-  } elsif ( $self->{verbose} ) {
-    warn "WARNING: can't get source ID for accession '$acc'\n";
-  }
-
-  return $source_id;
 }
 
 1;


### PR DESCRIPTION
## Description

RefSeqCoordinateParser has been updated, but no tests available yet.
Thus RefSeqCoordinateParser is being reversed in this branch for merge with master to be issue free.
The work done on RefSeqCoordinateParser is still availabe on the ensembl-xref repo, and backporting should be performed on it's own.

## Use case

See ENSCORESW-3220

## Benefits

Salvage more work from the 2018 xref sprint.

## Possible Drawbacks

none I can see

## Testing

_Have you added/modified unit tests to test the changes?_
no
_If so, do the tests pass/fail?_
yes
_Have you run the entire test suite and no regression was detected?_
yes

