### PR TITLE
Fix/metadata db versionned

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -2919,7 +2919,8 @@ sub version_check {
     }
 
     # ensembl_metadata was unversioned prior to release 96
-    if ( $dba->dbc()->dbname() eq 'ensembl_metadata' ) {
+      # we now have multiple pattern for metadata db name (qrp and grch37) - valid until we merge those.
+    if ( $dba->dbc()->dbname() =~ /ensembl_metadata(\_?(qrp|grch37)?)/s ) {
       return 1;
     }
     # ncbi_taxonomy was unversioned prior to release 100
@@ -2934,6 +2935,7 @@ sub version_check {
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_help_(\d+)/x ) {
       $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ / ensembl_metadata_(\d+) /msx ) {
+        # Prior to release 96 metadata is supposed to be versionned on meta-1. Not the case since
       $database_version = $1;
     } elsif ( $dba->dbc()->dbname() =~ /ensembl_ontology_(\d+)/x ) {
       $database_version = $1;


### PR DESCRIPTION
## Requirements

## Description

Fix a unwanted warning message about specific metadata database naming error: (from ENSPROD-6279 for context):

> No database version for database ensembl_metadata_qrp . You must be using a post version 34 database with version 34 or later code.
> You need to update your database or use the appropriate Ensembl software release to ensure your script does not crash
> For ensembl_metadata_qrp@mysql-ens-meta-prod-1 there is a difference in the software release (101) and the database release (0). You should update one of these to ensure that your script does not crash.

## Use case

When using metadata report_genome.pl script but this may apply to any script using registry against Rapid Release or GRCH37 dedicated metadata databases.

## Benefits

No more warning! :-)

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_ No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_ No wait for travis to do it. 

