### PR TITLE
comment out diag statements in tests

### DIFF
--- a/modules/t/translation.t
+++ b/modules/t/translation.t
@@ -353,13 +353,14 @@ my $transcript_adaptor = $db->get_TranscriptAdaptor();
 $transcript = $transcript_adaptor->fetch_by_stable_id("ENST00000217347");
 $transcript->edits_enabled(1);
 
-diag 'Before X insertion: ', explain($transcript->translate->seq());
+# diag 'Before X insertion: ', explain($transcript->translate->seq());
 
 my $stop_codon_rt_edit = Bio::EnsEMBL::StopCodonReadthroughEdit->new(265);
 $transcript->translation->add_Attributes($stop_codon_rt_edit->get_Attribute());
 my $translated_sequence = $transcript->translate->seq();
 
-diag 'After X insertion: ', explain($translated_sequence);
+# diag 'After X insertion: ', explain($translated_sequence);
+
 is($translated_sequence =~ /QEEXEE/, 1, 'X inserted');
 is(length($transcript->translate->seq()), length($translated_sequence), 'Length of the sequence pre and post edit is equal');
 


### PR DESCRIPTION

## Description

some diag statements are cluttering the tests with messages that should be for debug/diagnostics only. Commented them out.

## Use case

some diag statements are cluttering the tests with messages that should be for debug/diagnostics only.

## Benefits

Cleaner tests output

## Possible Drawbacks

none I can see. Perhaps it should just be removed instead of commented out?

## Testing

_Have you added/modified unit tests to test the changes?_

NA

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

yes

