### PR TITLE
ENSCORESW-3503: keep analysis id when storing coordinate xrefs

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
@@ -622,7 +622,7 @@ sub run_coordinatemapping {
 
   # Make all dumps.  Order is important.
   dump_xref( $xref_filename, $xref_id, \%mapped, \%unmapped );
-  dump_object_xref( $object_xref_filename, $object_xref_id, \%mapped );
+  dump_object_xref( $object_xref_filename, $object_xref_id, $analysis_id, \%mapped );
   dump_unmapped_reason( $unmapped_reason_filename, $unmapped_reason_id,
                         \%unmapped, $core_dbh );
   dump_unmapped_object( $unmapped_object_filename, $unmapped_object_id,
@@ -693,7 +693,7 @@ sub dump_xref {
 #-----------------------------------------------------------------------
 
 sub dump_object_xref {
-  my ( $filename, $object_xref_id, $mapped ) = @_;
+  my ( $filename, $object_xref_id, $analysis_id, $mapped ) = @_;
 
   ######################################################################
   # Dump for 'object_xref'.                                            #
@@ -715,7 +715,7 @@ sub dump_object_xref {
                    $object_xref->{'ensembl_object_type'},
                    $xref->{'xref_id'},
                    '\N',
-                   '0' );
+                   $analysis_id );
     }
   }
   $fh->close();


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Entries in the object_xref table for coordinate xrefs are being stored with an analysis_id 0
The corresponding analysis is created but not used
The proposed change passes the analysis_id for the correct analysis as an argument, to be stored in the object_xref table

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
analysis_id 0 is not really good
No analysis_id would already be better, but as the analysis object already exist, might as well use it here

## Benefits

_If applicable, describe the advantages the changes will have._
No entry in object_xref with analysis_id 0

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
None that I can see

## Testing

_Have you added/modified unit tests to test the changes?_
NA

_If so, do the tests pass/fail?_
NA

_Have you run the entire test suite and no regression was detected?_
This part of the code has no test cases associated to it.
The whole xref pipeline was run before and after the change to verify the change works as expected
In particular, the datachecks run at the end of the pipeline were reporting those entries with analysis_id 0 and do not with the change

