### PR TITLE
[ENSCORESW-3562] Create call in fetch_by_region to _fetch_by_fuzzy_matching

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -313,6 +313,7 @@ sub fetch_by_region {
 
     if ( defined($key) ) { $arr = $self->{'sr_name_cache'}->{$key} }
 
+<<<<<<< HEAD
     if ( defined($arr) ) {
       $length = $arr->[3];
     } else {
@@ -339,6 +340,78 @@ sub fetch_by_region {
         } else {
           $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
         }
+=======
+      # deal with cases where a coordsystem might not be defined by user
+      my $slice;
+      if (!defined $cs) {
+        print "Running synonym-match method...\n";
+        $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
+      } else {
+        print "Running synonym-match method...\n";
+        $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
+      }
+
+      # check whether any slice data has been returned
+      if ( $slice && $slice->seq_region_name ) {
+        print "Slice data has been returned...\n";
+        my $matched_name = $slice->seq_region_name;
+
+        # if matched name is different to query name, skip fuzzy matching
+        if ( $matched_name ne $seq_region_name ) {
+          print "Using matched name $matched_name derived from query name $seq_region_name...\n";
+          $seq_region_name = $matched_name;
+
+          # define $arr
+          print "Defining \$arr\n";
+          my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
+          $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
+          $length = $arr->[3];
+        }
+
+      }
+
+      # # try synonyms
+      # my $syn_sql = "select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? and cs.species_id =? ";
+      # if (defined $coord_system_name && defined $cs) {
+      #   $syn_sql .= "AND cs.name = '" . $coord_system_name . "' ";
+      # }
+      # if (defined $version) {
+      #   $syn_sql .= "AND cs.version = '" . $version . "' ";
+      # }
+      # my $syn_sql_sth = $self->prepare($syn_sql);
+      # $syn_sql_sth->bind_param(1, $seq_region_name, SQL_VARCHAR);
+      # $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER);
+      # $syn_sql_sth->execute();
+      # my ($new_name, $new_coord_system, $new_version);
+      # $syn_sql_sth->bind_columns( \$new_name, \$new_coord_system, \$new_version);
+      # if($syn_sql_sth->fetch){
+      #   if ((not defined($cs)) || ($cs->name eq $new_coord_system && $cs->version eq $new_version)) {
+      #       return $self->fetch_by_region($new_coord_system, $new_name, $start, $end, $strand, $new_version, $no_fuzz);
+      #   }
+      # } else {
+      #   # Try wildcard searching if no exact synonym was found
+      #   $syn_sql_sth = $self->prepare($syn_sql);
+      #   my $escaped_seq_region_name = $seq_region_name;
+      #   my $escape_char = $self->dbc->db_handle->get_info(14);
+      #   $escaped_seq_region_name =~ s/([_%])/$escape_char$1/g;
+      #   $syn_sql_sth->bind_param(1, "$escaped_seq_region_name%", SQL_VARCHAR);
+      #   $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER); 
+      #   $syn_sql_sth->execute();
+      #   $syn_sql_sth->bind_columns( \$new_name, \$new_coord_system, \$new_version);
+
+      #   if($syn_sql_sth->fetch){
+      #     if ((not defined($cs)) || ($cs->name eq $new_coord_system && $cs->version eq $new_version)) {
+      #         return $self->fetch_by_region($new_coord_system, $new_name, $start, $end, $strand, $new_version, $no_fuzz);
+      #     } elsif ($cs->name ne $new_coord_system) {
+      #         warning("Searched for a known feature on coordinate system: ".$cs->dbID." but found it on: ".$new_coord_system.
+      #         "\n No result returned, consider searching without coordinate system or use toplevel.");
+      #         return;
+      #     }
+          
+      #   }
+      # }
+      # $syn_sql_sth->finish;
+>>>>>>> Add calls to synonym sub and check if slice data returned
 
         # check whether any slice data has been returned
         if ( $slice && $slice->seq_region_name ) {

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -344,21 +344,17 @@ sub fetch_by_region {
       # deal with cases where a coordsystem might not be defined by user
       my $slice;
       if (!defined $cs) {
-        print "Running synonym-match method...\n";
         $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       } else {
-        print "Running synonym-match method...\n";
         $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
       }
 
       # check whether any slice data has been returned
       if ( $slice && $slice->seq_region_name ) {
-        print "Slice data has been returned...\n";
         my $matched_name = $slice->seq_region_name;
 
         # if matched name is different to query name, skip fuzzy matching
         if ( $matched_name ne $seq_region_name ) {
-          print "Using matched name $matched_name derived from query name $seq_region_name...\n";
           $seq_region_name = $matched_name;
 
           # define $arr

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -362,7 +362,6 @@ sub fetch_by_region {
           $seq_region_name = $matched_name;
 
           # define $arr
-          print "Defining \$arr\n";
           my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
           $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
           $length = $arr->[3];

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -2927,7 +2927,7 @@ sub _fetch_by_fuzzy_matching {
   my $sth =
     $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
 
-  unshift @$bind_params, [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
+  @$bind_params[0] = [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
   
   my $pos = 0;
   foreach my $param (@$bind_params) {

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -313,7 +313,6 @@ sub fetch_by_region {
 
     if ( defined($key) ) { $arr = $self->{'sr_name_cache'}->{$key} }
 
-<<<<<<< HEAD
     if ( defined($arr) ) {
       $length = $arr->[3];
     } else {
@@ -331,16 +330,8 @@ sub fetch_by_region {
       my @row = $sth->fetchrow_array();
       $sth->finish();
 
-      unless ( @row ) {
+    unless ( @row ) {
 
-        # deal with cases where a coordsystem might not be defined by user
-        my $slice;
-        if (!defined $cs) {
-          $slice = $self->_fetch_by_seq_region_synonym( undef, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
-        } else {
-          $slice = $self->_fetch_by_seq_region_synonym( $cs, $seq_region_name, $start, $end, $strand, $version, $no_fuzz );
-        }
-=======
       # deal with cases where a coordsystem might not be defined by user
       my $slice;
       if (!defined $cs) {
@@ -364,159 +355,40 @@ sub fetch_by_region {
           $cs = $slice->coord_system() if (!$cs);
         }
 
-      }
+      } else { # if no slice object with a match returned, try using a fuzzy match
+        if (!$no_fuzz) {
 
-      # # try synonyms
-      # my $syn_sql = "select s.name, cs.name, cs.version from seq_region s join seq_region_synonym ss using (seq_region_id) join coord_system cs using (coord_system_id) where ss.synonym like ? and cs.species_id =? ";
-      # if (defined $coord_system_name && defined $cs) {
-      #   $syn_sql .= "AND cs.name = '" . $coord_system_name . "' ";
-      # }
-      # if (defined $version) {
-      #   $syn_sql .= "AND cs.version = '" . $version . "' ";
-      # }
-      # my $syn_sql_sth = $self->prepare($syn_sql);
-      # $syn_sql_sth->bind_param(1, $seq_region_name, SQL_VARCHAR);
-      # $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER);
-      # $syn_sql_sth->execute();
-      # my ($new_name, $new_coord_system, $new_version);
-      # $syn_sql_sth->bind_columns( \$new_name, \$new_coord_system, \$new_version);
-      # if($syn_sql_sth->fetch){
-      #   if ((not defined($cs)) || ($cs->name eq $new_coord_system && $cs->version eq $new_version)) {
-      #       return $self->fetch_by_region($new_coord_system, $new_name, $start, $end, $strand, $new_version, $no_fuzz);
-      #   }
-      # } else {
-      #   # Try wildcard searching if no exact synonym was found
-      #   $syn_sql_sth = $self->prepare($syn_sql);
-      #   my $escaped_seq_region_name = $seq_region_name;
-      #   my $escape_char = $self->dbc->db_handle->get_info(14);
-      #   $escaped_seq_region_name =~ s/([_%])/$escape_char$1/g;
-      #   $syn_sql_sth->bind_param(1, "$escaped_seq_region_name%", SQL_VARCHAR);
-      #   $syn_sql_sth->bind_param(2, $self->species_id(), SQL_INTEGER); 
-      #   $syn_sql_sth->execute();
-      #   $syn_sql_sth->bind_columns( \$new_name, \$new_coord_system, \$new_version);
+          my ($fuzzy_matched_name, $cs) = $self->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
 
-      #   if($syn_sql_sth->fetch){
-      #     if ((not defined($cs)) || ($cs->name eq $new_coord_system && $cs->version eq $new_version)) {
-      #         return $self->fetch_by_region($new_coord_system, $new_name, $start, $end, $strand, $new_version, $no_fuzz);
-      #     } elsif ($cs->name ne $new_coord_system) {
-      #         warning("Searched for a known feature on coordinate system: ".$cs->dbID." but found it on: ".$new_coord_system.
-      #         "\n No result returned, consider searching without coordinate system or use toplevel.");
-      #         return;
-      #     }
-          
-      #   }
-      # }
-      # $syn_sql_sth->finish;
->>>>>>> Add calls to synonym sub and check if slice data returned
+          if (!$fuzzy_matched_name) {
+            return;
+          }
 
-        # check whether any slice data has been returned
-        if ( $slice && $slice->seq_region_name ) {
-          my $matched_name = $slice->seq_region_name;
-
-          # if matched name is different to query name, skip fuzzy matching
-          if ( $matched_name ne $seq_region_name ) {
-            $seq_region_name = $matched_name;
-
-            # define $arr
-            my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
+          # define arr
+          my $tmp_key_string = $fuzzy_matched_name . ":" . $cs->dbID();
+          if (exists $self->{'sr_name_cache'}->{$tmp_key_string}) {
+            $seq_region_name = $fuzzy_matched_name;
             $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
             $length = $arr->[3];
-            $cs = $slice->coord_system() if (!$cs);
+          } else {
+            return;
           }
-
-        } else { # if no slice object with a match returned, try using a fuzzy match
-
-          if ($no_fuzz) { return; }
-
-          # Do fuzzy matching, assuming that we are just missing a version
-          # on the end of the seq_region name.
-
-          $sth =
-            $self->prepare( $sql . " WHERE sr.name LIKE ? " . $constraint );
-
-          $bind_params[0] =
-            [ sprintf( '%s.%%', $seq_region_name ), SQL_VARCHAR ];
-
-          $pos = 0;
-          foreach my $param (@bind_params) {
-            $sth->bind_param( ++$pos, $param->[0], $param->[1] );
-          }
-
-          $sth->execute();
-
-          my $prefix_len = length($seq_region_name) + 1;
-          my $high_ver   = undef;
-          my $high_cs    = $cs;
-
-          # Find the fuzzy-matched seq_region with the highest postfix
-          # (which ought to be a version).
-
-          my ( $tmp_name, $id, $tmp_length, $cs_id );
-          $sth->bind_columns( \( $tmp_name, $id, $tmp_length, $cs_id ) );
-
-          my $i = 0;
-
-          while ( $sth->fetch ) {
-            my $tmp_cs =
-              ( defined($cs) ? $cs : $csa->fetch_by_dbID($cs_id) );
-
-            # cache values for future reference
-            my $arr = [ $id, $tmp_name, $cs_id, $tmp_length ];
-            $self->{'sr_name_cache'}->{"$tmp_name:$cs_id"} = $arr;
-            $self->{'sr_id_cache'}->{"$id"}                = $arr;
-
-            my $tmp_ver = substr( $tmp_name, $prefix_len );
-
-            # skip versions which are non-numeric and apparently not
-            # versions
-            if ( $tmp_ver !~ /^\d+$/ ) { next }
-
-            # take version with highest num, if two versions match take one
-            # with highest ranked coord system (lowest num)
-            if ( !defined($high_ver)
-              || $tmp_ver > $high_ver
-              || ( $tmp_ver == $high_ver && $tmp_cs->rank < $high_cs->rank )
-              )
-            {
-              $seq_region_name = $tmp_name;
-              $length          = $tmp_length;
-              $high_ver        = $tmp_ver;
-              $high_cs         = $tmp_cs;
-            }
-
-            $i++;
-          } ## end while ( $sth->fetch )
-          $sth->finish();
-
-          # warn if fuzzy matching found more than one result
-          if ( $i > 1 ) {
-            warning(
-              sprintf(
-                "Fuzzy matching of seq_region_name "
-                  . "returned more than one result.\n"
-                  . "You might want to check whether the returned seq_region\n"
-                  . "(%s:%s) is the one you intended to fetch.\n",
-                $high_cs->name(), $seq_region_name ) );
-          }
-
-          $cs = $high_cs;
-
-          # return if we did not find any appropriate match:
-          if ( !defined($high_ver) ) { return; }
+        } else {
+          return;
         }
-      } else {
-
-        my ( $id, $cs_id );
-        ( $seq_region_name, $id, $length, $cs_id ) = @row;
-
-        # cache to speed up for future queries
-        my $arr = [ $id, $seq_region_name, $cs_id, $length ];
-        $self->{'sr_name_cache'}->{"$seq_region_name:$cs_id"} = $arr;
-        $self->{'sr_id_cache'}->{"$id"}                       = $arr;
-        $cs = $csa->fetch_by_dbID($cs_id);
       }
-    } ## end else [ if ( defined($arr) ) ]
-  }
+    } else {
+
+      my ( $id, $cs_id );
+      ( $seq_region_name, $id, $length, $cs_id ) = @row;
+
+      # cache to speed up for future queries
+      my $arr = [ $id, $seq_region_name, $cs_id, $length ];
+      $self->{'sr_name_cache'}->{"$seq_region_name:$cs_id"} = $arr;
+      $self->{'sr_id_cache'}->{"$id"}                       = $arr;
+      $cs = $csa->fetch_by_dbID($cs_id);
+    }
+  } ## end else [ if ( defined($arr) ) ]
 
   if ( !defined($end) ) { $end = $length }
 

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -361,6 +361,7 @@ sub fetch_by_region {
           my $tmp_key_string = "$seq_region_name:" . $slice->coord_system()->dbID();
           $arr = $self->{'sr_name_cache'}->{$tmp_key_string};
           $length = $arr->[3];
+          $cs = $slice->coord_system() if (!$cs);
         }
 
       }

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -158,7 +158,7 @@ throws_ok{ $slice_adaptor->_fetch_by_seq_region_synonym(undef, undef) }
     . "AND cs.species_id = ? "
     . "ORDER BY cs.rank ASC";
   my @bind_params;
-  push( @bind_params, [ $db->species_id() ] );
+  $bind_params[1] = [ $db->species_id() ];
   my ($fuzzy_matched_name, $cs) = $slice_adaptor->_fetch_by_fuzzy_matching( undef, $seq_region_name, $sql, $constraint, \@bind_params );
   is($fuzzy_matched_name, 'AL031658.11', "Checking fuzzy match found: $fuzzy_matched_name equals that expected: AL031658.11");
   isa_ok($cs, 'Bio::EnsEMBL::CoordSystem');
@@ -174,11 +174,10 @@ throws_ok{ $slice_adaptor->_fetch_by_seq_region_synonym(undef, undef) }
                     $cs->dbID() );
   my $constraint = "AND sr.coord_system_id = ?";
   my @bind_params;
-  push( @bind_params, [ $cs->dbID() ] );
+  $bind_params[1] = [ $cs->dbID() ];
   my ($fuzzy_matched_name) = $slice_adaptor->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
   is($fuzzy_matched_name, 'AL031658.11', "Checking fuzzy match found: $fuzzy_matched_name equals that expected: AL031658.11");
 }
-
 
 #
 # fetch_by_contig_name


### PR DESCRIPTION
## Description

Add in calls from `fetch_by_region` to `_fetch_by_fuzzy_matching`. Remove the code from `fetch_by_region` that has been refactored into `_fetch_by_fuzzy_matching`.

## Use case

Any fetch_by_region examples that fuzzy match to the sequence region name input argument.

## Benefits

Will simplify SliceAdaptor::fetch_by_region.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_

No extra tests have been added in. Tests were added in to test `_fetch_by_fuzzy_matching` in a previous PR.

_If so, do the tests pass/fail?_

Tests all pass.

_Have you run the entire test suite and no regression was detected?_

The test suite passes.