### PR TITLE
ENSCORESW-3590: Create calls in fetch_by_region to _fetch_by_seq_region_synonym

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -114,7 +114,7 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::ProjectionSegment;
 use Scalar::Util qw/looks_like_number/;
 use Bio::EnsEMBL::Utils::Scalar qw/assert_integer/;
-
+use Data::Dumper;
 @ISA = ('Bio::EnsEMBL::DBSQL::BaseAdaptor');
 
 sub new {
@@ -330,6 +330,7 @@ sub fetch_by_region {
         print "Running synonym-match method...\n";
         $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       }
+      print Dumper( $slice );
 
       # check whether any slice data has been returned
       if ( $slice && $slice->seq_region_name ) {
@@ -345,26 +346,13 @@ sub fetch_by_region {
           print "Defining \$arr\n";
           my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
           $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
+          print Dumper( $arr );
           $length = $arr->[3];
         }
 
-      }
+      } else { # if no slice object with a match returned, try using a fuzzy match
 
-      if ($no_fuzz) { return; }
-
-      # Do fuzzy matching, assuming that we are just missing a version
-      # on the end of the seq_region name.
-
-      $sth =
-        $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
-
-      $bind_params[0] =
-        [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
-
-      $pos = 0;
-      foreach my $param (@bind_params) {
-        $sth->bind_param( ++$pos, $param->[0], $param->[1] );
-      }
+        if ($no_fuzz) { return; }
 
         # Do fuzzy matching, assuming that we are just missing a version
         # on the end of the seq_region name.
@@ -421,6 +409,28 @@ sub fetch_by_region {
             $high_ver        = $tmp_ver;
             $high_cs         = $tmp_cs;
           }
+
+          $i++;
+        } ## end while ( $sth->fetch )
+        $sth->finish();
+
+        # warn if fuzzy matching found more than one result
+        if ( $i > 1 ) {
+          warning(
+            sprintf(
+              "Fuzzy matching of seq_region_name "
+                . "returned more than one result.\n"
+                . "You might want to check whether the returned seq_region\n"
+                . "(%s:%s) is the one you intended to fetch.\n",
+              $high_cs->name(), $seq_region_name ) );
+        }
+
+        $cs = $high_cs;
+
+        # return if we did not find any appropriate match:
+        if ( !defined($high_ver) ) { return; }
+      }
+    } else {
 
           $i++;
         } ## end while ( $sth->fetch )

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -330,7 +330,6 @@ sub fetch_by_region {
         print "Running synonym-match method...\n";
         $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       }
