### PR TITLE
ENSCORESW-3196: do not overwrite source_id

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/Methods/MySQLChecksum.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/MySQLChecksum.pm
@@ -40,7 +40,6 @@ sub perform_mapping {
   my @final_results;
   my $dbc;
   if (defined $db_url) {
-    $source_id = 1;
     my ($dbconn_part, $driver, $user, $pass, $host, $port, $dbname, $table_name, $tparam_name, $tparam_value, $conn_param_string) =
             $db_url =~ m{^((\w*)://(?:(\w+)(?:\:([^/\@]*))?\@)?(?:([\w\-\.]+)(?:\:(\d*))?)?/([\w\-\.]*))(?:/(\w+)(?:\?(\w+)=([\w\[\]\{\}]*))?)?((?:;(\w+)=(\w+))*)$};
     $dbc = Bio::EnsEMBL::DBSQL::DBConnection->new(


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
We have checksum entries for RNAcentral (transcript sequences) and UniParc (protein sequences)
Currently, we do not distinguish between the two sources and attempt to map checksums from both sources to all sequences available.
Recently, due to clash in checksums, we have started mapping some UniParc checksums to transcript sequences.
To avoid this, we want to store the checksums with the source they come from and use that information in the later mapping stage, to only attempt to map RNAcentral to transcript sequences, and UniParc to protein sequences

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
UPI0001765128 is a UniParc entry with checksum CFECF93F30021B262B430492E53B847C
The transcript sequence for ENST00000616594.2 has the same checksum and maps to UPI0001765128
With this change, UPI0001765128 is only compared to protein sequences and will not map to ENST00000616594.2


## Benefits

_If applicable, describe the advantages the changes will have._
No cross-source checksum mapping happening

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
The individual checksum mapping stages might be slower, as the SQL query restricts on individual source_id


## Testing

_Have you added/modified unit tests to test the changes?_
NA

_If so, do the tests pass/fail?_
NA

_Have you run the entire test suite and no regression was detected?_
There is no test case for this pipeline
The whole xref pipeline was run before and after the change.
In particular, the DataChecks run at the end were reporting the mismapped UPI0001765128 xref before the change, but not after
