### PR TITLE
ENSCORESW-3476: import direct mappings to UniProt isoforms

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -1290,6 +1290,14 @@ order           = 20
 priority        = 1
 parser          = UniProtParser
 
+[source Uniprot_isoform]
+# Special source used in UniProtParser for protein isoforms
+name            = Uniprot_isoform
+download        = N
+order           = 30
+priority        = 1
+parser          = UniProtParser
+
 [source UniProt::protein_id]
 # Special source used in UniProtParser.  No species uses this source.
 name            = protein_id


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Add direct mappings to Uniprot isoforms, in addition to the existing mappings to the canonical accession

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
A single Uniprot accession can contain multiple sequences, mapping to different Ensembl transcripts
Adding the mappings to the specific isoform allows us to identify which of these sequences is an exact match to the equivalent Ensembl peptide

## Benefits

_If applicable, describe the advantages the changes will have._
More specific information available for users

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
The change was tested on human and it has successfully added additional xref mappings to this new sources without changing existing xrefs

