### PR TITLE
Tagging releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl
-
-


### PR DESCRIPTION
Hi,

I wanted to create an issue, but it seems to be impossible on this repo. So creating an empty pull request hoping that someone will read this.

We are in the process of creating [Conda packages for EnsEMBL perl modules](https://github.com/bioconda/bioconda-recipes/pull/18808), but, for reproducibility issues, we need to have tagged release archives with stable urls, as can be done automatically by GitHub.
See https://bioconda.github.io/contributor/linting.html#uses-vcs-url for the reasons why.

Currently only branches are available on the ensembl repos, so we are blocked, and can't finish these Conda packages.

Would it be possible to (automatically?) create githhub releases for each EnsEMBL releases? Or maybe there are some archives available at some stable url elsewhere?