### PR TITLE
Update to annotation provider in EMBL/GenBank files

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
@@ -476,34 +476,8 @@ sub dump_embl {
   #References (we are not dumping refereneces)
   #Database References (we are not dumping these)
 
-  #Get annotation source 
-  my @providers = ();
-  my @provider_urls = ();
-
-  foreach ( @{$meta_container->list_value_by_key('annotation.provider_name')} ) {
-    push @providers, $_ if $_ ne '';
-  }
-  foreach ( @{$meta_container->list_value_by_key('annotation.provider_url')} ) {
-    push @provider_urls, $_ if $_ ne '';
-  }
-  if ( ! scalar(@providers) ) {
-    foreach ( @{$meta_container->list_value_by_key('assembly.provider_name')} ) {
-      push @providers, $_ if $_ ne '';
-    }
-    foreach ( @{$meta_container->list_value_by_key('assembly.provider_url')} ) {
-      push @provider_urls, $_ if $_ ne '';
-    }
-  }
-  if ( ! scalar(@providers) ) {
-    push @providers, 'Ensembl';
-  }
-
-  my $annotation_source = join(' and ', @providers);
-  if (@provider_urls) {
-    $annotation_source .= ' ' . sprintf(q{(%s)}, join(', ', @provider_urls));
-  }
-
   #comments
+  my $annotation_source = $self->annotation_source($meta_container);
   foreach my $comment (@COMMENTS) {
     $comment =~ s/\#\#\#SOURCE\#\#\#/$annotation_source/;
     $self->write($FH, $EMBL_HEADER, 'CC', $comment);
@@ -684,34 +658,8 @@ sub dump_genbank {
 
   #refereneces
 
-  #Get annotation source 
-  my @providers = ();
-  my @provider_urls = ();
-
-  foreach ( @{$meta_container->list_value_by_key('annotation.provider_name')} ) {
-    push @providers, $_ if $_ ne '';
-  }
-  foreach ( @{$meta_container->list_value_by_key('annotation.provider_url')} ) {
-    push @provider_urls, $_ if $_ ne '';
-  }
-  if ( ! scalar(@providers) ) {
-    foreach ( @{$meta_container->list_value_by_key('assembly.provider_name')} ) {
-      push @providers, $_ if $_ ne '';
-    }
-    foreach ( @{$meta_container->list_value_by_key('assembly.provider_url')} ) {
-      push @provider_urls, $_ if $_ ne '';
-    }
-  }
-  if ( ! scalar(@providers) ) {
-    push @providers, 'Ensembl';
-  }
-
-  my $annotation_source = join(' and ', @providers);
-  if (@provider_urls) {
-    $annotation_source .= ' ' . sprintf(q{(%s)}, join(', ', @provider_urls));
-  }
-
   #comments
+  my $annotation_source = $self->annotation_source($meta_container);
   foreach my $comment (@COMMENTS) {
     $comment =~ s/\#\#\#SOURCE\#\#\#/$annotation_source/;
     $self->write($FH, $GENBANK_HEADER, 'COMMENT', $comment);
@@ -1170,6 +1118,48 @@ sub features2location {
   return $out;
 }
 
+=head2 annotation_source
+
+  Arg [1]    : Bio::EnsEMBL::DBSQL::MetaContainer
+  Example    : $seq_dumper->annotation_source($meta_container);
+  Description: Constructs a string with gene annotation sources
+  Returntype : string
+  Exceptions : none
+  Caller     : dump_embl, dump_genbank
+
+=cut
+
+sub annotation_source {
+  my ($self, $meta_container) = @_;
+
+  my @providers = ();
+  my @provider_urls = ();
+
+  foreach ( @{$meta_container->list_value_by_key('annotation.provider_name')} ) {
+    push @providers, $_ if $_ ne '';
+  }
+  foreach ( @{$meta_container->list_value_by_key('annotation.provider_url')} ) {
+    push @provider_urls, $_ if $_ ne '';
+  }
+  if ( ! scalar(@providers) ) {
+    foreach ( @{$meta_container->list_value_by_key('assembly.provider_name')} ) {
+      push @providers, $_ if $_ ne '';
+    }
+    foreach ( @{$meta_container->list_value_by_key('assembly.provider_url')} ) {
+      push @provider_urls, $_ if $_ ne '';
+    }
+  }
+  if ( ! scalar(@providers) ) {
+    push @providers, 'Ensembl';
+  }
+
+  my $annotation_source = join(' and ', @providers);
+  if (@provider_urls) {
+    $annotation_source .= ' ' . sprintf(q{(%s)}, join(', ', @provider_urls));
+  }
+
+  return $annotation_source;
+}
 
 sub _date_string {
   my $self = shift;
@@ -1182,7 +1172,6 @@ sub _date_string {
   
   return "$mday-$month-$year";
 }
-
 
 sub write {
   my ($self, $FH, $FORMAT, @values) = @_;

--- a/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
@@ -477,15 +477,31 @@ sub dump_embl {
   #Database References (we are not dumping these)
 
   #Get annotation source 
-  my ($provider_name)   = @{$meta_container->list_value_by_key('assembly.provider_name')};
-  my ($provider_url)    = @{$meta_container->list_value_by_key('assembly.provider_url')};
-  my $annotation_source = q{};
-   
-  if($provider_name) {
-    $annotation_source .= $provider_name;
-    $annotation_source .= sprintf(q{(%s)}, $provider_url) if $provider_url;
+  my @providers = ();
+  my @provider_urls = ();
+
+  foreach ( @{$meta_container->list_value_by_key('annotation.provider_name')} ) {
+    push @providers, $_ if $_ ne '';
   }
-  else { $annotation_source .= 'Ensembl'; }
+  foreach ( @{$meta_container->list_value_by_key('annotation.provider_url')} ) {
+    push @provider_urls, $_ if $_ ne '';
+  }
+  if ( ! scalar(@providers) ) {
+    foreach ( @{$meta_container->list_value_by_key('assembly.provider_name')} ) {
+      push @providers, $_ if $_ ne '';
+    }
+    foreach ( @{$meta_container->list_value_by_key('assembly.provider_url')} ) {
+      push @provider_urls, $_ if $_ ne '';
+    }
+  }
+  if ( ! scalar(@providers) ) {
+    push @providers, 'Ensembl';
+  }
+
+  my $annotation_source = join(' and ', @providers);
+  if (@provider_urls) {
+    $annotation_source .= ' ' . sprintf(q{(%s)}, join(', ', @provider_urls));
+  }
 
   #comments
   foreach my $comment (@COMMENTS) {
@@ -669,15 +685,31 @@ sub dump_genbank {
   #refereneces
 
   #Get annotation source 
-  my ($provider_name)   = @{$meta_container->list_value_by_key('assembly.provider_name')};
-  my ($provider_url)    = @{$meta_container->list_value_by_key('assembly.provider_url')};
-  my $annotation_source = q{};
-  
-  if($provider_name) {
-     $annotation_source .= $provider_name;
-     $annotation_source .= sprintf(q{(%s)}, $provider_url) if $provider_url;
+  my @providers = ();
+  my @provider_urls = ();
+
+  foreach ( @{$meta_container->list_value_by_key('annotation.provider_name')} ) {
+    push @providers, $_ if $_ ne '';
   }
-  else { $annotation_source .= 'Ensembl'; }
+  foreach ( @{$meta_container->list_value_by_key('annotation.provider_url')} ) {
+    push @provider_urls, $_ if $_ ne '';
+  }
+  if ( ! scalar(@providers) ) {
+    foreach ( @{$meta_container->list_value_by_key('assembly.provider_name')} ) {
+      push @providers, $_ if $_ ne '';
+    }
+    foreach ( @{$meta_container->list_value_by_key('assembly.provider_url')} ) {
+      push @provider_urls, $_ if $_ ne '';
+    }
+  }
+  if ( ! scalar(@providers) ) {
+    push @providers, 'Ensembl';
+  }
+
+  my $annotation_source = join(' and ', @providers);
+  if (@provider_urls) {
+    $annotation_source .= ' ' . sprintf(q{(%s)}, join(', ', @provider_urls));
+  }
 
   #comments
   foreach my $comment (@COMMENTS) {

--- a/modules/t/seqDumper.t
+++ b/modules/t/seqDumper.t
@@ -126,7 +126,15 @@ my $index_count_fh = sub {
     is(@{$lines}, 1, 'Expect only 1 Genbank BASE COUNT line describing a sequence');
     is($lines->[0], 'BASE COUNT       24986 a      24316 c      24224 g      26475 t          0 n', 'Formatting of BASE COUNT as expected');
   }
-  
+
+  {
+    my $fh = IO::String->new();
+    $sd->dump_embl($slice, $fh);
+    my $lines = $index_fh->($fh, 'CC ');
+    my $comments = join(' ', @{$lines});
+    $comments =~ s/CC\s+//gm;
+    like($comments, qr/This sequence was annotated by Ensembl \(www\.ensembl\.org\)/, 'Annotation source as expected');
+  }
 }
 
 done_testing();

--- a/modules/t/seqDumper.t
+++ b/modules/t/seqDumper.t
@@ -24,7 +24,6 @@ use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::Utils::SeqDumper;
 use Bio::EnsEMBL::Test::TestUtils;
 use Bio::EnsEMBL::Test::MultiTestDB;
-use Module::Refresh;
 our $verbose = 0;
 
 my $multi = Bio::EnsEMBL::Test::MultiTestDB->new();
@@ -141,8 +140,8 @@ my $index_count_fh = sub {
     # Because the 'source' has already been substituted in the comments
     # by an earlier test, need to reload the module to reset the
     # global variable.
-    my $refresher = Module::Refresh->new;
-    $refresher->refresh_module('Bio/EnsEMBL/Utils/SeqDumper.pm');
+    delete ( $INC{'Bio/EnsEMBL/Utils/SeqDumper.pm'} );
+    require Bio::EnsEMBL::Utils::SeqDumper;
 
     $multi->hide('core', 'meta');
 

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -122,4 +122,4 @@
 196	1	annotation.provider_name	Ensembl
 197	1	annotation.provider_url	www.ensembl.org
 198	1	assembly.provider_name	
-199	1	assembly.provider_name	
+199	1	assembly.provider_url	

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -119,3 +119,7 @@
 193	\N	patch	patch_101_102_a.sql|schema_version
 194	\N	patch	patch_102_103_a.sql|schema_version
 195	\N	patch	patch_103_104_a.sql|schema_version
+196	1	annotation.provider_name	Ensembl
+197	1	annotation.provider_url	www.ensembl.org
+198	1	assembly.provider_name	
+199	1	assembly.provider_name	


### PR DESCRIPTION
## Description
We used to have a meta_key, `provider.name` (and an associated `provider.url`), but this did not allow us to capture the fact that sometimes the assembly needs to be credited to one provider, and the gene annotation to another. Vertebrate databases used the field to indicate the annotation provider, and non-vertebrates used it for the assembly provider. To better represent these use cases, `provider.name` was replaced by two new meta_keys, `assembly.provider_name` and `annotation.provider_name` (https://www.ebi.ac.uk/panda/jira/browse/ENSINT-361).

In the comments of EMBL and GenBank files, the `provider.name` was formerly used to indicate the source of the annotation; this was replaced by `assembly.provider_name` in a previous PR (#506), but it would be more accurate to use `annotation.provider_name`, and only if that is undefined, fall back to `assembly.provider_name`.

Further, since an annotation can have multiple providers, it is good to list them all, rather than select one to include in the comments.

## Use case
For vertebrates, this change does not make much difference, because `assembly.provider_name` is typically not defined, so the code falls back to the generic 'Ensembl' in any case. But for non-vertebrates, which are typically annotated by non-Ensembl groups, this allows for more accurate attribution.

## Benefits
Better attribution for annotation in ftp files.

## Possible Drawbacks
None I can think of.

## Testing
_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes
