### PR TITLE
sars_cov_2 specific xref configuration

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/sars_cov_2.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/sars_cov_2.pm
@@ -57,6 +57,7 @@ sub transcript_names_from_gene {
   $ox_id_sth->bind_columns(\$ox_id);
   $ox_id_sth->fetch();
 
+  $del_xref_sth->execute();
   while ($get_genes->fetch()) {
     $get_source_id->execute($external_db . "_trans_name");
     $get_source_id->bind_columns(\$external_db_id);
@@ -73,6 +74,10 @@ sub transcript_names_from_gene {
     }
   }
 
+  $del_ox_sth->execute();
+  $del_ox_sth->finish();
+
+  $del_xref_sth->finish();
   $xref_id_sth->finish();
   $ox_id_sth->finish();
   $get_genes->finish();

--- a/misc-scripts/xref_mapping/XrefMapper/sars_cov_2.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/sars_cov_2.pm
@@ -1,0 +1,86 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package XrefMapper::sars_cov_2;
+
+use  XrefMapper::BasicMapper;
+
+use vars '@ISA';
+
+@ISA = qw{ XrefMapper::BasicMapper };
+use strict;
+
+
+sub transcript_names_from_gene {
+  my $self = shift;
+  my $core_dbi = $self->core->dbc;
+
+  my $reset_sth = $core_dbi->prepare("UPDATE transcript SET display_xref_id = null");
+  $reset_sth->execute();
+  $reset_sth->finish;
+
+  my $del_xref_sth = $core_dbi->prepare("DELETE x FROM xref x, object_xref ox, external_db e WHERE x.xref_id = ox.xref_id AND ensembl_object_type = 'Transcript' AND e.external_db_id = x.external_db_id AND e.db_name like '%_trans_name'");
+  my $del_ox_sth = $core_dbi->prepare("DELETE ox FROM object_xref ox LEFT JOIN xref x ON x.xref_id = ox.xref_id WHERE isnull(x.xref_id)");
+
+  my $xref_id_sth = $core_dbi->prepare("SELECT max(xref_id) FROM xref");
+  my $ox_id_sth = $core_dbi->prepare("SELECT max(object_xref_id) FROM object_xref");
+  my $ins_xref_sth = $core_dbi->prepare("INSERT IGNORE into xref (xref_id, external_db_id, dbprimary_acc, display_label, version, description, info_type, info_text) values(?, ?, ?, ?, 0, ?, 'MISC', ?)");
+  my $ins_ox_sth = $core_dbi->prepare("INSERT into object_xref (object_xref_id, ensembl_id, ensembl_object_type, xref_id) values(?, ?, 'Transcript', ?)");
+  my $update_tran_sth = $core_dbi->prepare("UPDATE transcript t SET t.display_xref_id= ? WHERE t.transcript_id=?");
+  my $get_genes = $core_dbi->prepare("SELECT g.gene_id, e.db_name, x.dbprimary_acc, x.display_label, x.description FROM gene g, xref x, external_db e where g.display_xref_id = x.xref_id and e.external_db_id = x.external_db_id");
+  my $get_transcripts = $core_dbi->prepare("SELECT transcript_id FROM transcript WHERE gene_id = ? ORDER BY seq_region_start, seq_region_end");
+  my $get_source_id = $core_dbi->prepare("SELECT external_db_id FROM external_db WHERE db_name like ?");
+
+  $get_genes->execute();
+  my ($gene_id, $external_db, $external_db_id, $acc, $label, $description, $transcript_id, $xref_id, $ox_id, $ext, $reuse_xref_id, $info_text);
+  $get_genes->bind_columns(\$gene_id, \$external_db, \$acc, \$label, \$description);
+  $xref_id_sth->execute();
+  $xref_id_sth->bind_columns(\$xref_id);
+  $xref_id_sth->fetch();
+  $ox_id_sth->execute();
+  $ox_id_sth->bind_columns(\$ox_id);
+  $ox_id_sth->fetch();
+
+  while ($get_genes->fetch()) {
+    $get_source_id->execute($external_db . "_trans_name");
+    $get_source_id->bind_columns(\$external_db_id);
+    $get_source_id->fetch();
+    $get_transcripts->execute($gene_id);
+    $get_transcripts->bind_columns(\$transcript_id);
+    while ($get_transcripts->fetch) {
+      $xref_id++;
+      $ox_id++;
+      $info_text = 'via gene ' . $acc;
+      $ins_xref_sth->execute($xref_id, $external_db_id, $label, $label, $description, $info_text);
+      $ins_ox_sth->execute($ox_id, $transcript_id, $xref_id);
+      $update_tran_sth->execute($xref_id, $transcript_id);
+    }
+  }
+
+  $xref_id_sth->finish();
+  $ox_id_sth->finish();
+  $get_genes->finish();
+  $get_source_id->finish();
+  $get_transcripts->finish();
+  $ins_xref_sth->finish();
+  $ins_ox_sth->finish();
+  $update_tran_sth->finish();
+}
+
+1;

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -1041,6 +1041,13 @@ priority        = 1
 prio_descr      = refseq
 parser          = RefSeqParser
 
+[source RefSeq_peptide::MULTI]
+name            = RefSeq_peptide
+download        = Y
+order           = 30
+priority        = 2
+parser          = RefSeqGPFFParser
+
 [source RefSeq_peptide::MULTI-fungi]
 # Used by saccharomyces_cerevisiae
 name            = RefSeq_peptide
@@ -1981,6 +1988,13 @@ data_uri        = ftp://ftp.geneontology.org/pub/go/gene-associations/gene_assoc
 # Additional configuration for species-specific sources                #
 #                                                                      #
 ########################################################################
+
+
+[species sars_cov_2]
+taxonomy_id     = 2697049
+source          = RefSeq_peptide::MULTI
+source          = EntrezGene::MULTI
+source          = Uniprot/SWISSPROT::MULTI
 
 [species vertebrates]
 taxonomy_id     = 7742


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
These configuration changes allow us to run the xref pipeline on the annotation for sars-cov-2

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
this is a virus genome with different data sources to the usual vertebrate species
the added configuration ensure we use the correct data for the virus annotation without affecting existing settings for vertebrate species

## Benefits

_If applicable, describe the advantages the changes will have._
no changes required to existing pipeline to run on new virus genome

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
a full run of the pipeline was done with the changes

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
the data was reviewed manually and released as part of the COVID-19 browser


