### PR TITLE
Core db schema patch to support longer assembly names in the mapping_session table. [release/100]

### DIFF
--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:32 2019
+-- Created on Tue Dec 17 11:37:28 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -135,3 +135,4 @@
 135	\N	patch	patch_98_99_a.sql|schema_version
 136	\N	patch	patch_99_100_a.sql|schema_version
 137	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+138	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=138 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=139 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:37 2019
+-- Created on Tue Dec 17 11:37:36 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -114,3 +114,4 @@
 188	\N	patch	patch_98_99_a.sql|schema_version
 189	\N	patch	patch_99_100_a.sql|schema_version
 190	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+191	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=191 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=192 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:42 2019
+-- Created on Tue Dec 17 11:37:43 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -114,3 +114,4 @@
 163	\N	patch	patch_98_99_a.sql|schema_version
 164	\N	patch	patch_99_100_a.sql|schema_version
 165	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+166	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=166 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=167 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:48 2019
+-- Created on Tue Dec 17 11:37:50 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -119,3 +119,4 @@
 2126	\N	patch	patch_98_99_a.sql|schema_version
 2127	\N	patch	patch_99_100_a.sql|schema_version
 2128	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+2129	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=394 DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2129 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2130 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:49 2019
+-- Created on Tue Dec 17 11:37:52 2019
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:54 2019
+-- Created on Tue Dec 17 11:37:58 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -75,3 +75,4 @@
 168	\N	patch	patch_98_99_a.sql|schema_version
 169	\N	patch	patch_99_100_a.sql|schema_version
 170	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+171	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=172 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:35:58 2019
+-- Created on Tue Dec 17 11:38:04 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -384,7 +384,7 @@ CREATE TABLE "hmm_curated_annot" (
   "seq_member_stable_id" varchar(40) NOT NULL,
   "model_id" varchar(40),
   "library_version" varchar(40) NOT NULL,
-  "annot_date" timestamp NOT NULL DEFAULT 'current_timestamp()',
+  "annot_date" timestamp NOT NULL DEFAULT current_timestamp,
   "reason" mediumtext,
   PRIMARY KEY ("seq_member_stable_id")
 );
@@ -442,7 +442,7 @@ CREATE TABLE "homology_member" (
 CREATE TABLE "mapping_session" (
   "mapping_session_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "type" enum,
-  "when_mapped" timestamp NOT NULL DEFAULT 'current_timestamp()',
+  "when_mapped" timestamp NOT NULL DEFAULT current_timestamp,
   "rel_from" integer,
   "rel_to" integer,
   "prefix" char(4) NOT NULL

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:36:03 2019
+-- Created on Tue Dec 17 11:38:11 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -192,3 +192,4 @@
 1704	\N	patch	patch_98_99_a.sql|schema_version
 1705	\N	patch	patch_99_100_a.sql|schema_version
 1706	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+1707	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1707 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1708 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:36:08 2019
+-- Created on Tue Dec 17 11:38:18 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -465,8 +465,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/nameless/core/meta.txt
+++ b/modules/t/test-genome-DBs/nameless/core/meta.txt
@@ -113,3 +113,4 @@
 167	\N	patch	patch_98_99_a.sql|schema_version
 168	\N	patch	patch_99_100_a.sql|schema_version
 169	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+170	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -410,8 +410,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -480,7 +480,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=170 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=171 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:36:10 2019
+-- Created on Tue Dec 17 11:38:21 2019
 -- 
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:36:15 2019
+-- Created on Tue Dec 17 11:38:30 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -476,8 +476,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -168,3 +168,4 @@
 248	\N	patch	patch_98_99_a.sql|schema_version
 249	\N	patch	patch_99_100_a.sql|schema_version
 250	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+251	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -420,8 +420,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=251 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=252 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 -- 
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Nov  6 10:36:20 2019
+-- Created on Tue Dec 17 11:38:37 2019
 -- 
 
 BEGIN TRANSACTION;
@@ -465,8 +465,8 @@ CREATE TABLE "mapping_session" (
   "new_db_name" varchar(80) NOT NULL DEFAULT '',
   "old_release" varchar(5) NOT NULL DEFAULT '',
   "new_release" varchar(5) NOT NULL DEFAULT '',
-  "old_assembly" varchar(20) NOT NULL DEFAULT '',
-  "new_assembly" varchar(20) NOT NULL DEFAULT '',
+  "old_assembly" varchar(80) NOT NULL DEFAULT '',
+  "new_assembly" varchar(80) NOT NULL DEFAULT '',
   "created" datetime
 );
 

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -188,3 +188,4 @@
 230	\N	patch	patch_98_99_a.sql|schema_version
 231	\N	patch	patch_99_100_a.sql|schema_version
 232	\N	patch	patch_99_100_b.sql|alter_externaldb_type_notnull
+233	\N	patch	patch_99_100_c.sql|alter_mapping_session_assembly_length

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -410,8 +410,8 @@ CREATE TABLE `mapping_session` (
   `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
   `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
@@ -480,7 +480,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=233 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=234 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/sql/patch_99_100_c.sql
+++ b/sql/patch_99_100_c.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_99_100_c.sql
+#
+# Title: Update mapping_session.old_assembly and mapping_session.new_assembly columns to VARCHAR(80).
+#
+# Description:
+#   Title: Update mapping_session.old_assembly and mapping_session.new_assembly columns to VARCHAR(80).
+
+ALTER TABLE mapping_session MODIFY COLUMN old_assembly VARCHAR(80) NOT NULL DEFAULT '';
+ALTER TABLE mapping_session MODIFY COLUMN new_assembly VARCHAR(80) NOT NULL DEFAULT '';
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_99_100_c.sql|alter_mapping_session_assembly_length');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -319,6 +319,9 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_99_100_b.sql|alter_externaldb_type_notnull');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_99_100_c.sql|alter_mapping_session_assembly_length');
+
 /**
 @table meta_coord
 @colour #C70C09

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1915,8 +1915,8 @@ CREATE TABLE mapping_session (
   new_db_name                 VARCHAR(80) NOT NULL DEFAULT '',
   old_release                 VARCHAR(5) NOT NULL DEFAULT '',
   new_release                 VARCHAR(5) NOT NULL DEFAULT '',
-  old_assembly                VARCHAR(20) NOT NULL DEFAULT '',
-  new_assembly                VARCHAR(20) NOT NULL DEFAULT '',
+  old_assembly                VARCHAR(80) NOT NULL DEFAULT '',
+  new_assembly                VARCHAR(80) NOT NULL DEFAULT '',
   created                     DATETIME NOT NULL,
 
   PRIMARY KEY (mapping_session_id)


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Increased length of old_assembly and new_assembly columns in the mapping_session table in the core databases.
## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Xenopus tropicalis assembly name would appear truncated as "Xenopus_tropicalis_v" in the current database schema for e100.
## Benefits

_If applicable, describe the advantages the changes will have._
Longer assembly names would be supported.
## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
More space would be required.
## Testing

_Have you added/modified unit tests to test the changes?_
No. I think the existing unit tests should work.
_If so, do the tests pass/fail?_
N/A.
_Have you run the entire test suite and no regression was detected?_
No.
