### PR TITLE
Gitlab CI: enable triggering of dependent builds on Travis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ before_script:
 
 test:perl5.14-sqlite:
   stage: test
-  image: perl:5.14-threaded
+  image: perl:5.14
   variables:
     COVERALLS: "false"
     DB: "sqlite"
@@ -50,7 +50,7 @@ test:perl5.14-sqlite:
 
 test:perl5.30-mysql:
   stage: test
-  image: perl:5.30-threaded
+  image: perl:5.30
   variables:
     # Note: relies on the secret variable COVERALLS_REPO_TOKEN for report uploads to work
     COVERALLS: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,10 +62,10 @@ test:perl5.30-mysql:
 # Triggers for dependent builds
 #
 
-# FIXME:
-#  - only partly tested so far
-#  - doesn't support PRs before they are merged
-#    (would need extended run condition and better selection of downstream branches)
+# The template. It doesn't presently support PRs before they are
+# merged (would need extended run condition and better selection of
+# downstream branches) - but then again, we do not trigger dependent
+# builds for PRs on Travis either.
 .dependent_template:
   stage: posttest
   # We want this to run even if any test jobs fail
@@ -73,13 +73,36 @@ test:perl5.30-mysql:
   only:
     - master
     - /^release/\d+$/
-  trigger:
-    project: $DEPENDENT_PROJECT
-    # Use the same branch as in this project
-    branch: $CI_COMMIT_REF_NAME
 
-# Example trigger job using the above, disabled for obvious reasons
-.post:trigger_foo:
+# Actual trigger jobs
+
+# ensembl-rest; disabled for now because that repo a) hasn't got
+# GitLab-CI config yet, and b) is still on the list in
+# trigger-dependent-build.sh.
+.post:trigger_rest:
   extends: .dependent_template
+  trigger:
+    project: ensembl-gh-mirror/ensembl-rest
+    # Use the same branch as in this project
+    branch: ${CI_COMMIT_REF_NAME}
+
+# Dependent builds on Travis
+# Relies on the secret variable TRAVIS_AUTH_TOKEN to actually work,
+# moreover the account associated with the token must have write
+# access to *all* dependent repositories; to be exact what it needs
+# is the Travis 'create_request' permission but Travis permissions are
+# generated from GitHub ones and it seems that in order to have
+# 'create_request' on the latter one requires 'write' on the former.
+post:trigger_travis:
+  extends: .dependent_template
+  image: alpine:3.10
   variables:
-    DEPENDENT_PROJECT: ensembl-gh-mirror/ensembl-foo
+    AUTH_TOKEN: ${TRAVIS_AUTH_TOKEN}
+    TRAVIS_REPO_SLUG: ${CI_PROJECT_PATH}
+    TRAVIS_BRANCH: ${CI_COMMIT_REF_NAME}
+    TRAVIS_COMMIT: ${CI_COMMIT_SHA}
+    # Safe as long as run conditions above do not include merge requests
+    TRAVIS_PULL_REQUEST: "false"
+  script:
+    - apk add --no-cache bash curl python3
+    - ${CI_PROJECT_DIR}/travisci/trigger-dependent-build.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,38 +2,42 @@ stages:
   - test
   - posttest
 
-services:
-  - mysql:5.6
+#
+# Test-job template
+#
 
-variables:
-  # FIXME: set some password for both users
-  MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-  MYSQL_USER: "travis"
-  MYSQL_PASSWORD: ""
-  USER: "gitlabci"
+.ensembl_test_template:
+  services:
+    - mysql:5.6
 
-# Run before each job not defining its own before_script
-before_script:
-  - apt-get update
-  - apt-get install -y build-essential cpanminus git
-  - apt-get install -y libmysqlclient-dev mysql-client || apt-get install -y default-libmysqlclient-dev default-mysql-client
-  - apt-get install -y libssl-dev sqlite3
-  - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-test.git
-  - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-io.git
-  - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-variation.git
-  - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-compara.git
-  - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git
-  - cpanm -v --installdeps --notest .
-  - ( cd ensembl-test && cpanm -v --installdeps --notest . )
-#  - ( cd ensembl-io && cpanm -v --installdeps --notest . )
-#  - ( cd ensembl-variation && cpanm -v --installdeps --notest . )
-  - ( cd ensembl-compara && cpanm -v --installdeps --notest . )
-  - ( cd misc-scripts/xref_mapping && cpanm -v --installdeps --notest . )
-  - cpanm -n Devel::Cover::Report::Coveralls
-  - cpanm -n DBD::SQLite
-  - cp travisci/MultiTestDB.conf.gitlabci.mysql  modules/t/MultiTestDB.conf.mysql
-  - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
-  - mysql -u root -h mysql -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
+  variables:
+    # FIXME: set some password for both users
+    MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    MYSQL_USER: "travis"
+    MYSQL_PASSWORD: ""
+    USER: "gitlabci"
+
+  before_script:
+    - apt-get update
+    - apt-get install -y build-essential cpanminus git
+    - apt-get install -y libmysqlclient-dev mysql-client || apt-get install -y default-libmysqlclient-dev default-mysql-client
+    - apt-get install -y libssl-dev sqlite3
+    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-test.git
+    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-io.git
+    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-variation.git
+    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-compara.git
+    - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git
+    - cpanm -v --installdeps --notest .
+    - ( cd ensembl-test && cpanm -v --installdeps --notest . )
+#    - ( cd ensembl-io && cpanm -v --installdeps --notest . )
+#    - ( cd ensembl-variation && cpanm -v --installdeps --notest . )
+    - ( cd ensembl-compara && cpanm -v --installdeps --notest . )
+    - ( cd misc-scripts/xref_mapping && cpanm -v --installdeps --notest . )
+    - cpanm -n Devel::Cover::Report::Coveralls
+    - cpanm -n DBD::SQLite
+    - cp travisci/MultiTestDB.conf.gitlabci.mysql  modules/t/MultiTestDB.conf.mysql
+    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
+    - mysql -u root -h mysql -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
 
 #
 # Test jobs
