### PR TITLE
patch for BaseParser.pm

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -605,7 +605,7 @@ sub upload_xref_object_graphs {
          $self->add_dependent_xref_maponly( $dep_xref_id,
                                             $dep{LINKAGE_SOURCE_ID},
                                             $xref_id,
-                                            $dep{LINKAGE_ANNOTATION} // $dep{SOURCE_ID} );
+                                            $dep{LINKAGE_ANNOTATION});
 
          #########################################################
          # if there are synonyms, add entries in the synonym table
@@ -1190,7 +1190,7 @@ IXR
   # Croak if we have failed to create/get the xref
   ################################################
   $dependent_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
-  if ( !(defined $dependent_id) ) {
+  if ( !$dependent_id ) {
     croak("$acc\t$label\t\t$source_id\t$species_id\n");
   }
 


### PR DESCRIPTION

## Description

Following the discussion in ENSCORESW-3380, this patches a likely candidate for an issue on BaseParser.pm.
A full scale pipeline test run named xref_testing_99_104_sprint has been set up running on this patched branch.

## Use case

See ENSCORESW-3380

## Benefits

Fix unlinked_entries issues in feature/xref_sprint.

## Possible Drawbacks

none

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
