### PR TITLE
[annual copyright updater]. Bugfix: do not touch symbolic links

### DIFF
--- a/misc-scripts/annual_copyright_updater.sh
+++ b/misc-scripts/annual_copyright_updater.sh
@@ -39,7 +39,7 @@ for var in $dirs; do
 
   echo "About to scan $(pwd) for files to replace '$search' with '$replacement'"
 
-  for file in $(grep -R --files-with-matches "$search" --exclude-dir=.git .); do
+  for file in $(grep -r --files-with-matches "$search" --exclude-dir=.git .); do
     echo "Replacing date in $file"
     if [ "$(uname)" = "Darwin" ]; then
       LC_CTYPE=C LANG=C sed -i '' -e "s/$search/$replacement/g" $file


### PR DESCRIPTION
## Use case

The previous version of the script processes all symbolic links (`-R` option of _grep_) but _sed_ then turns the links into real files.

## Description

Use the `-r` option to **not** follow symbolic links.

## Benefits

The script won't break symbolic links.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

No