### PR TITLE
ENSCORESW-3458: parse and store UniProt accession version

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -213,6 +213,9 @@ sub create_xrefs {
 
     my ($label, $sp_type) = $_ =~ /ID\s+(\w+)\s+(\w+)/;
     my ($protein_evidence_code) = $_ =~ /PE\s+(\d+)/; 
+    # Capture line with entry version
+    # Example: DT   22-APR-2020, entry version 1.
+    my ($version) = $_ =~ /DT\s+\d+-\w+-\d+, entry version (\d+)/;
 
     # SwissProt/SPTrEMBL are differentiated by having STANDARD/PRELIMINARY here
     if ($sp_type =~ /^Reviewed/i) {
@@ -240,7 +243,8 @@ sub create_xrefs {
 
     # some straightforward fields
     # the previous $label flag of type BRCA2_HUMAN is not used in Uniprot any more, use accession instead
-    $xref->{LABEL} = $accessions[0];
+    $xref->{LABEL} = $accessions[0] ."." . $version;
+    $xref->{VERSION} = $version;
     $xref->{SPECIES_ID} = $species_id;
     $xref->{SEQUENCE_TYPE} = 'peptide';
     $xref->{STATUS} = 'experimental';


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The proposed change captures the version of the UniProt accession processed when parsing the input file and stores it in the intermediate xref database

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
In the Ensembl browser, the xrefs are linked to the external resource they were extracted from.
Due to different release cycles, the data we processed for a release can be out of sync with the external data when it is published. Providing the version of the data processed means we can more easily identify where discrepancies come from mismatched versions

## Benefits

_If applicable, describe the advantages the changes will have._
Better reproducibility of the xref mapping and identification of mismatches
More accurate information provided on the browser

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
Highlights discrepancies between data sources due to different release cycles

## Testing

_Have you added/modified unit tests to test the changes?_
No test cases exist for the UniProtParser
The modified code was used on a full run of the xref pipeline and the results visualised in a browser sandbox

_If so, do the tests pass/fail?_
On the sandbox, links to UniProt in the General Identifiers and External References (eg http://www.ensembl.org/Homo_sapiens/Gene/Matches?db=core;g=ENSG00000224383;r=17:63992802-64038237;t=ENST00000425164) contain a versioned UniProt accession

_Have you run the entire test suite and no regression was detected?_
NA
