### PR TITLE
Bugfix/mim2gene

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -34,8 +34,6 @@ use parent qw( XrefParser::BaseParser );
 
 my $EXPECTED_NUMBER_OF_COLUMNS = 6;
 
-
-
 =head2 run
 
   Arg [1]    : HashRef standard list of arguments from ParseSource
@@ -58,18 +56,10 @@ my $EXPECTED_NUMBER_OF_COLUMNS = 6;
                 - EntrezGeneParser - otherwise there will be no
                   dependent-xref links.
 
-               mim2gene.txt begins with several lines of comments
-               which start with a hash; the last of these comment
-               lines contains a tab-separated list of column names.
-
-               The rest of the file are the following columns:
-                1) OMIM number
-                2) OMIM entry type
-                3) EntrezGene ID
-                4) HGNC gene symbol
-                5) Ensembl gene ID
-               The former two are mandatory, the latter can be empty
-               strings.
+               mim2gene_medgen file begins with a header line with
+               6 tab separated columns:
+               #MIM number	GeneID	type	Source	MedGenCUI	Comment
+               MIM number and GeneID are considered for the xrefs.               
 
   Return type: none
   Exceptions : throws on all processing errors
@@ -130,7 +120,6 @@ sub run {
   my %counters = (
                   'all_entries'                          => 0,
                   'dependent_on_entrez'                  => 0,
-                  'direct_ensembl'                       => 0,
                   'missed_master'                        => 0,
                   'missed_omim'                          => 0,
                 );
@@ -189,11 +178,12 @@ sub run {
     # bother we do not have an xref this entry would operate on anyway
     # - which is why we only check this after the preceding two
     # presence checks.
+    
     if ( ( $type ne 'gene')
          && ( $type ne 'gene/phenotype' )
          && ( $type ne 'predominantly phenotypes' )
          && ( $type ne 'phenotype' ) ) {
-      confess "Unknown type $type for MIM Number '${omim_acc}' "
+      warn "Unknown type $type for MIM Number '${omim_acc}' "
         . "(${filename}:" . $csv->record_number() . ")";
     }
 
@@ -229,7 +219,6 @@ sub run {
   if ( $verbose ) {
     print 'Processed ' . $counters{'all_entries'} . " entries. Out of those\n"
       . "\t" . $counters{'missed_omim'} . " had missing OMIM entries,\n"
-      . "\t" . $counters{'direct_ensembl'} . " were direct gene xrefs,\n"
       . "\t" . $counters{'dependent_on_entrez'} . " were dependent EntrezGene xrefs,\n"
       . "\t" . $counters{'missed_master'} . " had missing master entries.\n";
   }

--- a/misc-scripts/xref_mapping/t/mim2gene.t
+++ b/misc-scripts/xref_mapping/t/mim2gene.t
@@ -41,12 +41,7 @@ my $SOURCE_ID_OMIM_GENE   = 61;
 my $SOURCE_ID_OMIM_MORBID = 62;
 my $SPECIES_ID_HUMAN      = 9606;
 
-# Increase this by 1 if/when BaseAdaptor::get_valid_codes() has begun to
-# consider synonyms
-# my $NUMBER_OF_DIRECT_LINKS         = 4;
-# Increase this by 1 once the parser has been updated to insert
-# dependent links for entries which get direct ones as well, and by
-# another 1 if/when has begun to consider synonyms
+# Increase this by 1 once the parser has been updated to consider synonyms
 my $NUMBER_OF_DEPENDENT_LINKS      = 3;
 # Decrease this by 1 if/when BaseAdaptor::get_valid_codes() has begun to
 # consider synonyms
@@ -58,17 +53,6 @@ my $db = Xref::Test::TestDB->new();
 # should *not* add corresponding source entries at this point yet, as
 # there is a test below which checks what happens if the parser cannot
 # retrieve appropriate source IDs.
-
-
-# 100050	-	phenotype	-	C3149220	-
-# 100070	-	phenotype	-	C1853365	-
-# 100100	1131	phenotype	 GeneMap	C0033770	question
-# 100200	-	phenotype	-	C4551519	-
-# 100300	57514	phenotype	 GeneMap	C4551482	-
-# 100600	-	phenotype	-	C0000889	-
-# 100640	216	gene	-	-	-
-# 100650	217	gene	-	-	-
-# 100660	218	gene	-	-	-
 
 $db->schema->populate( 'Xref', [
   [ qw{ xref_id accession source_id species_id info_type } ],
@@ -242,46 +226,6 @@ subtest 'Successful inserts' => sub {
 
 };
 
-# subtest 'Direct-xrefs links' => sub {
-#   my $rs;
-#   my $matching_xref;
-#   my $matching_link;
-
-#   is( $db->schema->resultset('GeneDirectXref')->count,
-#       $NUMBER_OF_DIRECT_LINKS,
-#       'Expected number of direct-xref links' );
-
-#   $rs = $db->schema->resultset('Xref')->search({
-#     accession => '987654',
-#     source_id => $SOURCE_ID_OMIM_GENE,
-#   });
-#   $matching_xref = $rs->next;
-#   is( $matching_xref->info_type, 'DIRECT',
-#       'info_type of directly linked xref updated correctly' );
-
-#   # Now let's have a closer look at the link
-#   $rs = $db->schema->resultset('GeneDirectXref')->search({
-#     general_xref_id => $matching_xref->xref_id,
-#   });
-#   $matching_link = $rs->next;
-#   isnt( $matching_link, undef,
-#         'Directly linked xref has a direct-xref link' );
-#   is( $matching_link->ensembl_stable_id, 'ENSG00000000002',
-#       'Link points to expected Ensembl gene stable ID' );
-#   is( $matching_link->linkage_xref, undef,
-#       "Link's linkage_xref is left undefined" );
-
-#   # This may or may not change in the future
-#   $rs = $db->schema->resultset('Synonym')->search({
-#     synonym => '313370',
-#   });
-#   $matching_xref = $rs->next;
-#   is( $rs = $db->schema->resultset('GeneDirectXref')->count({
-#         general_xref_id => $matching_xref->xref_id,
-#       }), 0, 'No direct-xref link assigned to a synonym' );
-
-# };
-
 subtest 'Dependent-xref links' => sub {
   my $rs;
   my $matching_xref;
@@ -357,10 +301,6 @@ subtest 'Replay safety' => sub {
     species_id => $SPECIES_ID_HUMAN,
     files      => [ "$Bin/test-data/mim2gene-mini.txt" ],
   }); }, 'Re-parsed Mim2Gene map without errors' );
-
-  # is( $db->schema->resultset('GeneDirectXref')->count,
-  #     $NUMBER_OF_DIRECT_LINKS,
-  #     'No new direct-xref links inserted by the replay' );
 
   is( $db->schema->resultset('DependentXref')->count,
       $NUMBER_OF_DEPENDENT_LINKS,

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooFewCols.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooFewCols.txt
@@ -1,2 +1,3 @@
-# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
-142830	gene	ENSG00000234745
+#MIM number	GeneID	type	Source	MedGenCUI	Comment
+100050	-	phenotype	-	C3149220	-
+100070	-	-	C1853365	-

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooManyCols.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badData-tooManyCols.txt
@@ -1,2 +1,2 @@
-# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
-142830	gene/phenotype	3106	HLA-B	ENSG00000234745	fnord
+#MIM number	GeneID	type	Source	MedGenCUI	Comment
+100050	-	phenotype	-	C3149220	-	ExtraCol

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName1.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName1.txt
@@ -1,2 +1,2 @@
-# The Ultimate Answer	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
-100640	gene	216	ALDH1A1	ENSG00000165092
+#MIMO	GeneID	type	Source	MedGenCUI	Comment
+100050	-	phenotype	-	C3149220	-

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName2.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName2.txt
@@ -1,2 +1,2 @@
-# MIM Number	Exit Strategy	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
-100640	gene	216	ALDH1A1	ENSG00000165092
+#MIM number	Gene	type	Source	MedGenCUI	Comment
+100050	-	phenotype	-	C3149220	-

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName4.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName4.txt
@@ -1,4 +1,4 @@
-#MIM number	GeneID	typo	Source	MedGenCUI	Comment
+#MIM number	GeneID	type	eSourc	MedGenCUI	Comment
 100050	-	phenotype	-	C3149220	-
 100070	-	phenotype	-	C1853365	-
 100100	1131	phenotype	 GeneMap	C0033770	question

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName5.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName5.txt
@@ -1,2 +1,3 @@
-# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Stuff and things
-100640	gene	216	ALDH1A1	ENSG00000165092
+#MIM number	GeneID	type	Source	MedGenGUI	Comment
+100050	-	phenotype	-	C3149220	-
+100660	218	gene	-	-	-

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName6.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-badHeader-wrongName6.txt
@@ -1,0 +1,2 @@
+#MIM number	GeneID	type	Source	MedGenCUI	FooBar
+100050	-	phenotype	-	C3149220	-

--- a/misc-scripts/xref_mapping/t/test-data/mim2gene-mini.txt
+++ b/misc-scripts/xref_mapping/t/test-data/mim2gene-mini.txt
@@ -1,12 +1,10 @@
-# Copyright (c) 1966-2018 Johns Hopkins University. Use of this file adheres to the terms specified at https://omim.org/help/agreement.
-# Generated: 2018-10-18
-# This file provides links between the genes in OMIM and other gene identifiers.
-# THIS IS NOT A TABLE OF GENE-PHENOTYPE RELATIONSHIPS.
-# MIM Number	MIM Entry Type (see FAQ 1.3 at https://omim.org/help/faq)	Entrez Gene ID (NCBI)	Approved Gene Symbol (HGNC)	Ensembl Gene ID (Ensembl)
-100050	predominantly phenotypes			
-100640	gene	216	ALDH1A1	ENSG00000165092
-100680	moved/removed			
-142830	gene/phenotype	3106	HLA-B	ENSG00000234745
-313370	gene			ENSG00000000001
-617386	predominantly phenotypes	643609	NR1H5P	
-987654	gene			ENSG00000000002
+#MIM number	GeneID	type	Source	MedGenCUI	Comment
+100050	-	phenotype	-	C3149220	-
+100070	-	phenotype	-	C1853365	-
+100100	1131	phenotype	 GeneMap	C0033770	question
+100200	-	phenotype	-	C4551519	-
+100300	57514	phenotype	 GeneMap	C4551482	-
+100600	-	phenotype	-	C0000889	-
+100640	216	gene	-	-	-
+100650	217	gene	-	-	-
+100660	218	gene	-	-	-


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Refer https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3457

## Use case

The xref mappings decreased because of use of a different MIM file. Reverting to the file and parser to earlier version.

## Benefits

Increase in mapping to more mim_morbid data.

## Possible Drawbacks

NA

## Testing

mim2gene.t modified to remove direct links test cases.

_If so, do the tests pass/fail?_

Tests have passed

