### PR TITLE
Enable VGNC xrefs for 15 more species

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -547,6 +547,15 @@ priority        = 1
 parser          = VGNCParser
 data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
 
+[source VGNC::sus_scrofa]
+# Used by sus_scrofa
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
 [source HGNC::homo_sapiens#01]
 # Used by homo_sapiens
 name            = HGNC
@@ -1955,6 +1964,10 @@ source          = VGNC::microcebus_murinus
 [species papio_anubis]
 taxonomy_id     = 9555
 source          = VGNC::papio_anubis
+
+[species sus_scrofa]
+taxonomy_id     = 9823
+source          = VGNC::sus_scrofa
 
 [species ciona_intestinalis]
 taxonomy_id     = 7719

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -664,6 +664,24 @@ priority        = 1
 parser          = VGNCParser
 data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
 
+[source VGNC::cebus_capucinus]
+# Used by cebus_capucinus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::saimiri_boliviensis_boliviensis]
+# Used by saimiri_boliviensis_boliviensis
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
 [source HGNC::homo_sapiens#01]
 # Used by homo_sapiens
 name            = HGNC
@@ -2124,6 +2142,14 @@ source          = VGNC::propithecus_coquereli
 [species rhinopithecus_bieti]
 taxonomy_id     = 61621
 source          = VGNC::rhinopithecus_bieti
+
+[species cebus_capucinus]
+taxonomy_id     = 1737458
+source          = VGNC::cebus_capucinus
+
+[species saimiri_boliviensis_boliviensis]
+taxonomy_id     = 39432
+source          = VGNC::saimiri_boliviensis_boliviensis
 
 [species ciona_intestinalis]
 taxonomy_id     = 7719

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -556,6 +556,114 @@ priority        = 1
 parser          = VGNCParser
 data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
 
+[source VGNC::aotus_nancymaae]
+# Used by aotus_nancymaae
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::carlito_syrichta]
+# Used by carlito_syrichta
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::cercocebus_atys]
+# Used by cercocebus_atys
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::chlorocebus_sabaeus]
+# Used by chlorocebus_sabaeus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::macaca_fascicularis]
+# Used by macaca_fascicularis
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::macaca_nemestrina]
+# Used by macaca_nemestrina
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::mandrillus_leucophaeus]
+# Used by mandrillus_leucophaeus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::nomascus_leucogenys]
+# Used by nomascus_leucogenys
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::otolemur_garnettii]
+# Used by otolemur_garnettii
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::pan_paniscus]
+# Used by pan_paniscus
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::propithecus_coquereli]
+# Used by propithecus_coquereli
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
+[source VGNC::rhinopithecus_bieti]
+# Used by rhinopithecus_bieti
+name            = VGNC
+download        = Y
+order           = 29
+priority        = 1
+parser          = VGNCParser
+data_uri        = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+
 [source HGNC::homo_sapiens#01]
 # Used by homo_sapiens
 name            = HGNC
@@ -1968,6 +2076,54 @@ source          = VGNC::papio_anubis
 [species sus_scrofa]
 taxonomy_id     = 9823
 source          = VGNC::sus_scrofa
+
+[species aotus_nancymaae]
+taxonomy_id     = 37293
+source          = VGNC::aotus_nancymaae
+
+[species carlito_syrichta]
+taxonomy_id     = 1868482
+source          = VGNC::carlito_syrichta
+
+[species cercocebus_atys]
+taxonomy_id     = 9531
+source          = VGNC::cercocebus_atys
+
+[species chlorocebus_sabaeus]
+taxonomy_id     = 60711
+source          = VGNC::chlorocebus_sabaeus
+
+[species macaca_fascicularis]
+taxonomy_id     = 9541
+source          = VGNC::macaca_fascicularis
+
+[species macaca_nemestrina]
+taxonomy_id     = 9545
+source          = VGNC::macaca_nemestrina
+
+[species mandrillus_leucophaeus]
+taxonomy_id     = 9568
+source          = VGNC::mandrillus_leucophaeus
+
+[species nomascus_leucogenys]
+taxonomy_id     = 61853
+source          = VGNC::nomascus_leucogenys
+
+[species otolemur_garnettii]
+taxonomy_id     = 30611
+source          = VGNC::otolemur_garnettii
+
+[species pan_paniscus]
+taxonomy_id     = 9597
+source          = VGNC::pan_paniscus
+
+[species propithecus_coquereli]
+taxonomy_id     = 379532
+source          = VGNC::propithecus_coquereli
+
+[species rhinopithecus_bieti]
+taxonomy_id     = 61621
+source          = VGNC::rhinopithecus_bieti
 
 [species ciona_intestinalis]
 taxonomy_id     = 7719


### PR DESCRIPTION
## Description

xref_config.ini: enable VGNC xrefs for pig (full gene set) and 14 more new species (cytochrome P450 only)

## Use case

As requested by VGNC.

## Benefits

More species with VGNC xrefs.

## Possible Drawbacks

Increased run time of the xref pipeline. Species from commit 3eb69e9 may or may not prove problematic.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

No, there aren't any xref-pipeline tests in the test suite.