### PR TITLE
Create chromosome alias in CoordSystem object

### DIFF
--- a/modules/Bio/EnsEMBL/CoordSystem.pm
+++ b/modules/Bio/EnsEMBL/CoordSystem.pm
@@ -184,6 +184,10 @@ sub new {
     throw('The RANK argument must be a positive integer');
   }
 
+  if ( defined($alias_to) ) {
+    throw("The ALIAS_TO argument can only be defined as 'chromosome'") unless $alias_to eq "chromosome";
+  }
+
   $self->{'version'}        = $version;
   $self->{'name'}           = $name;
   $self->{'top_level'}      = $top_level;
@@ -393,6 +397,9 @@ sub rank {
 
 sub alias_to {
   my ($self, $alias_to) = @_;
+  if (defined($alias_to)) {
+    throw("The alias can only be set to 'chromosome'") unless $alias_to eq "chromosome";
+  }
   $self->{'alias_to'} = $alias_to if defined $alias_to;
   return $self->{'alias_to'};
 }

--- a/modules/Bio/EnsEMBL/CoordSystem.pm
+++ b/modules/Bio/EnsEMBL/CoordSystem.pm
@@ -110,6 +110,8 @@ use vars qw(@ISA);
                              coordinate system
                -ADAPTOR   - (optional) The adaptor which provides database
                             interaction for this object
+               -ALIAS_TO  - (optional) Sets an alias for a coordsystem. If set 
+                            it should only be set to 'chromosome'
   Example    : $cs = Bio::EnsEMBL::CoordSystem->new(-NAME    => 'chromosome',
                                                     -VERSION => 'NCBI33',
                                                     -RANK    => 1,

--- a/modules/Bio/EnsEMBL/CoordSystem.pm
+++ b/modules/Bio/EnsEMBL/CoordSystem.pm
@@ -132,10 +132,11 @@ sub new {
 
   my $self = $class->SUPER::new(@_);
 
-  my ( $name, $version, $top_level, $sequence_level, $default, $rank ) =
+  my ( $name, $version, $top_level, $sequence_level, $default, $rank, $alias_to ) =
     rearrange( [ 'NAME',      'VERSION',
                  'TOP_LEVEL', 'SEQUENCE_LEVEL',
-                 'DEFAULT',   'RANK' ],
+                 'DEFAULT',   'RANK',
+                 'ALIAS_TO' ],
                @_ );
 
   $top_level      = ($top_level)      ? 1 : 0;
@@ -187,6 +188,7 @@ sub new {
   $self->{'sequence_level'} = $sequence_level;
   $self->{'default'}        = $default;
   $self->{'rank'}           = $rank;
+  $self->{'alias_to'}       = $alias_to;
 
   return $self;
 } ## end sub new
@@ -372,5 +374,26 @@ sub rank {
   my $self = shift;
   return $self->{'rank'};
 }
+
+
+
+=head2 alias_to
+
+  Arg [1]    : string
+  Example    : $coord->alias_to('chromosome');
+  Description: Getter/Setter for the alias of this coordinate system.
+  Returntype : Bio::EnsEMBL::CoordSystem
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub alias_to {
+  my ($self, $alias_to) = @_;
+  $self->{'alias_to'} = $alias_to if defined $alias_to;
+  return $self->{'alias_to'};
+}
+
 
 1;

--- a/modules/t/coordSystem.t
+++ b/modules/t/coordSystem.t
@@ -118,4 +118,12 @@ ok($coord_system->name() eq $name);
 ok($coord_system->is_top_level());
 ok($coord_system->rank() == 0);
 
+#
+# test alias_to getter/setter
+#
+
+my $alias = 'chromosome';
+ok(test_getter_setter($coord_system, 'alias_to', $alias)); 
+is($coord_system->alias_to(), $alias, "Correctly retrieved alias '$alias'");
+
 done_testing();

--- a/modules/t/coordSystem.t
+++ b/modules/t/coordSystem.t
@@ -20,6 +20,8 @@ use Bio::EnsEMBL::CoordSystem;
 
 use Bio::EnsEMBL::Test::TestUtils;
 
+use Test::Exception;
+
 our $verbose = 0;
 
 use Test::More;
@@ -119,11 +121,37 @@ ok($coord_system->is_top_level());
 ok($coord_system->rank() == 0);
 
 #
-# test alias_to getter/setter
+# Test constructor with alias set
 #
+{
+  my $name = "primary_assembly";
+  my $alias = "chromosome";
+  my $coord_system = Bio::EnsEMBL::CoordSystem->new
+  (-NAME     => $name,
+   -RANK     => $rank,
+   -ALIAS_TO => $alias);
 
+  is($coord_system->alias_to(), $alias, "Correctly initialised alias variable in constructor to '$alias'");
+
+  my $bad_alias = "badalias";
+  throws_ok {
+    my $cs_bad_alias = Bio::EnsEMBL::CoordSystem->new
+    (-NAME     => $name,
+    -RANK     => $rank,
+    -ALIAS_TO => $bad_alias);
+  } qr /The ALIAS_TO argument can only be defined as 'chromosome'/,
+  "Checks that error is thrown if -ALIAS_TO in constructor is defined as something other than '$alias'";
+}
+
+
+#
+# Test alias_to getter/setter
+#
 my $alias = 'chromosome';
 ok(test_getter_setter($coord_system, 'alias_to', $alias)); 
-is($coord_system->alias_to(), $alias, "Correctly retrieved alias '$alias'");
+is($coord_system->alias_to(), $alias, "Getter method correctly retrieved alias '$alias'");
+
+throws_ok{ $coord_system->alias_to('somethingelse') } qr/The alias can only be set to/,
+  'Checks that error is thrown if requested alias is not called chromosome';
 
 done_testing();


### PR DESCRIPTION
## Description

As described in [JIRA ticket ENSCORESW-3021](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3021), sequence assembly data has changed in format in recent years, resulting in recent databases having only a single 'primary_assembly' coordinate system. This is compared to older assembly data with multiple coordinate systems including: 'chromosome', 'contig', 'scaffold'.

## Use case

Currently, a coordinate system named 'chromosome' may not exist in an Ensembl database, due to a change in sequence assembly formatting in databases created in the last few years. Examples include the Parus major and Clupea harengus databases, which contain a single coordinate system named 'primary_assembly'. If a user requests a chromosome slice object and there is no explicitly-named chromosome coordinate system in the query database, this new feature uses karyotype-based attributes in the database to identify a coordinate system to add an appropriate ('chromosome') alias to.

## Benefits

Where an Ensembl Core species database does not have coordinate system named chromosome, this code will create an alias to the appropriate coordinate system when a user requests a chromosome slice object, as long as the requested name has associated karyotype attributes.

## Possible Drawbacks

Once the tests have been updated (as mentioned below), there are no drawbacks that I can think of.

## Testing

Yes, tests have been added to `coordSystem.t`.

_If so, do the tests pass/fail?_

The tests in `coordSystem.t` pass.

_Have you run the entire test suite and no regression was detected?_

The test suite is passing in the Travis-CI build.