### PR TITLE
ENSCORESW-3534: xref Database is also a DBConnection object

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -28,6 +28,10 @@ use Bio::EnsEMBL::DBSQL::DBConnection;
 use File::Spec::Functions;
 use IO::File;
 use English;
+use vars qw(@ISA);
+use strict;
+
+@ISA = qw( Bio::EnsEMBL::DBSQL::DBConnection);
 
 sub new {
   my ( $proto, $arg_ref ) = @_;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Convert Database object to inherit from DBConnection

## Use case

DBConnection has a large number of methods implemented to deal with database connection management.
the Database object used in the xref pipeline is created from the DBConnection object
by adding the ISA, the Database object also inherits all the methods from the DBConnection object
 
## Benefits

The Database object can use methods like disconnect_if_idle 

## Possible Drawbacks

NA
## Testing

_Have you added/modified unit tests to test the changes?_
Tried running the ParseSource runnable by adding disconnect_if_idle onto the newly created Database object
This fails with the master code (disconnect_if_idle not available) but works with this code change

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

