### PR TITLE
ENSCORESW-3589: Add private subroutine create_chromosome_alias

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2727,6 +2727,86 @@ sub _build_circular_slice_cache {
   $sth->finish();
 } ## end _build_circular_slice_cache
 
+=head2 create_chromosome_alias
+
+  Args       : none
+  Example    : $self->create_chromosome_alias();
+  Description: create chromosome alias in coordinate system with karyotype attributes
+  Returntype : Bio::EnsEMBL::CoordSystem, or none 
+  Exceptions : None
+  Caller     : general
+  Status     : in testing
+
+=cut
+
+sub create_chromosome_alias {
+  my $self = shift;
+  my $csa  = $self->db->get_CoordSystemAdaptor();
+
+  print " DEBUG: Noticed you have requested to get a chromosome slice, when no chromosome CoordSystem exists. Finding CoordSystem to alias to...\n";
+
+  # to store reformatted db query results
+  my %karyotype_seq_regions;
+  
+  my $karyotype_rank_string = "karyotype_rank";
+
+  # to store coord_system_id to alias 
+  my $coord_system_id;
+
+  # check whether seq region cache exists, otherwise run database query
+  if ( $self->{'karyotype_cache'} ) {
+    print "Seq region cache exists...\n";
+    %karyotype_seq_regions = $self->{'karyotype_cache'};
+  } else {
+    print "Seq region cache does not exist. Running SQL..\n";
+    # cannot find a coordssystem called chromosome
+    # look through attribs to find seq_regions with karyotype
+
+    my $sth =
+      $self->prepare( "SELECT sr.seq_region_id, sr.name, sr.coord_system_id, sr.length, a.code "
+                    . "FROM seq_region sr, seq_region_attrib sra, attrib_type a "
+                    . "WHERE sr.seq_region_id = sra.seq_region_id "
+                    . "AND a.attrib_type_id = sra.attrib_type_id "
+                    . "AND a.code = ?" );
+
+    $sth->bind_param( 1, $karyotype_rank_string );
+    $sth->execute();
+
+    # fetch SQL results and identify coord_system_id that
+    # has karyotype attribs
+
+    while ( my $hashref = $sth->fetchrow_hashref() ) {
+      my $seq_region_id   = $hashref->{ seq_region_id };
+      my $seq_region_name = $hashref->{ name };
+      $coord_system_id    = $hashref->{ coord_system_id };
+      my $length          = $hashref->{ length };
+      my $code            = $hashref->{ code };
+
+      $karyotype_seq_regions{ $seq_region_name }{ code }            = $code;
+      $karyotype_seq_regions{ $seq_region_name }{ coord_system_id } = $coord_system_id;
+      $karyotype_seq_regions{ $seq_region_name }{ length }          = $length;
+      $karyotype_seq_regions{ $seq_region_name }{ seq_region_id }   = $seq_region_id;
+    }
+    $sth->finish();
+  }
+
+  if ( !$coord_system_id ) {
+    throw("No coordinate system to create a chromosome slice from (because there is no suitable coordinate system to create an alias to).\n");
+  } else {
+
+    # use appropriate 'coord_system_id' to set 'alias_to' variable
+    my $cs = $csa->fetch_by_dbID( $coord_system_id );
+    print "Fetched CoordSystem with coord_system_id: $coord_system_id.\n";
+    $cs->alias_to('chromosome');
+
+    # create karyotype cache in retrieved coordsystem
+    $cs->{'karyotype_cache'} = \%karyotype_seq_regions;
+    print Dumper( $cs );
+
+    return $cs;
+  }
+} ## end create_chromosome_alias
+
 
 =head2 _fetch_by_seq_region_synonym
   Args       : $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2743,8 +2743,6 @@ sub _create_chromosome_alias {
   my $self = shift;
   my $csa  = $self->db->get_CoordSystemAdaptor();
 
-  print " DEBUG: Noticed you have requested to get a chromosome slice, when no chromosome CoordSystem exists. Finding CoordSystem to alias to...\n";
-
   # to store reformatted db query results
   my %karyotype_seq_regions;
   
@@ -2755,10 +2753,8 @@ sub _create_chromosome_alias {
 
   # check whether seq region cache exists, otherwise run database query
   if ( $self->{'karyotype_cache'} ) {
-    print "Seq region cache exists...\n";
     %karyotype_seq_regions = $self->{'karyotype_cache'};
   } else {
-    print "Seq region cache does not exist. Running SQL..\n";
     # cannot find a coordssystem called chromosome
     # look through attribs to find seq_regions with karyotype
 
@@ -2800,12 +2796,10 @@ sub _create_chromosome_alias {
     if ( $cs->name eq "chromosome" ) {
       throw("A chromosome CoordSystem object already exists. Cannot create chromosome alias.");
     }
-    print "Fetched CoordSystem with coord_system_id: $coord_system_id.\n";
     $cs->alias_to('chromosome');
 
     # create karyotype cache in retrieved coordsystem
     $cs->{'karyotype_cache'} = \%karyotype_seq_regions;
-    print Dumper( $cs );
 
     return $cs;
   }

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2727,7 +2727,7 @@ sub _build_circular_slice_cache {
   $sth->finish();
 } ## end _build_circular_slice_cache
 
-=head2 create_chromosome_alias
+=head2 _create_chromosome_alias
 
   Args       : none
   Example    : $self->create_chromosome_alias();

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2739,7 +2739,7 @@ sub _build_circular_slice_cache {
 
 =cut
 
-sub create_chromosome_alias {
+sub _create_chromosome_alias {
   my $self = shift;
   my $csa  = $self->db->get_CoordSystemAdaptor();
 

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -103,7 +103,7 @@ Bio::EnsEMBL::Slice module.
 package Bio::EnsEMBL::DBSQL::SliceAdaptor;
 use vars qw(@ISA);
 use strict;
-use Data::Dumper; #NLW
+
 
 use Bio::EnsEMBL::DBSQL::BaseAdaptor;
 use Bio::EnsEMBL::Slice;
@@ -129,7 +129,6 @@ sub new {
 
   my $seq_region_cache = $self->db->get_SeqRegionCache();
 
-
   $self->{'sr_name_cache'} = $seq_region_cache->{'name_cache'};
   $self->{'sr_id_cache'}   = $seq_region_cache->{'id_cache'};
 
@@ -139,7 +138,6 @@ sub new {
   if(scalar(@values) and $values[0]->[0]){
     $self->{'lrg_region_test'} = $values[0]->[0];
   }
-  # print "new slice object:\n", Dumper( $self ),  "\n";
   return $self;
 }
 
@@ -223,29 +221,20 @@ sub fetch_by_region {
   my $csa = $self->db->get_CoordSystemAdaptor();
 
   if ( defined($coord_system_name) ) {
-
     $cs = $csa->fetch_by_name( $coord_system_name, $version );
 
     if ( !defined($cs) ) {
-
-      # deal with cases when the undefined coordsystem name is 'chromosome'
-      if ( $coord_system_name eq "chromosome" ) {
-
-        $cs = $self->create_chromosome_alias();
-
-      } else {
-        throw( sprintf( "Unknown coordinate system:\n"
-                  . "name='%s' version='%s' seq region name='%s'\n",
-                $coord_system_name, $version, $seq_region_name ) );
-      }
+      throw( sprintf( "Unknown coordinate system:\n"
+                        . "name='%s' version='%s'\n",
+                      $coord_system_name, $version ) );
     }
 
     # fetching by toplevel is same as fetching w/o name or version
     if ( $cs->is_top_level() ) {
-      print " DEBUG: Found that requested CoordSystem is 'toplevel'...\n";
       $cs      = undef;
       $version = undef;
     }
+
   } ## end if ( defined($coord_system_name...))
 
   my $constraint;
@@ -254,8 +243,6 @@ sub fetch_by_region {
   my $key;
 
   if ( defined($cs) ) {
-    print " DEBUG: CoordSystem object with name '$coord_system_name' is defined: $cs\n";
-
     $sql = sprintf( "SELECT sr.name, sr.seq_region_id, sr.length, %d "
                       . "FROM seq_region sr ",
                     $cs->dbID() );
@@ -2739,101 +2726,6 @@ sub _build_circular_slice_cache {
   }
   $sth->finish();
 } ## end _build_circular_slice_cache
-
-sub create_chromosome_alias {
-  my $self = shift;
-  my $csa  = $self->db->get_CoordSystemAdaptor();
-
-  print " DEBUG: Noticed you have requested to get a chromosome slice, when no chromosome CoordSystem exists. Finding CoordSystem to alias to...\n";
-
-  # cannot find a coordssystem called chromosome
-  # look through attribs to find seq_regions with karyotype
-  # and toplevel attributes
-
-  my $karyotype_attrib_id = '367';
-  my $toplevel_attrib_id  = '6';
-
-  my $sth =
-    $self->prepare( "SELECT sr.seq_region_id, sr.coord_system_id, sra.attrib_type_id "
-                  . "FROM seq_region sr, seq_region_attrib sra "
-                  . "WHERE sr.seq_region_id = sra.seq_region_id "
-                  . "AND ( attrib_type_id = ? || attrib_type_id = ?)" );
-
-  $sth->bind_param( 1, $karyotype_attrib_id );
-  $sth->bind_param( 2, $toplevel_attrib_id );
-  $sth->execute();
-
-  # fetch SQL results and
-  # identify coord_system_id that
-  # has both karyotype and toplevel attribs
-
-  # to store reformatted db query results
-  my %seq_regions;
-
-  # to store coord_system_id to alias 
-  my $coord_system_dbid;
-
-  # while ( my @row = $sth->fetchrow_array() ) {
-  while ( my $hashref = $sth->fetchrow_hashref() ) {
-    # print Dumper( $hashref );
-
-    my $seq_region_id   = $hashref->{ seq_region_id };
-    my $coord_system_id = $hashref->{ coord_system_id };
-    my $attrib_type_id  = $hashref->{ attrib_type_id };
-
-    # print "seq_region_id: $seq_region_id, coord_system_id: $coord_system_id, attrib_type_id: $attrib_type_id\n";
-
-    $seq_regions{ $seq_region_id }{ coord_system_id } = $coord_system_id;
-
-    # print "Pushing on $attrib_type_id...\n";
-    push( @{ $seq_regions{ $seq_region_id }{ attrib_type_id } }, $attrib_type_id );
-    # print Dumper( \%seq_regions );
-
-    # exit;
-
-    
-  }
-  $sth->finish();
-
-  print Dumper( \%seq_regions );
-
-  # check that the retrieved coordsystem has both karyotype and toplevel attribs
-  my $has_both_attribs;
-  foreach my $seq_region_id ( sort keys %seq_regions ) {
-    my %attribs = map { $_ => 1 } @{ $seq_regions{ $seq_region_id }{ attrib_type_id } };
-
-    # print "Attribs:\n";
-    # print Dumper( \%attribs );
-    
-    # if ( exists $attribs{ $karyotype_attrib_id } ) { print "$attribs{ $karyotype_attrib_id } exists.\n" };
-    # if ( exists $attribs{ $toplevel_attrib_id } ) { print "$attribs{ $toplevel_attrib_id } exists.\n" };
-    # # exit;
-
-    if ( exists $attribs{ $karyotype_attrib_id } && exists $attribs{ $toplevel_attrib_id } ) {
-      # print "TRUE\n";
-      $has_both_attribs == 1;
-      # print "Getting coord_system_dbid with $seq_region_id key\n";
-      # print "coord_system_dbid = ", $seq_regions{ $seq_region_id }{ coord_system_id }, "\n";
-      $coord_system_dbid = $seq_regions{ $seq_region_id }{ coord_system_id };
-    } else {
-      # print "FALSE\n";
-      # set as false to dismiss any coordsystems lacking both types of attrib
-      $has_both_attribs == 0;
-      $coord_system_dbid = undef;
-    }
-  }
-
-  print "coord_system_dbid: $coord_system_dbid\n";
-
-  # use appropriate 'coord_system_id' to set 'alias_to' variable for
-  my $cs = $csa->fetch_by_dbID( $coord_system_dbid );
-  print "Fetched CoordSystem with coord_system_id: $coord_system_dbid.\n";
-  $cs->alias_to('chromosome');
-  print Dumper( $cs );
-
-  return $cs;
-
-}
 
 
 =head2 _fetch_by_seq_region_synonym

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2795,7 +2795,11 @@ sub _create_chromosome_alias {
   } else {
 
     # use appropriate 'coord_system_id' to set 'alias_to' variable
+    # first check that a chromosome object does not already exist
     my $cs = $csa->fetch_by_dbID( $coord_system_id );
+    if ( $cs->name eq "chromosome" ) {
+      throw("A chromosome CoordSystem object already exists. Cannot create chromosome alias.");
+    }
     print "Fetched CoordSystem with coord_system_id: $coord_system_id.\n";
     $cs->alias_to('chromosome');
 

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -54,6 +54,14 @@ ok($slice->end   == $END);
 ok($slice->seq_region_length == 62842997);
 debug("slice seq_region length = " . $slice->seq_region_length());
 
+#
+# _create_chromosome_alias
+#
+{
+  # test that no alias can be defined for species with pre-existing chromosome coordsystem
+  throws_ok{ $slice_adaptor->_create_chromosome_alias() } qr/A chromosome CoordSystem object already exists/, 'Correctly thrown error after finding existing chromosome CoordSystem object';
+}
+exit 1;
 
 #
 # _fetch_by_seq_region_synonym

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -60,6 +60,16 @@ debug("slice seq_region length = " . $slice->seq_region_length());
 {
   # test that no alias can be defined for species with pre-existing chromosome coordsystem
   throws_ok{ $slice_adaptor->_create_chromosome_alias() } qr/A chromosome CoordSystem object already exists/, 'Correctly thrown error after finding existing chromosome CoordSystem object';
+
+  # test sliceadaptor object is created ok from Parus major test db
+  debug("Testing chromosome alias feature with Parus major slices");
+  my $parus_major_db = Bio::EnsEMBL::Test::MultiTestDB->new("parus_major1");
+  my $parus_major_dba = $parus_major_db->get_DBAdaptor("core");
+  my $parus_major_sa = Bio::EnsEMBL::DBSQL::SliceAdaptor->new($parus_major_dba);
+  isa_ok($parus_major_sa, 'Bio::EnsEMBL::DBSQL::SliceAdaptor');
+
+  ### test chromosome alias is defined for Parus major with no pre-existing chromosome coordsystem
+  ### TODO: finish and integrate branch alias_chromosome_coordsystem to be able to add in this test
 }
 
 #

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -61,7 +61,6 @@ debug("slice seq_region length = " . $slice->seq_region_length());
   # test that no alias can be defined for species with pre-existing chromosome coordsystem
   throws_ok{ $slice_adaptor->_create_chromosome_alias() } qr/A chromosome CoordSystem object already exists/, 'Correctly thrown error after finding existing chromosome CoordSystem object';
 }
-exit 1;
 
 #
 # _fetch_by_seq_region_synonym

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -57,6 +57,7 @@ debug("slice seq_region length = " . $slice->seq_region_length());
 #
 # _create_chromosome_alias
 #
+
 {
   # test that no alias can be defined for species with pre-existing chromosome coordsystem
   throws_ok{ $slice_adaptor->_create_chromosome_alias() } qr/A chromosome CoordSystem object already exists/, 'Correctly thrown error after finding existing chromosome CoordSystem object';
@@ -67,6 +68,23 @@ debug("slice seq_region length = " . $slice->seq_region_length());
   my $parus_major_dba = $parus_major_db->get_DBAdaptor("core");
   my $parus_major_sa = Bio::EnsEMBL::DBSQL::SliceAdaptor->new($parus_major_dba);
   isa_ok($parus_major_sa, 'Bio::EnsEMBL::DBSQL::SliceAdaptor');
+
+  ### make up a fake hash to test cases with multiple coordSystem objects with karyotype attributes
+  my %data;
+  $data{'1'}{'2'} = {
+    'seq_region_id' => 1,
+    'code' => 'karyotype_rank',
+    'length' => 114059860,
+    'rank' => 4
+  };
+  $data{'1'}{'3'} = {
+    'seq_region_id' => 1,
+    'code' => 'karyotype_rank',
+    'length' => 114059860,
+    'rank' => 6
+  };
+  $parus_major_sa->{'karyotype_cache'} = \%data;
+  throws_ok{ $parus_major_sa->_create_chromosome_alias() } qr/Unable to retrieve CoordSystem object using dbID: 2/, "Retrieves correct coordSystem to alias but throws error as this is example data not in db";
 
   ### test chromosome alias is defined for Parus major with no pre-existing chromosome coordsystem
   ### TODO: finish and integrate branch alias_chromosome_coordsystem to be able to add in this test


### PR DESCRIPTION
## Description 

Add private subroutine to `SliceAdaptor.pm`, which will attempt to create a chromosome alias, when requested by a user.

## Use case

If a user requests a chromosome slice object and there is no explicitly-named chromosome coordinate system in the query database, this new subroutine uses karyotype-based attributes in the database to identify a coordinate system to add an appropriate ('chromosome') alias to.

## Benefits

Where an Ensembl Core species database does not have coordinate system named chromosome, this code will create an alias to the appropriate coordinate system when a user requests a chromosome slice object, as long as the requested name has associated karyotype attributes.

## Possible Drawbacks

None I can think so.

## Testing

_Have you added/modified unit tests to test the changes?_

Adding tests. Waiting for new Parus major test db branch to be integrated before adding more tests. 

_If so, do the tests pass/fail?_

Current tests in `sliceAdaptor.t` pass.

_Have you run the entire test suite and no regression was detected?_

