### PR TITLE
To support longer assembly names in the core dbs mapping_session table.

### DIFF
--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=394 DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -16,7 +16,7 @@ CREATE TABLE "alt_allele" (
 
 CREATE UNIQUE INDEX "gene_idx" ON "alt_allele" ("gene_id");
 
---Increased old_assembly and new_assembly lengths in mapping_session.mapp
+--
 -- Table: "alt_allele_attrib"
 --
 CREATE TABLE "alt_allele_attrib" (

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -16,7 +16,7 @@ CREATE TABLE "alt_allele" (
 
 CREATE UNIQUE INDEX "gene_idx" ON "alt_allele" ("gene_id");
 
---
+--Increased old_assembly and new_assembly lengths in mapping_session.mapp
 -- Table: "alt_allele_attrib"
 --
 CREATE TABLE "alt_allele_attrib" (
@@ -465,8 +465,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -410,8 +410,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -465,8 +465,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -410,8 +410,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;

--- a/sql/patch_99_100_c.sql
+++ b/sql/patch_99_100_c.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_99_100_c.sql
+#
+# Title: Update mapping_session.old_assembly and mapping_session.new_assembly columns to VARCHAR(80).
+#
+# Description:
+#   Title: Update mapping_session.old_assembly and mapping_session.new_assembly columns to VARCHAR(80).
+
+ALTER TABLE mapping_session MODIFY COLUMN old_assembly VARCHAR(80);
+ALTER TABLE mapping_session MODIFY COLUMN new_assembly VARCHAR(80);
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_99_100_c.sql|alter_mapping_session_assembly_length');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1915,8 +1915,8 @@ CREATE TABLE mapping_session (
   new_db_name                 VARCHAR(80) NOT NULL DEFAULT '',
   old_release                 VARCHAR(5) NOT NULL DEFAULT '',
   new_release                 VARCHAR(5) NOT NULL DEFAULT '',
-  old_assembly                VARCHAR(20) NOT NULL DEFAULT '',
-  new_assembly                VARCHAR(20) NOT NULL DEFAULT '',
+  old_assembly                VARCHAR(80) NOT NULL DEFAULT '',
+  new_assembly                VARCHAR(80) NOT NULL DEFAULT '',
   created                     DATETIME NOT NULL,
 
   PRIMARY KEY (mapping_session_id)


### PR DESCRIPTION
VARCHAR(20) is too short for some assembly names.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Increased length of old_assembly and new_assembly columns in the mapping_session table in the core databases.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Xenopus tropicalis assembly name would appear truncated as "Xenopus_tropicalis_v" in the current database schema.

## Benefits

_If applicable, describe the advantages the changes will have._
Longer assembly names would be supported.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
More space would be required.

## Testing

_Have you added/modified unit tests to test the changes?_
No. I think the existing unit tests should work.

_If so, do the tests pass/fail?_
N/A.

_Have you run the entire test suite and no regression was detected?_
No.
