### PR TITLE
ENSCORESW-3553: store RGD separately based on type of link

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -60,6 +60,14 @@ sub run {
     confess 'Need to pass source_id, species_id and files as pairs';
   }
 
+  my $source_sql = "select source_id from source where name = 'RGD' and priority_description = 'direct_xref'";
+  my $sth = $dbi->prepare($source_sql);
+  $sth->execute();
+  my ($direct_source_id);
+  $sth->bind_columns(\$direct_source_id);
+  $sth->fetch();
+  $sth->finish();
+
   my $file = @{$files}[0];
 
  # Used to assign dbIDs for when RGD Xrefs are dependent on RefSeq xrefs
@@ -152,11 +160,11 @@ sub run {
           label      => $cols->{SYMBOL},
           desc       => $cols->{NAME},
           dbi        => $dbi,
-          source_id  => $source_id,
+          source_id  => $direct_source_id,
           species_id => $species_id,
         });
         my $xref_id =
-          $self->get_xref( $cols->{GENE_RGD_ID}, $source_id,
+          $self->get_xref( $cols->{GENE_RGD_ID}, $direct_source_id,
                            $species_id, $dbi );
         $syn_count +=
           $self->process_synonyms( $xref_id, $cols->{OLD_SYMBOL},


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

For RGD which have a direct link to an Ensembl stable ID, use a different source than RGD which have an inferred link via RefSeq

## Use case

RGD accessions can be linked to a RefSeq accession or directly to an Ensembl stable ID.
Storing these links as two separate xref entries means we can treat them separately and prioritise the better link when available.
Without the distinction, we can have the same accession mapped to two different stable IDs and one link is arbitrarily chosen over the other. In some cases, the chosen link is invalid and no link to RGD is kept.

## Benefits

More links to RGD, more reproducible, more reliable

## Possible Drawbacks

NA

## Testing

_Have you added/modified unit tests to test the changes?_
NA
_If so, do the tests pass/fail?_
NA
_Have you run the entire test suite and no regression was detected?_
NA

The xref pipeline currently fails for rat because some links become invalid after loading into the core database.
With the proposed fix, the pipeline runs successfully and RGD xrefs are correctly mapped to Ensembl genes
