### PR TITLE
Bugfix/null translation

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -590,6 +590,13 @@ sub remove {
   my $attrib_adp = $self->db->get_AttributeAdaptor;
   $attrib_adp->remove_from_Translation($translation);
 
+  #remove all transcripts links to translation
+  my $sth = $self->prepare
+    ("UPDATE transcript SET canonical_translation_id = NULL WHERE canonical_translation_id = ?");
+  $sth->bind_param(1,$translation->dbID,SQL_INTEGER);
+  $sth->execute();
+  $sth->finish();
+
   # remove all xref associations to this translation
   my $dbe_adaptor = $self->db()->get_DBEntryAdaptor();
   foreach my $dbe (@{$translation->get_all_DBEntries()}) {

--- a/modules/t/translation.t
+++ b/modules/t/translation.t
@@ -192,6 +192,9 @@ my $pfeat_minus = @{$translation->get_all_ProteinFeatures()};
 
 $ta->remove($translation);
 
+my $transcript_after_remove = $tra->fetch_by_translation_id($translation->dbID);
+
+ok(!$transcript_after_remove);
 ok(!defined($translation->dbID));
 ok(!defined($translation->adaptor()));
 


### PR DESCRIPTION
#478  Description

Bugfix, that makes canonical_translation_id NULL on translation delete

## Use case
When translation is removed, links to the translation still thers in transcript table

## Benefits

Data consistency for translation table

## Possible Drawbacks

Not found

## Testing

Unit tests are added for this case

_If so, do the tests pass/fail?_

All tests pass, with travis as well

