### PR TITLE
Add private subroutine fetch_by_fuzzy_matching

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2730,10 +2730,10 @@ sub _build_circular_slice_cache {
 
 
 =head2 _fetch_by_fuzzy_matching
-  Args       : $cs, $version, $seq_region_name
-  Example    : my $fuzzy_matched_name = $self->fetch_by_fuzzy_matching( $cs, $version, $seq_region_name );
+  Args       : $cs, $seq_region_name, $sql, $constraint, $bind_params
+  Example    : my $fuzzy_matched_name = $self->fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, $bind_params );
   Description: fetches all the fuzzy matches for a given seq_region_name when requested
-  Returntype : string
+  Returntype : string, Bio::EnsEMBL::CoordSystem
   Exceptions : None
   Caller     : general
   Status     : (refactored from fetch_by_region)

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2741,7 +2741,7 @@ sub _build_circular_slice_cache {
 
 sub _fetch_by_fuzzy_matching {
 
-  my ($self, $cs, $version, $seq_region_name, $sql, $constraint, $bind_params) = @_;
+  my ($self, $cs, $seq_region_name, $sql, $constraint, $bind_params) = @_;
 
   my $csa = $self->db->get_CoordSystemAdaptor();
   my $length;

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2744,14 +2744,7 @@ sub _fetch_by_fuzzy_matching {
   my ($self, $cs, $version, $seq_region_name, $sql, $constraint, $bind_params) = @_;
 
   my $csa = $self->db->get_CoordSystemAdaptor();
-  # my @bind_params;
   my $length;
-
-  # my $sql = sprintf( "SELECT sr.name, sr.seq_region_id, sr.length, sr.coord_system_id "
-  #                  . "FROM seq_region sr " );
-  # my $constraint = "AND sr.coord_system_id = ?";
-
-  print "Do fuzzy matching...\n";
 
   # Do fuzzy matching, assuming that we are just missing a version
   # on the end of the seq_region name.
@@ -2763,13 +2756,10 @@ sub _fetch_by_fuzzy_matching {
 
   my $pos = 0;
   foreach my $param (@$bind_params) {
-    # print "++$pos, $param->[0], $param->[1]\n";
     $sth->bind_param( ++$pos, $param->[0], $param->[1] );
   }
 
-
   $sth->execute();
-  # print Dumper( $sth->fetch );
 
   my $prefix_len = length($seq_region_name) + 1;
   my $high_ver   = undef;
@@ -2784,7 +2774,6 @@ sub _fetch_by_fuzzy_matching {
   my $i = 0;
 
   while ( $sth->fetch ) {
-    # print "HERE!\n";
     my $tmp_cs =
       ( defined($cs) ? $cs : $csa->fetch_by_dbID($cs_id) );
 
@@ -2794,8 +2783,6 @@ sub _fetch_by_fuzzy_matching {
     $self->{'sr_id_cache'}->{"$id"}                = $arr;
 
     my $tmp_ver = substr( $tmp_name, $prefix_len );
-
-    # print "tmp_ver = $tmp_ver\n";
 
     # skip versions which are non-numeric and apparently not
     # versions
@@ -2833,8 +2820,6 @@ sub _fetch_by_fuzzy_matching {
 
   # return if we did not find any appropriate match:
   if ( !defined($high_ver) ) { return; }
-
-  print "Returning: $seq_region_name, $cs\n";
 
   return ($seq_region_name, $cs);
 }

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2752,8 +2752,8 @@ sub _fetch_by_fuzzy_matching {
   my $sth =
     $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
 
-  $bind_params->[0] = [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
-
+  unshift @$bind_params, [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
+  
   my $pos = 0;
   foreach my $param (@$bind_params) {
     $sth->bind_param( ++$pos, $param->[0], $param->[1] );

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -84,9 +84,8 @@ debug("slice seq_region length = " . $slice->seq_region_length());
   my $constraint = "AND sr.coord_system_id = ?";
   my @bind_params;
   push( @bind_params, [ $cs->dbID() ] );
-  my ($fuzzy_matched_name, $cs) = $slice_adaptor->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
+  my ($fuzzy_matched_name) = $slice_adaptor->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
   is($fuzzy_matched_name, 'AL031658.11', "Checking fuzzy match found: $fuzzy_matched_name equals that expected: AL031658.11");
-  isa_ok($cs, 'Bio::EnsEMBL::CoordSystem');
 }
 
 

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -57,6 +57,40 @@ debug("slice seq_region length = " . $slice->seq_region_length());
 
 
 #
+# _fetch_by_fuzzy_matching
+#
+{
+  my $seq_region_name = 'AL031658';
+  my $sql =
+    "SELECT sr.name, sr.seq_region_id, sr.length, cs.coord_system_id FROM seq_region sr, coord_system cs ";
+  my $constraint = "AND sr.coord_system_id = cs.coord_system_id "
+    . "AND cs.species_id = ? "
+    . "ORDER BY cs.rank ASC";
+  my @bind_params;
+  push( @bind_params, [ $db->species_id() ] );
+  my ($fuzzy_matched_name, $cs) = $slice_adaptor->_fetch_by_fuzzy_matching( undef, $seq_region_name, $sql, $constraint, \@bind_params );
+  is($fuzzy_matched_name, 'AL031658.11', "Checking fuzzy match found: $fuzzy_matched_name equals that expected: AL031658.11");
+  isa_ok($cs, 'Bio::EnsEMBL::CoordSystem');
+}
+
+{
+  my $coord_system_name = "clone";
+  my $csa = $db->get_CoordSystemAdaptor();
+  my $cs = $csa->fetch_by_name( $coord_system_name );
+  my $seq_region_name = 'AL031658';
+  my $sql = sprintf( "SELECT sr.name, sr.seq_region_id, sr.length, %d "
+                      . "FROM seq_region sr ",
+                    $cs->dbID() );
+  my $constraint = "AND sr.coord_system_id = ?";
+  my @bind_params;
+  push( @bind_params, [ $cs->dbID() ] );
+  my ($fuzzy_matched_name, $cs) = $slice_adaptor->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
+  is($fuzzy_matched_name, 'AL031658.11', "Checking fuzzy match found: $fuzzy_matched_name equals that expected: AL031658.11");
+  isa_ok($cs, 'Bio::EnsEMBL::CoordSystem');
+}
+
+
+#
 # fetch_by_contig_name
 #
 


### PR DESCRIPTION
## Description

There is code in SliceAdaptor::fetch_by_region() that has been marked for refactoring, specifically the code dealing with synonym/wildcard/fuzzy-matching. During work on creating a chromosome alias feature, I worked on refactoring this code into two new subroutines. This PR has simply added a new subroutine for code relating to fetching sequence regions by fuzzy matching. There are no calls to this subroutine or changes to fetch_by_region to make this PR as simple as possible.

## Use case

This refactored code will be used by any SliceAdaptor::fetch_by_region request where the seq_region_name user argument is not an exact match to a seq_region_name attribute in the relevant core database.

I understand that this code is used extensively by Ensembl users and therefore a note here to say that these changes will of course be extensively tested. (Use cases to be added here during this work.)

## Benefits

In brief, the removal of superfluous code and making the code more readable.

During work on the chromosome alias feature, it became clear that the synonym/wildcard/fuzzy-match code needed to be refactored into subroutines to avoid large chunks of duplicate code being used in SliceAdaptor::fetch_by_region.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes, tests added to `sliceAdaptor.t`.

_If so, do the tests pass/fail?_



_Have you run the entire test suite and no regression was detected?_

