### PR TITLE
RFAMParser: relax selection criteria on analysis.logic_name

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
@@ -105,7 +105,7 @@ sub run_script {
       $dba = $registry->get_DBAdaptor($species_name, 'core');
   }
 
-  my $rfam_sql = "select distinct t.stable_id, hit_name from analysis a join transcript t on (a.analysis_id = t.analysis_id and a.logic_name = 'ncRNA' and t.biotype != 'miRNA') join exon_transcript et on (t.transcript_id = et.transcript_id) join supporting_feature sf on (et.exon_id = sf.exon_id and sf.feature_type = 'dna_align_feature' ) join dna_align_feature df on (sf.feature_id = df.dna_align_feature_id) order by hit_name";
+  my $rfam_sql = "select distinct t.stable_id, hit_name from analysis a join transcript t on (a.analysis_id = t.analysis_id and a.logic_name like 'ncrna%' and t.biotype != 'miRNA') join exon_transcript et on (t.transcript_id = et.transcript_id) join supporting_feature sf on (et.exon_id = sf.exon_id and sf.feature_type = 'dna_align_feature' ) join dna_align_feature df on (sf.feature_id = df.dna_align_feature_id) order by hit_name";
 
   my $sth = $dba->dbc->prepare($rfam_sql);
   $sth->execute();


### PR DESCRIPTION
## Description

Update analysis.logic_name selection criteria in RFAMParser to account for ncRNA-related changes made during release 98.

Issue: ENSINT-402

## Use case

Due to changes in the structure of the production database, since release 98 the value of analysis.logic_name corresponding to non-coding RNA can be either 'ncrna' (which is what we used before) or 'ncrna_species_name'. Change the SQL query used to map RFAM IDs to Ensembl stable IDs so that it can correctly handle species using the latter syntax, i.e. human, mouse and zebrafish.

## Benefits

Will be able to load RFAM xrefs for human, mouse and zebrafish again.

## Possible Drawbacks

None I can think of, we should probably rebase _feature/xref_sprint_ against _master_ before merging it in anyway.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, there are no unit tests for RFAMParser. I have, however, tested the updated SQL query against homo_sapiens_core_97_38, homo_sapiens_core_98_38 and homo_sapiens_core_99_38 (the first two on the public MySQL server, the last one on staging); returns a non-empty set on all three.