### PR TITLE
Update of gene and transcript includes version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ensembl Core API
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=master)][travis]
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=master)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=release/99)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=release/99)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl

--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -1595,7 +1595,8 @@ sub update {
               display_xref_id = ?,
               description = ?,
               is_current = ?,
-              canonical_transcript_id = ?
+              canonical_transcript_id = ?,
+              version = ?
         WHERE gene_id = ?
   );
 
@@ -1621,8 +1622,8 @@ sub update {
   } else {
     $sth->bind_param(6, 0, SQL_INTEGER);
   }
-
-  $sth->bind_param(7, $gene->dbID(), SQL_INTEGER);
+  $sth->bind_param(7, $gene->version(), SQL_TINYINT);
+  $sth->bind_param(8, $gene->dbID(), SQL_INTEGER);
 
   $sth->execute();
 

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
@@ -1696,7 +1696,7 @@ sub update {
   }
 
   my $update_transcript_sql = 
-    sprintf "UPDATE transcript SET analysis_id = ?, display_xref_id = ?, description = ?,%s biotype = ?, is_current = ?, canonical_translation_id = ? WHERE transcript_id = ?", ($self->schema_version > 74)?" source = ?,":'';
+    sprintf "UPDATE transcript SET analysis_id = ?, display_xref_id = ?, description = ?,%s biotype = ?, is_current = ?, canonical_translation_id = ?, version = ? WHERE transcript_id = ?", ($self->schema_version > 74)?" source = ?,":'';
 
   my $display_xref = $transcript->display_xref();
   my $display_xref_id;
@@ -1723,6 +1723,7 @@ sub update {
                       ? $transcript->translation()->dbID()
                       : undef ),
                     SQL_INTEGER );
+  $sth->bind_param( ++$i, $transcript->version(), SQL_INTEGER );
   $sth->bind_param( ++$i, $transcript->dbID(), SQL_INTEGER );
 
   $sth->execute();


### PR DESCRIPTION
## Requirements

## Description

On gene and transcript update, update version as well;

## Use case

When other teams runs gene/transcript updates, they have a problem to separately update version with direct sql request, so we just include version update in common update.

## Benefits

Less code in pipeline, remove from pipelines authors responsibility to update a version separately from common update

## Possible Drawbacks

Version will be updated in all cases

## Testing

no new tests needed, data health checks will cover tesdcases

