### PR TITLE
ENSCORESW-3526 changed provider.* metakey to assembly.provider_*

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
@@ -477,8 +477,8 @@ sub dump_embl {
   #Database References (we are not dumping these)
 
   #Get annotation source 
-  my ($provider_name)   = @{$meta_container->list_value_by_key('provider.name')};
-  my ($provider_url)    = @{$meta_container->list_value_by_key('provider.url')};
+  my ($provider_name)   = @{$meta_container->list_value_by_key('assembly.provider_name')};
+  my ($provider_url)    = @{$meta_container->list_value_by_key('assembly.provider_url')};
   my $annotation_source = q{};
    
   if($provider_name) {
@@ -669,8 +669,8 @@ sub dump_genbank {
   #refereneces
 
   #Get annotation source 
-  my ($provider_name)   = @{$meta_container->list_value_by_key('provider.name')};
-  my ($provider_url)    = @{$meta_container->list_value_by_key('provider.url')};
+  my ($provider_name)   = @{$meta_container->list_value_by_key('assembly.provider_name')};
+  my ($provider_url)    = @{$meta_container->list_value_by_key('assembly.provider_url')};
   my $annotation_source = q{};
   
   if($provider_name) {

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -57,8 +57,8 @@
 13	1	genebuild.start_date	2012-08-EnsemblBacteria
 12	1	genebuild.version	2012-08-EnsemblBacteria
 61	1	patch	patch_73_74_b.sql|remove_dnac
-42	1	provider.name	European Nucleotide Archive
-43	1	provider.url	http://www.ebi.ac.uk/ena/data/view/GCA_000292705
+42	1	assembly.provider_name	European Nucleotide Archive
+43	1	assembly.provider_url	http://www.ebi.ac.uk/ena/data/view/GCA_000292705
 18	1	repeat.analysis	Dust
 19	1	repeat.analysis	TRF
 48	1	sample.gene_param	BTF1_30792

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -68,8 +68,8 @@
 94	1	genebuild.initial_release_date	2013-12-MIPS
 95	1	genebuild.last_geneset_update	2013-12-MIPS
 96	1	genebuild.version	2.2
-97	1	provider.name	IWGSC
-98	1	provider.url	http://www.wheatgenome.org/
+97	1	assembly.provider_name	IWGSC
+98	1	assembly.provider_url	http://www.wheatgenome.org/
 188	1	transcriptbuild.level	toplevel
 100	1	genebuild.method	Imported from IWGSC
 101	1	sample.transcript_param	Traes_1BS_1172A6B03.1

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -57,8 +57,8 @@
 13	1	genebuild.start_date	2012-08-EnsemblBacteria
 12	1	genebuild.version	2012-08-EnsemblBacteria
 61	1	patch	patch_73_74_b.sql|remove_dnac
-42	1	provider.name	European Nucleotide Archive
-43	1	provider.url	http://www.ebi.ac.uk/ena/data/view/GCA_000292705
+42	1	assembly.provider_name	European Nucleotide Archive
+43	1	assembly.provider_url	http://www.ebi.ac.uk/ena/data/view/GCA_000292705
 18	1	repeat.analysis	Dust
 19	1	repeat.analysis	TRF
 48	1	sample.gene_param	BTF1_30792
@@ -111,8 +111,8 @@
 113	2	genebuild.start_date	2012-08-EnsemblBacteria
 112	2	genebuild.version	2012-08-EnsemblBacteria
 161	2	patch	patch_73_74_b.sql|remove_dnac
-142	2	provider.name	European Nucleotide Archive
-143	2	provider.url	http://www.ebi.ac.uk/ena/data/view/GCA_000292706
+142	2	assembly.provider_name	European Nucleotide Archive
+143	2	assembly.provider_url	http://www.ebi.ac.uk/ena/data/view/GCA_000292706
 119	2	repeat.analysis	TRF
 148	2	sample.gene_param	BTF1_30792
 149	2	sample.gene_text	BTF1_30792


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Change in meta-key provider.name to assembly.provider_name

## Use case

As per https://www.ebi.ac.uk/panda/jira/browse/ENSINT-361

## Benefits

Generic meta-keys

## Possible Drawbacks

NA

## Testing

No changes to test-cases. Only test db updated.

_If so, do the tests pass/fail?_

NA

