### PR TITLE
ENSCORESW-3591: clean up deprecated methods

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/danio_rerio.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/danio_rerio.pm
@@ -42,48 +42,10 @@ sub get_official_name{
    return "ZFIN_ID";
 }
 
-sub get_canonical_name{
-   return "ZFIN_ID";
-}
-
 # Not running transcript_names_from_gene for merged species
 # as this is already been done in the OfficialNaming mapper
 sub transcript_names_from_gene {
   return;
 }
-
-
-sub species_specific_pre_attributes_set{
-  my $self  = shift;
-  $self->official_naming();
-}
-
-sub species_specific_cleanup{
-  my $self = shift;
-  my $dbname = $self->get_canonical_name;
-
-  print "Removing all $dbname from object_xref not on a Gene\n";
-  my $remove_old_ones = (<<JSQL);
-delete ox
-  from object_xref ox, xref x, external_db e
-    where e.db_name like "$dbname" and
-          ox.ensembl_object_type != "Gene" and
-          ox.xref_id = x.xref_id and
-          x.external_db_id = e.external_db_id;
-JSQL
-
-  #
-  # First Delete all the hgnc object_xrefs not on a gene. (i.e these are copys).
-  #
-
-  my $sth = $self->core->dbc->prepare($remove_old_ones);
-
-  $sth->execute() || die "Could not execute: \n$remove_old_ones \n";
-
-  $sth->finish;
-
-}
-
-
 
 1;

--- a/misc-scripts/xref_mapping/XrefMapper/homo_sapiens.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/homo_sapiens.pm
@@ -31,41 +31,10 @@ sub get_official_name{
    return "HGNC";
 }
 
-sub get_canonical_name{
-   return "HGNC";
-}
-
 # Not running transcript_names_from_gene for merged species
 # as this is already been done in the OfficialNaming mapper
 sub transcript_names_from_gene {
   return;
-}
-
-
-sub species_specific_cleanup{
-  my $self = shift;
-  my $dbname = $self->get_canonical_name;
-
-  print "Removing all $dbname from object_xref not on a Gene\n";
-  my $remove_old_ones = (<<JSQL);
-delete ox 
-  from object_xref ox, xref x, external_db e
-    where e.db_name like "$dbname" and 
-          ox.ensembl_object_type != "Gene" and
-          ox.xref_id = x.xref_id and
-	  x.external_db_id = e.external_db_id;
-JSQL
-
-  #
-  # First Delete all the hgnc object_xrefs not on a gene. (i.e these are copys).
-  #
-
-  my $sth = $self->core->dbc->prepare($remove_old_ones);
-
-  $sth->execute() || die "Could not execute: \n$remove_old_ones \n";
-
-  $sth->finish;
-
 }
 
 

--- a/misc-scripts/xref_mapping/XrefMapper/mus_musculus.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/mus_musculus.pm
@@ -44,86 +44,10 @@ sub get_official_name{
    return "MGI";
 }
 
-sub get_canonical_name{
-   return "MGI";
-}
-
 # Not running transcript_names_from_gene for merged species
 # as this is already been done in the OfficialNaming mapper
 sub transcript_names_from_gene {
   return;
 }
-
-sub species_specific_pre_attributes_set{
-  my $self  = shift;
-  $self->official_naming();
-}
-
-sub species_specific_cleanup{
-  my $self = shift;
-  my $dbname = $self->get_canonical_name;
-
-  print "Removing all $dbname from object_xref not on a Gene\n";
-  my $remove_old_ones = (<<JSQL);
-delete ox 
-  from object_xref ox, xref x, external_db e
-    where e.db_name like "$dbname" and 
-          ox.ensembl_object_type != "Gene" and
-          ox.xref_id = x.xref_id and
-	  x.external_db_id = e.external_db_id;
-JSQL
-
-  #
-  # First Delete all the hgnc object_xrefs not on a gene. (i.e these are copys).
-  #
-
-  my $sth = $self->core->dbc->prepare($remove_old_ones);
-
-  $sth->execute() || die "Could not execute: \n$remove_old_ones \n";
-
-  $sth->finish;
-
-}
-
-sub special_filter {
-
-  return ('\(?[0-9A-Z]{10}RIK PROTEIN\)?[ \.]',
-	  'RIKEN CDNA [0-9A-Z]{10} GENE',
-	  '.*RIKEN FULL-LENGTH ENRICHED LIBRARY.*PRODUCT:',
-	  '.*RIKEN FULL-LENGTH ENRICHED LIBRARY.*',
-	  '\(*HYPOTHETICAL\s+.*',
-	  '^UNKNOWN\s+.*',
-	  'CDNA SEQUENCE\s?,? [A-Z]+\d+[ \.;]',
-	  'CLONE MGC:\d+[ \.;]',
-	  ' MGC:\s*\d+[ \.;]',
-	  'HYPOTHETICAL PROTEIN,',
-	  'HYPOTHETICAL PROTEIN \S+[\.;]',
-	  'DNA SEGMENT, CHR.*',
-	  'PROTEIN \S+ HOMOLOG\.?',
-	  '^SIMILAR TO GENE.*',
-	  'SIMILAR TO PUTATIVE[ \.]',
-	  '^SIMILAR TO HYPOTHETICAL.*',
-	  'SIMILAR TO (KIAA|LOC|RIKEN).*',
-	  'SIMILAR TO GENBANK ACCESSION NUMBER\s+\S+',
-	  'SIMILAR TO\s+$',
-          'EXPRESSED SEQUENCE [A-Z]+\d+[ \.;]',
-          'EST [A-Z]+\d+[ \.;]',
-          '^\s*\(FRAGMENT\)\.?\s*$',
-	  '^\s*\(?GENE\)?\.?;?\s*$',
-          '\s*\(?GENE\)?\.?;?',
-          '\s*\(?PRECURSOR\)?\.?;?',
-          '^\s*\(\s*\)\s*$',
-	  '^\s*\(\d*\)\s*[ \.]$',
-          '^\s+\(?\s*$');
-}
-
-
-#sub get_list_of_sources_for_one_max_per_transcript{
-#  my $self = shift;
-
-#  my @list = qw(MGI);
-
-#  return @list;
-#}
 
 1;

--- a/misc-scripts/xref_mapping/XrefMapper/rattus_norvegicus.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/rattus_norvegicus.pm
@@ -29,10 +29,6 @@ sub get_official_name {
   return 'RGD';
 }
 
-sub get_canonical_name{
-   return "RGD";
-}
-
 # Not running transcript_names_from_gene for merged species
 # as this is already been done in the OfficialNaming mapper
 sub transcript_names_from_gene {

--- a/misc-scripts/xref_mapping/XrefMapper/sus_scrofa.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/sus_scrofa.pm
@@ -32,10 +32,6 @@ sub get_official_name{
    return "PIGGY";
 }
 
-sub get_canonical_name{
-   return "PIGGY";
-}
-
 # Not running transcript_names_from_gene for merged species
 # as this is already beng done in the OfficialNaming mapper
 sub transcript_names_from_gene {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Some species have a separate config file to overwrite methods in various Mapper modules.
Some of these methods are not used any more and making maintenance of the config files difficult.
The proposed change removes any method that is not used in other modules.

## Use case

Remove species-specific configuration that is not used.

## Benefits

Code is cleaner and easier to maintain.

## Possible Drawbacks

NA

## Testing

_Have you added/modified unit tests to test the changes?_
No test cases available for the mapping part of the xref pipeline.
The methods removed are not found any where else in the whole repository

_If so, do the tests pass/fail?_
NA

_Have you run the entire test suite and no regression was detected?_
NA
