### PR TITLE
ENSCORESW-3600: Add calls to new chromosome alias subroutine

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -251,14 +251,25 @@ sub fetch_by_region {
   my $key;
 
   if ( defined($cs) ) {
-    $sql = sprintf( "SELECT sr.name, sr.seq_region_id, sr.length, %d "
-                      . "FROM seq_region sr ",
-                    $cs->dbID() );
 
-    $constraint = "AND sr.coord_system_id = ?";
-    push( @bind_params, [ $cs->dbID(), SQL_INTEGER ] );
+    # if chromosome alias is defined, use karyotype_cache to access seq region data
+    # rather than a database query
+    if ( $cs->alias_to() eq "chromosome" ) {
 
-    $key = "$seq_region_name:" . $cs->dbID();
+      $key = "karyotype_cache";
+
+    } else { # otherwise, search database to access seq region data, etc.
+
+      $sql = sprintf( "SELECT sr.name, sr.seq_region_id, sr.length, %d "
+                        . "FROM seq_region sr ",
+                      $cs->dbID() );
+
+      $constraint = "AND sr.coord_system_id = ?";
+      push( @bind_params, [ $cs->dbID(), SQL_INTEGER ] );
+
+      $key = "$seq_region_name:" . $cs->dbID();
+      
+    }
   } else {
     $sql =
       "SELECT sr.name, sr.seq_region_id, sr.length, cs.coord_system_id "

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -224,9 +224,17 @@ sub fetch_by_region {
     $cs = $csa->fetch_by_name( $coord_system_name, $version );
 
     if ( !defined($cs) ) {
-      throw( sprintf( "Unknown coordinate system:\n"
-                        . "name='%s' version='%s'\n",
-                      $coord_system_name, $version ) );
+      # deal with cases where undefined coordsystem name requested is 'chromosome'
+      if ( $coord_system_name eq "chromosome" ) {
+
+        # set the 'chromosome' alias, if not yet set
+        $cs = $self->_create_chromosome_alias();
+
+      } else {
+        throw( sprintf( "Unknown coordinate system:\n"
+                  . "name='%s' version='%s' seq region name='%s'\n",
+                $coord_system_name, $version, $seq_region_name ) );
+      }
     }
 
     # fetching by toplevel is same as fetching w/o name or version


### PR DESCRIPTION
## Description

Add in calls to the new subroutine (_create_chromosome_alias) in fetch_by_region. Also, create a karyotype data-based cache to avoid having to run a big database query more than once.

## Use case

If a user requests a chromosome slice object and there is no explicitly-named chromosome coordinate system in the query database, this new feature uses karyotype-based attributes in the database to identify a coordinate system to add an appropriate ('chromosome') alias to.

## Benefits

Allows users to access chromosome slice data more easily via the Perl API.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

