### PR TITLE
Fix error msg, to avoid DBI error on connection error

### DIFF
--- a/misc-scripts/ping_ensembl.pl
+++ b/misc-scripts/ping_ensembl.pl
@@ -168,7 +168,7 @@ eval {
 if($error) {
   print "ERROR: Error detected when connecting to Ensembl!\n";
   
-  if($error =~ /Can't connect to MySQL server on/) {
+  if($error =~ /Can't connect to MySQL server on /) {
     print "\tPlease check if your connection with mysql client works fine. \n";
   } elsif ($error =~ /Cannot connect to/) {
     print "\tCannot seem to contact EnsemblDB at '$host' with the username '$user'. Try running 'ping $host' or asking your systems about firewalls against port $port\n";

--- a/misc-scripts/ping_ensembl.pl
+++ b/misc-scripts/ping_ensembl.pl
@@ -167,7 +167,12 @@ eval {
 # Print all the errors which could have occured 
 if($error) {
   print "ERROR: Error detected when connecting to Ensembl!\n";
-  if($error =~ /DBI/) {
+  
+  if($error =~ /Can't connect to MySQL server on/) {
+    print "\tPlease check if your connection with mysql client works fine. \n";
+  } elsif ($error =~ /Cannot connect to/) {
+    print "\tCannot seem to contact EnsemblDB at '$host' with the username '$user'. Try running 'ping $host' or asking your systems about firewalls against port $port\n";
+  } elsif ($error =~ /DBI/) {
     print "\tCannot find the DBI perl module. Please install this using your package management system, cpan or cpanm. Please consult http://www.ensembl.org/info/docs/api/api_installation.html\n";
   }
   if($error =~ /mysql/) {
@@ -179,9 +184,7 @@ if($error) {
   if($error =~ /Can't locate Bio\/Perl/) {
     print "\tLooks like you need to setup your PERL5LIB with BioPerl. Please consult http://www.ensembl.org/info/docs/api/api_installation.html\n";
   }
-  if($error =~ /Cannot connect to/) {
-    print "\tCannot seem to contact EnsemblDB at '$host' with the username '$user'. Try running 'ping $host' or asking your systems about firewalls against port $port\n";
-  }
+  
   if($error =~ /internal name/) {
     print "\tSpecies was not found. You may have accidentally download the HEAD API version (found API release $db_version & public FTP release is $ftp_version). Please consult http://www.ensembl.org/info/docs/api/api_installation.html\n";
   }


### PR DESCRIPTION
## Description

Change error msg: don't propose install DBI if it is just connection problem

## Use case

WHen user doesn't have mysql connection correct, now error msg proposees to install DBI module, we must avoid it and propose to check connection

## Benefits

Clear error msg

## Possible Drawbacks

Not found

## Testing

No, this script is not a part of API

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

All tests works fine
