### PR TITLE
Bugfix/access karyotype cache fix

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -294,13 +294,20 @@ sub fetch_by_region {
   # use $key to access karyotype cache and define $arr
   if ( defined($key) && ($key eq "karyotype_cache") ) {
     
+    my $coord_system_id = $cs->dbID();
+    
     # retrieve values from karyotype cache
-    my $coord_system_id = $cs->{$key}{$seq_region_name}{'coord_system_id'};
-    my $seq_region_id   = $cs->{$key}{$seq_region_name}{'seq_region_id'};
-    $length             = $cs->{$key}{$seq_region_name}{'length'};
+    my $seq_region_id   = $cs->{$key}{$seq_region_name}{$coord_system_id}{'seq_region_id'};
+    $length             = $cs->{$key}{$seq_region_name}{$coord_system_id}{'length'};
 
     # populate $arr with values from karyotype cache
     $arr = [ $seq_region_name, $seq_region_id, $length, $coord_system_id ];
+
+    # define $end, if not yet defined
+    if ( !defined($end) ) { $end = $length }
+
+    # add in check that $arr is populated
+    throw("Unable to popular $arr with values from karyotype cache") unless $arr;
 
   } else {
 

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -36,6 +36,10 @@ ok(1);
 my $multi = Bio::EnsEMBL::Test::MultiTestDB->new;
 my $db    = $multi->get_DBAdaptor('core');
 
+# parus major-related variables
+my $parus_major_db = Bio::EnsEMBL::Test::MultiTestDB->new("parus_major1");
+my $parus_major_dba = $parus_major_db->get_DBAdaptor("core");
+my $parus_major_sa = Bio::EnsEMBL::DBSQL::SliceAdaptor->new($parus_major_dba);
 
 #
 # SliceAdaptor::new
@@ -54,13 +58,15 @@ ok($slice->end   == $END);
 ok($slice->seq_region_length == 62842997);
 debug("slice seq_region length = " . $slice->seq_region_length());
 
+# test a slice can be returned correctly
+my $p_major_slice = $parus_major_sa->fetch_by_region( 'chromosome', '25LG2' );
+print Dumper($p_major_slice);
+is($p_major_slice->end, "809223", "Slice end/length correctly retrieved from karyotype cache");
+
 #
 # _create_chromosome_alias
 #
 
-my $parus_major_db = Bio::EnsEMBL::Test::MultiTestDB->new("parus_major1");
-my $parus_major_dba = $parus_major_db->get_DBAdaptor("core");
-my $parus_major_sa = Bio::EnsEMBL::DBSQL::SliceAdaptor->new($parus_major_dba);
 {
   # test that no alias can be defined for species with pre-existing chromosome coordsystem
   debug("Testing chromosome alias feature");

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -60,7 +60,6 @@ debug("slice seq_region length = " . $slice->seq_region_length());
 
 # test a slice can be returned correctly
 my $p_major_slice = $parus_major_sa->fetch_by_region( 'chromosome', '25LG2' );
-print Dumper($p_major_slice);
 is($p_major_slice->end, "809223", "Slice end/length correctly retrieved from karyotype cache");
 
 #


### PR DESCRIPTION
## Description

Adding fix to retrieving data from karyotype cache.

## Use case

Printing a slice from Parus major (for example), or any species with a 'primary_assembly' coordinate system aliased with 'chromosome' will currently return an empty 'end' string in the Slice object. The karyotype cache has a data structure to allow for the storage of multiple coordinate systems with karyotype attributes, from which one of these would be chosen to be aliased. This PR fixes a bug to correctly retrieve data from the karyotype cache.

## Benefits

Bug fix. No more undef in the Slice object that should not be undef.

## Possible Drawbacks

None that I'm aware of.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

The tests pass.

_Have you run the entire test suite and no regression was detected?_

Test build passes.