@@ -41,6 +45,7 @@ before_script:
 
 test:perl5.14-sqlite:
   stage: test
+  extends: .ensembl_test_template
   image: perl:5.14
   variables:
     COVERALLS: "false"
@@ -50,6 +55,7 @@ test:perl5.14-sqlite:
 
 test:perl5.30-mysql:
   stage: test
+  extends: .ensembl_test_template
   image: perl:5.30
   variables:
     # Note: relies on the secret variable COVERALLS_REPO_TOKEN for report uploads to work

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ stages:
 #
 
 .ensembl_test_template:
+  image: dockerhub.ebi.ac.uk/ensembl-infrastructure/ensembl-ci-docker-images:${PERL_VERSION}
+
   services:
     - mysql:5.6
 
@@ -46,8 +48,8 @@ stages:
 test:perl5.14-sqlite:
   stage: test
   extends: .ensembl_test_template
-  image: perl:5.14
   variables:
+    PERL_VERSION: "5.14"
     COVERALLS: "false"
     DB: "sqlite"
   script:
@@ -56,8 +58,8 @@ test:perl5.14-sqlite:
 test:perl5.30-mysql:
   stage: test
   extends: .ensembl_test_template
-  image: perl:5.30
   variables:
+    PERL_VERSION: "5.30"
     # Note: relies on the secret variable COVERALLS_REPO_TOKEN for report uploads to work
     COVERALLS: "true"
     DB: "mysql"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,3 @@
-stages:
-  - test
-  - posttest
-
 #
 # Test-job template
 #
@@ -75,9 +71,7 @@ test:perl5.30-mysql:
 # downstream branches) - but then again, we do not trigger dependent
 # builds for PRs on Travis either.
 .dependent_template:
-  stage: posttest
-  # We want this to run even if any test jobs fail
-  when: always
+  stage: test
   only:
     - master
     - /^release/\d+$/
@@ -87,7 +81,7 @@ test:perl5.30-mysql:
 # ensembl-rest; disabled for now because that repo a) hasn't got
 # GitLab-CI config yet, and b) is still on the list in
 # trigger-dependent-build.sh.
-.post:trigger_rest:
+.test:trigger_rest:
   extends: .dependent_template
   trigger:
     project: ensembl-gh-mirror/ensembl-rest
@@ -101,7 +95,7 @@ test:perl5.30-mysql:
 # is the Travis 'create_request' permission but Travis permissions are
 # generated from GitHub ones and it seems that in order to have
 # 'create_request' on the latter one requires 'write' on the former.
-post:trigger_travis:
+test:trigger_travis:
   extends: .dependent_template
   image: alpine:3.10
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@
   before_script:
     - apt-get update
     - apt-get install -y build-essential cpanminus git
-    - apt-get install -y libmysqlclient-dev mysql-client || apt-get install -y default-libmysqlclient-dev default-mysql-client
+    - apt-get install -y default-libmysqlclient-dev default-mysql-client
     - apt-get install -y libssl-dev sqlite3
     - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-test.git
     - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-io.git


### PR DESCRIPTION
## Description

Extend .gitlab-ci.yml so that _ensembl_ pipelines on EBI GitLab can trigger dependent builds in projects still using Travis.

## Use case

The switch from to GitLab CI is to take place on a per-team basis so there will be dependent projects on Travis.

## Benefits

Ensure CI compatibility of Core projects on EBI GitLab with dependent projects still on Travis.

## Possible Drawbacks

In order for all dependent builds to be triggered successfully the user whose API token is used to authenticate with Travis REST API must have write access to all dependent repositories, which will have to be set up manually (in case of all-Travis runs there is implicit organisation-wide trust).

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

N/A, changes only affect the running of tests on EBI GitLab.
