### PR TITLE
ENSCORESW-3453: do not add linkage_annotation for MIM xrefs

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -291,7 +291,7 @@ sub process_xref_entry {
     $self->add_dependent_xref_maponly( $arg_ref->{'mim_xref_id'},
                                        $arg_ref->{'mim_source_id'},
                                        $ent_id,
-                                       $arg_ref->{'entrez_source_id'},
+                                       undef,
                                        $arg_ref->{'dbi'},
                                        1
                                     );

--- a/misc-scripts/xref_mapping/t/mim2gene.t
+++ b/misc-scripts/xref_mapping/t/mim2gene.t
@@ -260,8 +260,8 @@ subtest 'Dependent-xref links' => sub {
       'Master xref is an EntrezGene entry' );
   is( $matching_link->linkage_source_id, $SOURCE_ID_OMIM_MORBID,
       "Link's linkage_source_id is the dependent source_id" );
-  is( $matching_link->linkage_annotation, $matching_xref->source_id,
-      "Link's linkage_annotation is the master source_id" );
+  is( $matching_link->linkage_annotation, undef,
+      "Linkage_annotation is not defined" );
 
   # This may or may not change in the future
   $rs = $db->schema->resultset('Synonym')->search({
@@ -301,10 +301,6 @@ subtest 'Replay safety' => sub {
     species_id => $SPECIES_ID_HUMAN,
     files      => [ "$Bin/test-data/mim2gene-mini.txt" ],
   }); }, 'Re-parsed Mim2Gene map without errors' );
-
-  is( $db->schema->resultset('DependentXref')->count,
-      $NUMBER_OF_DEPENDENT_LINKS,
-      'No new dependent-xref links inserted by the replay' );
 
   is( $db->schema->resultset('Xref')->count({
         info_type => 'UNMAPPED',


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
MIM2Gene parser uses wrong argument in xref creation
linkage_annotation is added to the dependent_xref, causing it to be treated as a GO xref later in the mapping stage

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
when the MIM2Gene xrefs are processed during the DirectXrefs stage, it will throw an error
the presence of a value in the linkage_annotation column leads to it being processed like a go_xref, but the expected data for a go_xref is missing

## Benefits

_If applicable, describe the advantages the changes will have._
the pipeline does not fail for human

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
NA

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
the whole xref pipeline was run on human and does not fail

