### PR TITLE
Update of gene and transcript includes version update

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -1595,7 +1595,8 @@ sub update {
               display_xref_id = ?,
               description = ?,
               is_current = ?,
-              canonical_transcript_id = ?
+              canonical_transcript_id = ?,
+              version = ?
         WHERE gene_id = ?
   );
 
@@ -1621,8 +1622,8 @@ sub update {
   } else {
     $sth->bind_param(6, 0, SQL_INTEGER);
   }
-
-  $sth->bind_param(7, $gene->dbID(), SQL_INTEGER);
+  $sth->bind_param(7, $gene->version(), SQL_TINYINT);
+  $sth->bind_param(8, $gene->dbID(), SQL_INTEGER);
 
   $sth->execute();
 

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
@@ -1696,7 +1696,7 @@ sub update {
   }
 
   my $update_transcript_sql = 
-    sprintf "UPDATE transcript SET analysis_id = ?, display_xref_id = ?, description = ?,%s biotype = ?, is_current = ?, canonical_translation_id = ? WHERE transcript_id = ?", ($self->schema_version > 74)?" source = ?,":'';
+    sprintf "UPDATE transcript SET analysis_id = ?, display_xref_id = ?, description = ?,%s biotype = ?, is_current = ?, canonical_translation_id = ?, version = ? WHERE transcript_id = ?", ($self->schema_version > 74)?" source = ?,":'';
 
   my $display_xref = $transcript->display_xref();
   my $display_xref_id;
@@ -1723,6 +1723,7 @@ sub update {
                       ? $transcript->translation()->dbID()
                       : undef ),
                     SQL_INTEGER );
+  $sth->bind_param( ++$i, $transcript->version(), SQL_INTEGER );
   $sth->bind_param( ++$i, $transcript->dbID(), SQL_INTEGER );
 
   $sth->execute();

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -470,7 +470,7 @@ ok($newgene->description eq 'dummy');
 ok($newgene->is_current == 0);
 ok($newgene->canonical_transcript_id == 2018226);
 ok($newgene->version == 5);
-ok($newgene->analysis_id == 8355');
+ok($newgene->analysis_id == 8355);
 
 
 $multi->restore('core', 'gene');

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -455,11 +455,23 @@ my $dbEntryAdaptor = $db->get_DBEntryAdaptor();
 
 $gene->display_xref($dbEntryAdaptor->fetch_by_dbID(614));
 $gene->biotype('dummy');
+$gene->description('dummy'); 
+$gene->is_current(0); 
+$gene->canonical_transcript_id(2018226); 
+$gene->version(5); 
+$gene->analysis_id(8355);
+
 $ga->update($gene);
 
 $newgene = $ga->fetch_by_stable_id("ENSG00000171456");
 ok($newgene->display_xref->dbID() == 614);
 ok($newgene->biotype eq 'dummy');
+ok($newgene->description eq 'dummy');
+ok($newgene->is_current == 0);
+ok($newgene->canonical_transcript_id == 2018226);
+ok($newgene->version == 5);
+ok($newgene->analysis_id == 8355');
+
 
 $multi->restore('core', 'gene');
 

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -240,10 +240,25 @@ is( $up_tr->display_xref->dbID(), 97759, 'Fetched the correct dbID' );
 my $dbentryAdaptor = $db->get_DBEntryAdaptor();
 
 $tr->display_xref($dbentryAdaptor->fetch_by_dbID( 614 ));
+$tr->biotype('dummy');
+$tr->description('dummy'); 
+$tr->is_current(0); 
+$tr->canonical_translation_id(2018226); 
+$tr->version(5); 
+$tr->analysis_id(8355);
+
 $ta->update($tr);
+
 
 $up_tr = $ta->fetch_by_stable_id( "ENST00000217347" );
 is ( $up_tr->display_xref->dbID(), 614, 'Fetched the correct display xref id');
+ok($up_tr->biotype eq 'dummy');
+ok($up_tr->description eq 'dummy');
+ok($up_tr->is_current == 0);
+ok($up_tr->canonical_translation_id == 2018226);
+ok($up_tr->version == 5);
+ok($up_tr->analysis_id == 8355);
+
 
 $multi->restore('core', 'transcript', 'meta_coord');
 


### PR DESCRIPTION
Description

On gene and transcript update, update version as well;

Use case

When other teams runs gene/transcript updates, they have a problem to separately update version with direct sql request, so we just include version update in common update.

Benefits

Less code in pipeline, remove from pipelines authors responsibility to update a version separately from common update

Possible Drawbacks

Version will be updated in all cases

Testing

existing tests covers proposed code, data health checks will cover the rest of the testcases