### PR TITLE
Remove Try::Tiny dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,6 @@ requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';
 requires 'Config::IniFiles';
-requires 'Try::Tiny';
 
 test_requires 'Test::Warnings';
 test_requires 'Test::Differences';

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -82,7 +82,7 @@ use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Scalar qw(check_ref assert_ref);
 use Bio::EnsEMBL::Slice;
-use Try::Tiny;
+
 use vars qw(@ISA);
 
 use Scalar::Util qw(weaken);
@@ -1462,7 +1462,7 @@ sub feature_so_acc {
   my $so_acc;
 
   # Get the caller class SO acc
-  try {
+  eval {
     $so_acc = $ref->SEQUENCE_ONTOLOGY->{'acc'};
   };
 
@@ -1489,7 +1489,7 @@ sub feature_so_term {
   my $so_term;
 
   # Get the caller class SO acc
-  try {
+  eval {
     $so_term = $ref->SEQUENCE_ONTOLOGY->{'term'};
   };
 


### PR DESCRIPTION

## Description

The creation of ensembl VM 99 exposed some issues with installing Try::Tiny with cpanm on perl 5.14.4 using plenv.
Try::Tiny has been already in use for a few releases with no issues, but added to the cpan file this release.
Using perl 5.26.1 fixes the problem, but given that the Try::Tiny dependency is used in only one module and is easily replaced with alternative methods it would perhaps be good to drop it.

## Use case

See ENSCORESW-3303

## Benefits

One less external perl module dependency.
VM build can happen in perl 5.14

## Possible Drawbacks

Discourages future usage of Try::Tiny

## Testing

_Have you added/modified unit tests to test the changes?_
no

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
yes

