### PR TITLE
bug-fix as per description in ENSCORESW-3452. change in data_uri for …

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -775,7 +775,7 @@ order           = 60
 priority        = 1
 parser          = Mim2GeneParser
 dependent_on    = MIM,EntrezGene
-data_uri        = ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen
+data_uri        = https://omim.org/static/omim/data/mim2gene.txt
 
 [source MGI::mus_musculus#01]
 # Used by mus_musculus


### PR DESCRIPTION
…MIM2Gene.

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Change in data_uri for MIM2Gene xref

## Use case

Fix as per description in ENSCORESW-3452. Same change to be made in production repo for xref_config.json

## Benefits

Correct source for the parser.

## Possible Drawbacks

NA

## Testing

NA

_If so, do the tests pass/fail?_

NA

