### PR TITLE
ENSCORESW-3609: only use best transcript if no best translation

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
@@ -359,9 +359,12 @@ sub run_script {
                   $best_score = $score;
                 }
               }
-            } elsif ($score >= $best_score) {
-              $best_id = $tid;
-              $best_score = $score;
+            }
+            if (!defined $best_id) { 
+              if ($score >= $best_score) {
+                $best_id = $tid;
+                $best_score = $score;
+              }
             }
           }
         }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Select best transcript only if no best translation found.

## Use case

When selecting the best RefSeq match, we consider first the best translation match, then the best transcript match.
In a few cases, we end up selecting a transcript that is not the best translation match.
This happens if the best translation is selected first, then overwritten by the next transcript, which has the same transcript score or better.

## Benefits

We choose the best translation match where available.

## Possible Drawbacks

NA

## Testing

_Have you added/modified unit tests to test the changes?_
There are no test cases for this parser. The code change was run on human and the reported mismatches were fixed.
The results were compared to a complete run on human prior to the code change, the same number of transcripts were matched and there were a few more peptides matches.

_If so, do the tests pass/fail?_
NA
_Have you run the entire test suite and no regression was detected?_
NA

