### PR TITLE
[ENSCORESW-3183][ENSCORESW-3176] Mapper performance improvements

### DIFF
--- a/modules/Bio/EnsEMBL/Mapper.pm
+++ b/modules/Bio/EnsEMBL/Mapper.pm
@@ -1023,12 +1023,36 @@ sub _dump{
   if( !defined $fh ) {
     $fh = \*STDERR;
   }
-  foreach my $id ( keys %{$self->{'_pair_hash_from'}} ) {
-    print $fh "From Hash $id\n";
-    foreach my $pair ( @{$self->{'_pair_hash_from'}->{uc($id)}} ) {
+
+  my $from = $self->{'from'};
+  my $to = $self->{'to'};
+
+  print $fh "--------------------begin mapper dump--------------------\n";
+  print $fh "dumping from-hash _pair_$from\n";
+  foreach my $id ( keys %{$self->{"_pair_$from"}} ) {
+    print $fh "{_pair_$from}->{" . uc($id) . "}:\n";
+    foreach my $pair ( @{$self->{"_pair_$from"}->{uc($id)}} ) {
       print $fh "    ",$pair->from->start," ",$pair->from->end,":",$pair->to->start," ",$pair->to->end," ",$pair->to->id,"\n";
     }
+    if (defined($self->{"_tree_$from"}->{uc($id)})) {
+      print $fh "{_tree_$from}->{" . uc($id) . "} instantiated\n";
+    } else {
+      print $fh "{_tree_$from}->{" . uc($id) . "} empty\n";
+    }
   }
+  print $fh "dumping to-hash _pair_$to\n";
+  foreach my $id ( keys %{$self->{"_pair_$to"}} ) {
+    print $fh "{_pair_$to}->{" . uc($id) . "}:\n";
+    foreach my $pair ( @{$self->{"_pair_$to"}->{uc($id)}} ) {
+      print $fh "    ",$pair->to->start," ",$pair->to->end,":",$pair->from->start," ",$pair->from->end," ",$pair->from->id,"\n";
+    }
+    if (defined($self->{"_tree_$to"}->{uc($id)})) {
+      print $fh "{_tree_$to}->{" . uc($id) . "} instantiated\n";
+    } else {
+      print $fh "{_tree_$to}->{" . uc($id) . "} empty\n";
+    }
+  }
+  print $fh "---------------------end mapper dump---------------------\n";
 }
 
 

--- a/modules/Bio/EnsEMBL/Mapper.pm
+++ b/modules/Bio/EnsEMBL/Mapper.pm
@@ -1016,7 +1016,6 @@ sub _dump{
   my $from = $self->{'from'};
   my $to = $self->{'to'};
 
-  print $fh "--------------------begin mapper dump--------------------\n";
   print $fh "dumping from-hash _pair_$from\n";
   foreach my $id ( keys %{$self->{"_pair_$from"}} ) {
     print $fh "{_pair_$from}->{" . uc($id) . "}:\n";
@@ -1041,7 +1040,6 @@ sub _dump{
       print $fh "{_tree_$to}->{" . uc($id) . "} empty\n";
     }
   }
-  print $fh "---------------------end mapper dump---------------------\n";
 }
 
 
@@ -1201,9 +1199,7 @@ sub _build_immutable_tree {
     my $end = $i->{$pair_side}{end};
 
     if ($end < $start) {
-      my $tmp = $start;
-      $start = $end;
-      $end = $tmp;
+        ($end, $start) = ($start, $end);
     }
 
     push @{$from_intervals}, Bio::EnsEMBL::Utils::Interval->new($start, $end, $i);

--- a/modules/t/mapper.t
+++ b/modules/t/mapper.t
@@ -80,6 +80,8 @@ test_transform ($mapper,
 
 #
 # check if the mapper can do merging
+# at the same time, check that IntervalTrees are correctly cached
+# and that IntervalTree caches are correctly invalidated
 #
 
 $mapper = Bio::EnsEMBL::Mapper->new( "asm1", "asm2" );
@@ -88,10 +90,17 @@ $mapper->add_map_coordinates( "1", 1, 10, 1, "1", 101, 110 );
 $mapper->add_map_coordinates( "1", 21, 30, 1, "1", 121, 130 );
 $mapper->add_map_coordinates( "1", 11, 20, 1, "1", 111, 120 );
 
+is($mapper->{_tree_asm1}->{1}, undef, "tree not yet created for asm1 interval 1");
+
 test_transform( $mapper, 
 		[ "1", 5, 25, 1, "asm1" ],
 		[ "1", 105, 125, 1 ] );
 
+is(defined($mapper->{_tree_asm1}->{1}), 1, "tree created and cached for asm1 interval 1");
+
+
+$mapper->add_map_coordinates( "1", 31, 40, 1, "1", 131, 140);
+is($mapper->{_tree_asm1}->{1}, undef, "tree deleted after modifying asm1 interval 1");
 
 
 #


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

These changes improve the speed of the recent interval tree based Mapper implementation. There are two main sets of fixes in this PR:

- Improvements to the immutable interval tree code to speed up building a new tree (by not sorting already-sorted lists, and using less stringent typechecking)
- Caching interval trees used by the mapper for reuse, rather than re-creating them each time `map_coordinates()` or `map_insert()` is called

I also fixed up `_dump()` so that it works again and is more useful, as I needed to use that method to aid in implementing these changes.

## Use case

Other teams have raised several JIRA tickets complaining about the slowness of the release/97 interval tree based Mapper. The Mapper is used directly or indirectly in many, many places throughout Ensembl, so its performance issues have wide impact for production as well as other Ensembl users. These are gathered in JIRA epic ENSCORESW-3183, and this in particular addresses the difficulty reported by production in ENSCORESW-3176

## Benefits

A 2-3 order of magnitude speedup in performance. For example, the Mapper calls involved in dumping the sequence of human chromosome 20 speeds up from  4954 seconds (82 minutes, 465 ms per call) to 19.7 seconds (1.8 ms per call). Most of this improvement is due to caching of trees in Mapper. The improvements in the IntervalTree itself cut the runtime by about 1/3 to 1/2

## Possible Drawbacks

We need to make sure that Mapper adaptors (e.g. AssemblyMapperAdaptor) continue to cache the Mappers themselves, so that they can be re-used. Otherwise, we end up having to go through the expense of rebuilding all these data structures all over again.

Because of these changes, Mapper is now fully subject to the two hard things in computer science: naming things, cache invalidation, and off by one errors. Any further changes to the Mapper need to be carefully considered to be sure stored trees are correctly instantiated and removed.

## Testing

_Have you added/modified unit tests to test the changes?_
Yes, tests for tree caching and invalidation in mapper.t

_If so, do the tests pass/fail?_
pass

_Have you run the entire test suite and no regression was detected?_
yes

In addition, I have run sequence dumper scripts with these new changes and the output is identical to the pre-change output.

