### PR TITLE
xref_parser.t: Fix malformed synthetic UniProt DR lines

### DIFF
--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -180,7 +180,7 @@ my @recognised_sources = (
  "MEROPS; C26.956; -.",
 );
 for my $l (@recognised_sources) {
-  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR  $l/;
+  (my $uniprot_elegans_record_extra_line = $uniprot_elegans_record) =~ s/DR(.*?)\n/DR$1\nDR   $l/;
   test_parser("XrefParser::UniProtParser", $uniprot_elegans_record_extra_line,  {
     xref => 4,
     primary_xref => 1,


### PR DESCRIPTION
This bug had been fixed in _feature/xref_sprint_ before but was intentionally re-introduced in order for #436 to be a clean revert to master state. Fix it again.