-      print Dumper( $slice );
 
       # check whether any slice data has been returned
       if ( $slice && $slice->seq_region_name ) {
@@ -343,10 +342,8 @@ sub fetch_by_region {
           $seq_region_name = $matched_name;
 
           # define $arr
-          print "Defining \$arr\n";
           my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
           $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
-          print Dumper( $arr );
           $length = $arr->[3];
         }
 
@@ -588,7 +585,6 @@ sub fetch_by_toplevel_location {
 
 sub fetch_by_location {
   my ($self, $location, $coord_system_name, $coord_system_version, $no_warnings, $no_fuzz, $ucsc) = @_;
-  
   throw "No coordinate system name specified" unless $coord_system_name;
   
   my ($seq_region_name, $start, $end, $strand) = $self->parse_location_to_values($location, $no_warnings);
@@ -601,6 +597,7 @@ sub fetch_by_location {
     throw "Cannot request a slice whose start is greater than its end. Start: $start. End: $end";
   }
   
+  $seq_region_name =~ s/^chr// if ($ucsc);
   my $slice = $self->fetch_by_region($coord_system_name, $seq_region_name, $start, $end, $strand, $coord_system_version, $no_fuzz);
   if(! defined $slice) {
     if($ucsc) {

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -114,7 +114,7 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::ProjectionSegment;
 use Scalar::Util qw/looks_like_number/;
 use Bio::EnsEMBL::Utils::Scalar qw/assert_integer/;
-use Data::Dumper;
+
 @ISA = ('Bio::EnsEMBL::DBSQL::BaseAdaptor');
 
 sub new {
@@ -324,21 +324,17 @@ sub fetch_by_region {
       # deal with cases where a coordsystem might not be defined by user
       my $slice;
       if (!defined $cs) {
-        print "Running synonym-match method...\n";
         $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       } else {
-        print "Running synonym-match method...\n";
         $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       }
 
       # check whether any slice data has been returned
       if ( $slice && $slice->seq_region_name ) {
-        print "Slice data has been returned...\n";
         my $matched_name = $slice->seq_region_name;
 
         # if matched name is different to query name, skip fuzzy matching
         if ( $matched_name ne $seq_region_name ) {
-          print "Using matched name $matched_name derived from query name $seq_region_name...\n";
           $seq_region_name = $matched_name;
 
           # define $arr

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2936,7 +2936,7 @@ sub _fetch_by_seq_region_synonym {
       
     } else {
       if ($no_fuzz) {
-        throw("No synonym or wildcard match found and use fuzzy match is set to false.\n");
+        return;
       }
       return;
     }

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -433,27 +433,6 @@ sub fetch_by_region {
         # return if we did not find any appropriate match:
         if ( !defined($high_ver) ) { return; }
       }
-    } else {
-
-          $i++;
-        } ## end while ( $sth->fetch )
-        $sth->finish();
-
-        # warn if fuzzy matching found more than one result
-        if ( $i > 1 ) {
-          warning(
-            sprintf(
-              "Fuzzy matching of seq_region_name "
-                . "returned more than one result.\n"
-                . "You might want to check whether the returned seq_region\n"
-                . "(%s:%s) is the one you intended to fetch.\n",
-              $high_cs->name(), $seq_region_name ) );
-        }
-
-        $cs = $high_cs;
-
-        # return if we did not find any appropriate match:
-        if ( !defined($high_ver) ) { return; }
 
       } else {
 

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -321,59 +321,34 @@ sub fetch_by_region {
 
       unshift( @bind_params, [ $seq_region_name, SQL_VARCHAR ] );
 
-      my $pos = 0;
-      foreach my $param (@bind_params) {
-        $sth->bind_param( ++$pos, $param->[0], $param->[1] );
+      # deal with cases where a coordsystem might not be defined by user
+      my $slice;
+      if (!defined $cs) {
+        print "Running synonym-match method...\n";
+        $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
+      } else {
+        print "Running synonym-match method...\n";
+        $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       }
 
-      $sth->execute();
-      my @row = $sth->fetchrow_array();
-      $sth->finish();
+      # check whether any slice data has been returned
+      if ( $slice && $slice->seq_region_name ) {
+        print "Slice data has been returned...\n";
+        my $matched_name = $slice->seq_region_name;
 
-      unless ( @row ) {
+        # if matched name is different to query name, skip fuzzy matching
+        if ( $matched_name ne $seq_region_name ) {
+          print "Using matched name $matched_name derived from query name $seq_region_name...\n";
+          $seq_region_name = $matched_name;
 
-        # try synonyms
-        my $syn_sql = "select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? and cs.species_id =? ";
-        if (defined $coord_system_name && defined $cs) {
-          $syn_sql .= "AND cs.name = '" . $coord_system_name . "' ";
+          # define $arr
+          print "Defining \$arr\n";
+          my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
+          $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
+          $length = $arr->[3];
         }
-        if (defined $version) {
-          $syn_sql .= "AND cs.version = '" . $version . "' ";
-        }
-        my $syn_sql_sth = $self->prepare($syn_sql);
-        $syn_sql_sth->bind_param(1, $seq_region_name, SQL_VARCHAR);
-        $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER);
-        $syn_sql_sth->execute();
-        my ($new_name, $new_coord_system, $new_version);
-        $syn_sql_sth->bind_columns( \$new_name, \$new_coord_system, \$new_version);
-        if($syn_sql_sth->fetch){
-          if ((not defined($cs)) || ($cs->name eq $new_coord_system && $cs->version eq $new_version)) {
-              return $self->fetch_by_region($new_coord_system, $new_name, $start, $end, $strand, $new_version, $no_fuzz);
-          }
-        } else {
-          # Try wildcard searching if no exact synonym was found
-          $syn_sql_sth = $self->prepare($syn_sql);
-          my $escaped_seq_region_name = $seq_region_name;
-          my $escape_char = $self->dbc->db_handle->get_info(14);
-          $escaped_seq_region_name =~ s/([_%])/$escape_char$1/g;
-          $syn_sql_sth->bind_param(1, "$escaped_seq_region_name%", SQL_VARCHAR);
-          $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER); 
-          $syn_sql_sth->execute();
-          $syn_sql_sth->bind_columns( \$new_name, \$new_coord_system, \$new_version);
 
-          if($syn_sql_sth->fetch){
-            if ((not defined($cs)) || ($cs->name eq $new_coord_system && $cs->version eq $new_version)) {
-                return $self->fetch_by_region($new_coord_system, $new_name, $start, $end, $strand, $new_version, $no_fuzz);
-            } elsif ($cs->name ne $new_coord_system) {
-                warning("Searched for a known feature on coordinate system: ".$cs->dbID." but found it on: ".$new_coord_system.
-                "\n No result returned, consider searching without coordinate system or use toplevel.");
-                return;
-            }
-            
-          }
-        }
-        $syn_sql_sth->finish;
-
+      }
 
         if ($no_fuzz) { return; }
 

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -341,6 +341,7 @@ sub fetch_by_region {
           my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
           $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
           $length = $arr->[3];
+          $cs = $slice->coord_system() if (!$cs);
         }
 
       } else { # if no slice object with a match returned, try using a fuzzy match

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -330,110 +330,111 @@ sub fetch_by_region {
       my @row = $sth->fetchrow_array();
       $sth->finish();
 
-      # deal with cases where a coordsystem might not be defined by user
-      my $slice;
-      if (!defined $cs) {
-        $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
-      } else {
-        $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
-      }
+      unless ( @row ) {
 
-      # check whether any slice data has been returned
-      if ( $slice && $slice->seq_region_name ) {
-        my $matched_name = $slice->seq_region_name;
-
-        # if matched name is different to query name, skip fuzzy matching
-        if ( $matched_name ne $seq_region_name ) {
-          $seq_region_name = $matched_name;
-
-          # define $arr
-          my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
-          $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
-          $length = $arr->[3];
-          $cs = $slice->coord_system() if (!$cs);
+        # deal with cases where a coordsystem might not be defined by user
+        my $slice;
+        if (!defined $cs) {
+          $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
+        } else {
+          $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
         }
 
-      } else { # if no slice object with a match returned, try using a fuzzy match
+        # check whether any slice data has been returned
+        if ( $slice && $slice->seq_region_name ) {
+          my $matched_name = $slice->seq_region_name;
 
-        if ($no_fuzz) { return; }
+          # if matched name is different to query name, skip fuzzy matching
+          if ( $matched_name ne $seq_region_name ) {
+            $seq_region_name = $matched_name;
 
-        # Do fuzzy matching, assuming that we are just missing a version
-        # on the end of the seq_region name.
-
-        $sth =
-          $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
-
-        $bind_params[0] =
-          [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
-
-        $pos = 0;
-        foreach my $param (@bind_params) {
-          $sth->bind_param( ++$pos, $param->[0], $param->[1] );
-        }
-
-        $sth->execute();
-
-        my $prefix_len = length($seq_region_name) + 1;
-        my $high_ver   = undef;
-        my $high_cs    = $cs;
-
-        # Find the fuzzy-matched seq_region with the highest postfix
-        # (which ought to be a version).
-
-        my ( $tmp_name, $id, $tmp_length, $cs_id );
-        $sth->bind_columns( \( $tmp_name, $id, $tmp_length, $cs_id ) );
-
-        my $i = 0;
-
-        while ( $sth->fetch ) {
-          my $tmp_cs =
-            ( defined($cs) ? $cs : $csa->fetch_by_dbID($cs_id) );
-
-          # cache values for future reference
-          my $arr = [ $id, $tmp_name, $cs_id, $tmp_length ];
-          $self->{'sr_name_cache'}->{"$tmp_name:$cs_id"} = $arr;
-          $self->{'sr_id_cache'}->{"$id"}                = $arr;
-
-          my $tmp_ver = substr( $tmp_name, $prefix_len );
-
-          # skip versions which are non-numeric and apparently not
-          # versions
-          if ( $tmp_ver !~ /^\d+$/ ) { next }
-
-          # take version with highest num, if two versions match take one
-          # with highest ranked coord system (lowest num)
-          if ( !defined($high_ver)
-            || $tmp_ver > $high_ver
-            || ( $tmp_ver == $high_ver && $tmp_cs->rank < $high_cs->rank )
-            )
-          {
-            $seq_region_name = $tmp_name;
-            $length          = $tmp_length;
-            $high_ver        = $tmp_ver;
-            $high_cs         = $tmp_cs;
+            # define $arr
+            my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
+            $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
+            $length = $arr->[3];
+            $cs = $slice->coord_system() if (!$cs);
           }
 
-          $i++;
-        } ## end while ( $sth->fetch )
-        $sth->finish();
+        } else { # if no slice object with a match returned, try using a fuzzy match
 
-        # warn if fuzzy matching found more than one result
-        if ( $i > 1 ) {
-          warning(
-            sprintf(
-              "Fuzzy matching of seq_region_name "
-                . "returned more than one result.\n"
-                . "You might want to check whether the returned seq_region\n"
-                . "(%s:%s) is the one you intended to fetch.\n",
-              $high_cs->name(), $seq_region_name ) );
+          if ($no_fuzz) { return; }
+
+          # Do fuzzy matching, assuming that we are just missing a version
+          # on the end of the seq_region name.
+
+          $sth =
+            $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
+
+          $bind_params[0] =
+            [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
+
+          $pos = 0;
+          foreach my $param (@bind_params) {
+            $sth->bind_param( ++$pos, $param->[0], $param->[1] );
+          }
+
+          $sth->execute();
+
+          my $prefix_len = length($seq_region_name) + 1;
+          my $high_ver   = undef;
+          my $high_cs    = $cs;
+
+          # Find the fuzzy-matched seq_region with the highest postfix
+          # (which ought to be a version).
+
+          my ( $tmp_name, $id, $tmp_length, $cs_id );
+          $sth->bind_columns( \( $tmp_name, $id, $tmp_length, $cs_id ) );
+
+          my $i = 0;
+
+          while ( $sth->fetch ) {
+            my $tmp_cs =
+              ( defined($cs) ? $cs : $csa->fetch_by_dbID($cs_id) );
+
+            # cache values for future reference
+            my $arr = [ $id, $tmp_name, $cs_id, $tmp_length ];
+            $self->{'sr_name_cache'}->{"$tmp_name:$cs_id"} = $arr;
+            $self->{'sr_id_cache'}->{"$id"}                = $arr;
+
+            my $tmp_ver = substr( $tmp_name, $prefix_len );
+
+            # skip versions which are non-numeric and apparently not
+            # versions
+            if ( $tmp_ver !~ /^\d+$/ ) { next }
+
+            # take version with highest num, if two versions match take one
+            # with highest ranked coord system (lowest num)
+            if ( !defined($high_ver)
+              || $tmp_ver > $high_ver
+              || ( $tmp_ver == $high_ver && $tmp_cs->rank < $high_cs->rank )
+              )
+            {
+              $seq_region_name = $tmp_name;
+              $length          = $tmp_length;
+              $high_ver        = $tmp_ver;
+              $high_cs         = $tmp_cs;
+            }
+
+            $i++;
+          } ## end while ( $sth->fetch )
+          $sth->finish();
+
+          # warn if fuzzy matching found more than one result
+          if ( $i > 1 ) {
+            warning(
+              sprintf(
+                "Fuzzy matching of seq_region_name "
+                  . "returned more than one result.\n"
+                  . "You might want to check whether the returned seq_region\n"
+                  . "(%s:%s) is the one you intended to fetch.\n",
+                $high_cs->name(), $seq_region_name ) );
+          }
+
+          $cs = $high_cs;
+
+          # return if we did not find any appropriate match:
+          if ( !defined($high_ver) ) { return; }
         }
-
-        $cs = $high_cs;
-
-        # return if we did not find any appropriate match:
-        if ( !defined($high_ver) ) { return; }
-      }
-
       } else {
 
         my ( $id, $cs_id );

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -350,7 +350,21 @@ sub fetch_by_region {
 
       }
 
-        if ($no_fuzz) { return; }
+      if ($no_fuzz) { return; }
+
+      # Do fuzzy matching, assuming that we are just missing a version
+      # on the end of the seq_region name.
+
+      $sth =
+        $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
+
+      $bind_params[0] =
+        [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
+
+      $pos = 0;
+      foreach my $param (@bind_params) {
+        $sth->bind_param( ++$pos, $param->[0], $param->[1] );
+      }
 
         # Do fuzzy matching, assuming that we are just missing a version
         # on the end of the seq_region name.

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -321,6 +321,15 @@ sub fetch_by_region {
 
       unshift( @bind_params, [ $seq_region_name, SQL_VARCHAR ] );
 
+      my $pos = 0;
+      foreach my $param (@bind_params) {
+        $sth->bind_param( ++$pos, $param->[0], $param->[1] );
+      }
+
+      $sth->execute();
+      my @row = $sth->fetchrow_array();
+      $sth->finish();
+
       # deal with cases where a coordsystem might not be defined by user
       my $slice;
       if (!defined $cs) {

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -135,10 +135,11 @@ is($p_major_slice->end, "809223", "Slice end/length correctly retrieved from kar
 
 {
   # if no synonym match found and fuzzy match option is set as false,
-  # test that an error is thrown for no possible result
+  # test that undef slice is returned 
+  # (NW: undef slice expected behaviour reported by JA in Production Team)
   my $clone_name = 'AL031658';
-  throws_ok { $slice_adaptor->_fetch_by_seq_region_synonym(undef, $clone_name, '1', '1000', '1', undef, 1) }
-  qr/No synonym or wildcard match found and use fuzzy match is set to false/, 'Error correctly thrown when no synonym/wildcard/fuzzy match can be made';
+  my $slice = $slice_adaptor->_fetch_by_seq_region_synonym(undef, $clone_name, '1', '1000', '1', undef, 1);
+  ok(!defined $slice);
 }
 
 # ensure that seq_region_name is provided


### PR DESCRIPTION
## Description

Add in calls from `fetch_by_region` to `_fetch_by_seq_region_synonym`. Remove the code from `fetch_by_region` that has been refactored into `_fetch_by_seq_region_synonym`.

## Use case

Any `fetch_by_region` examples that use a synonym or synonym-wildcard as the sequence region name input argument.

## Benefits

Will simplify SliceAdaptor::fetch_by_region.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Pass.

_Have you run the entire test suite and no regression was detected?_

Test suite passes.