### PR TITLE
Feature/lrg xrefs

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -263,11 +263,9 @@ CCDS
 
     # Direct LRG to ENST mappings
     my $lrg_id = $data->{'Locus specific databases'};
-    if ( defined $lrg_id && $lrg_id =~ m/(LRG_\d+)|/x ){
-      $lrg_id = $1;
-    }
 
-    if ( defined $lrg_id ){
+    if ( defined $lrg_id && $lrg_id =~ m/(LRG_\d+)\|/x){
+      $lrg_id = $1;
       $self->add_to_direct_xrefs({
           stable_id   => $lrg_id,
           type        => 'gene',

--- a/misc-scripts/xref_mapping/t/test-data/hgnc.tsv
+++ b/misc-scripts/xref_mapping/t/test-data/hgnc.tsv
@@ -7,8 +7,8 @@ HGNC:27057	A2M-AS1	A2M antisense RNA 1			144571	ENSG00000245105	NR_026971
 HGNC:41022	A2ML1-AS1	A2ML1 antisense RNA 1				ENSG00000256661			
 HGNC:8	A2MP1	alpha-2-macroglobulin pseudogene 1	A2MP		3	ENSG00000256069	NG_001067		
 HGNC:30005	A3GALT2	alpha 1,3-galactosyltransferase 2	A3GALT2P	IGBS3S, IGB3S	127550	ENSG00000184389	NM_001080438	CCDS60080	
-HGNC:18149	A4GALT	alpha 1,4-galactosyltransferase (P blood group)	P1	A14GALT, Gb3S, P(k)	53947	ENSG00000128274	NM_017436	CCDS14041	"LRG_795|http://ftp.ebi.ac.uk/pub/databases/lrgex/pending/LRG_795.xml"
-HGNC:17968	A4GNT	alpha-1,4-N-acetylglucosaminyltransferase		alpha4GnT	51146	ENSG00000118017	NM_016161	CCDS3097	
+HGNC:18149	A4GALT	alpha 1,4-galactosyltransferase (P blood group)	P1	A14GALT, Gb3S, P(k)	53947	ENSG00000128274	NM_017436	CCDS14041	 "Global Variome shared LOVD|https://databases.lovd.nl/shared/genes/ABCB7","LRG_795|http://ftp.ebi.ac.uk/pub/databases/lrgex/pending/LRG_795.xml"
+HGNC:17968	A4GNT	alpha-1,4-N-acetylglucosaminyltransferase		alpha4GnT	51146	ENSG00000118017	NM_016161	CCDS3097	"Global Variome shared LOVD|https://databases.lovd.nl/shared/genes/ACE2"
 HGNC:13666	AAAS	aladin WD repeat nucleoporin			8086	ENSG00000094914		CCDS8856, CCDS53797	
 HGNC:30205	AAMDC	adipogenesis associated Mth938 domain containing	C11orf67	PTD015, FLJ21035, CK067	28971	ENSG00000087884	NM_024684	CCDS8254, CCDS81604, CCDS81605, CCDS86232	
 HGNC:18	AAMP	angio associated migratory cell protein			14	ENSG00000127837	NM_001087	CCDS33378, CCDS77530	


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Change regex to capture all relevant LRG mappings.

## Use case

Input data from HGNC can have multiple entries for 'Locus specific databases' while the current regex assumes it will only ever be LRG data.
The regex update ensures we correctly capture the LRG ID when it is available and ignore any other data from that column.

## Benefits

_If applicable, describe the advantages the changes will have._
All the relevant HGNC data for LRGs will be correctly parsed and stored in the xref database

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
NA

## Testing

_Have you added/modified unit tests to test the changes?_
The test data was updated to include a wider range of examples for the 'Locus specific databases' column

_If so, do the tests pass/fail?_
Updating the test data without any code change results in the test case failing.
With the proposed code change, the test case passes

_Have you run the entire test suite and no regression was detected?_
yes
