### PR TITLE
ENSCORESW-3548: don't add clone names if nothing else available

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
@@ -49,7 +49,6 @@ use base qw( XrefMapper::BasicMapper);
 #               ii)  RFAM
 #               iii) miRBase
 #               iv)   EntrezGene
-#               v) Clone name
 #
 #      NOTE: for "i)" above, if more than one exists we find the "best" one if possible
 #            and remove the other ones. If there is more than one "best" we keep all and


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Remove clone name assignment step in OfficialNaming module.

## Use case

For merged species (human, mouse, rat, zebrafish), the OfficialNaming module adds clone names when no xref is suitable to be used as display xref.
These clone names are not useful any more and it is better to leave the genes without a display xref, defaulting to the Ensembl stable ID instead.
The proposed code change removes the step assigning those clone names

## Benefits

No more clone names.
OfficialNaming code is simplified.
Display_xref assignment is quicker, as the last step is removed.

## Possible Drawbacks

Some genes have no display_xref and default to stable ID instead

## Testing

_Have you added/modified unit tests to test the changes?_
There are no test cases for the mapping part of the xref pipline.
The whole pipeline has been run on all four merged species twice, with the code on master and with the proposed code changes.

_If so, do the tests pass/fail?_
The pipeline runs through to the end with the proposed changes.
The assigned display xref are comparable between the two runs, apart from the clone names which are not assigned when running the updated code.

_Have you run the entire test suite and no regression was detected?_
NA
