### PR TITLE
stable_id mapping updates: replace production-rh7 queue to production-rh74

### DIFF
--- a/misc-scripts/id_mapping/default.conf
+++ b/misc-scripts/id_mapping/default.conf
@@ -40,9 +40,9 @@ build_cache_concurrent_jobs = 25
 ;biotypes_exclude=protein_coding,pseudogene,retrotransposed
 
 ;; LSF parameters
-lsf_opt_run_small           = "-q production-rh7 "
-lsf_opt_run                 = "-q production-rh7 -We 90 -M12000 -R 'select[mem>12000]' -R  'rusage[mem=12000]'"
-lsf_opt_dump_cache          = "-q production-rh7 -We 5 -M4000 -R 'select[mem>4000]'  -R 'rusage[mem=4000]'"
+lsf_opt_run_small           = "-q production-rh74 "
+lsf_opt_run                 = "-q production-rh74 -We 90 -M12000 -R 'select[mem>12000]' -R  'rusage[mem=12000]'"
+lsf_opt_dump_cache          = "-q production-rh74 -We 5 -M4000 -R 'select[mem>4000]'  -R 'rusage[mem=4000]'"
 
 transcript_score_threshold  = 0.25
 gene_score_threshold        = 0.125
@@ -54,10 +54,10 @@ exonerate_bytes_per_job     = 2500000
 exonerate_concurrent_jobs   = 200
 exonerate_threshold         = 0.5
 exonerate_extra_params      = '--bestn 100'
-lsf_opt_exonerate           = "-q production-rh7 -We 10 -M8000 -R 'select[mem>8000]' -R 'rusage[mem=8000]'"
+lsf_opt_exonerate           = "-q production-rh74 -We 10 -M8000 -R 'select[mem>8000]' -R 'rusage[mem=8000]'"
 
 synteny_rescore_jobs        = 20
-lsf_opt_synteny_rescore     = "-q production-rh7 -We 10 -M8000 -R 'select[mem>8000]' -R  'rusage[mem=8000]'"
+lsf_opt_synteny_rescore     = "-q production-rh74 -We 10 -M8000 -R 'select[mem>8000]' -R  'rusage[mem=8000]'"
 
 ;; StableIdMapper
 mapping_types               = gene,transcript,translation,exon

--- a/misc-scripts/stable_id_lookup/README
+++ b/misc-scripts/stable_id_lookup/README
@@ -34,7 +34,7 @@ RELEASE=88
 DIR=ensembl/misc-scripts/stable_id_lookup
 
 cd $DIR
-bsub -q production-rh7 -M 700 -R'select[mem>700] rusage[mem=700]' -o stable_id_lookup.out -e stable_id_lookup.err perl populate_stable_id_lookup.pl \
+bsub -q production-rh74 -M 700 -R'select[mem>700] rusage[mem=700]' -o stable_id_lookup.out -e stable_id_lookup.err perl populate_stable_id_lookup.pl \
 -lhost mysql-xxx-dev-x.ebi.ac.uk -luser xxxx -lpass xxxx -lport 4484 -dbname ensembl_stable_ids_${RELEASE} -create -host mysql-ens-xxx-1.ebi.ac.uk  -user xxx -port 4519 -version ${RELEASE} -create_index
 
 -luser,lpass,lhost,lport = lookup credentials, or the dev server account with write permissions.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBasic.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBasic.pm
@@ -143,7 +143,7 @@ sub resubmit_exonerate {
 
   chmod 0755, $exe_file;
 
-  my $queue = $self->mapper->farm_queue || 'production-rh7';
+  my $queue = $self->mapper->farm_queue || 'production-rh74';
   
   my $usage = '-M 1500 -R"select[mem>1500] rusage[tmp='.$disk_space_needed.', mem=1500]" -J "'.$unique_name.'"';
   $queue and $usage .=  ' -q '. $queue;
@@ -284,7 +284,7 @@ EON
 
   my $output = $self->get_class_name() . "_" . $ensembl_type . "_" . "\$LSB_JOBINDEX.map";
 
-  my $queue = $self->mapper->farm_queue || 'production-rh7';
+  my $queue = $self->mapper->farm_queue || 'production-rh74';
 
 
   my $usage = '-M 1500 -R"select[mem>1500] rusage[tmp='.$disk_space_needed.', mem=1500]" '.'-J "'.$unique_name.'[1-'.$num_jobs.']%200" -o '.$prefix.'.%J-%I.out -e  '.$prefix.'.%J-%I.err';

--- a/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2021] EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1049,7 +1049,7 @@ sub submit_depend_job {
 
   # rest of command
   
-  my $queue = $self->mapper->farm_queue || 'production-rh7';
+  my $queue = $self->mapper->farm_queue || 'production-rh74';
 #  push @depend_bsub, ('-q', $queue, '-o', "$root_dir/depend.out", '-e', "$root_dir/depend.err");
 
   my $jobid = 0;

--- a/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2021] EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -520,7 +520,7 @@ sub run_exonerate {
   $self->logger->info("Waiting for exonerate jobs to finish...\n", 0, 'stamped');
 
   my $dependent_job =
-    qq{bsub -K -w "ended($lsf_name)" -q production-rh7 } .
+    qq{bsub -K -w "ended($lsf_name)" -q production-rh74 } .
     qq{-M 1000 -R 'select[mem>1000]' -R 'rusage[mem=1000]' } .
     qq{-o $logpath/exonerate_depend.out /bin/true};
 

--- a/modules/Bio/EnsEMBL/IdMapping/SyntenyFramework.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/SyntenyFramework.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/SyntenyFramework.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/SyntenyFramework.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2021] EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -412,7 +412,7 @@ sub rescore_gene_matrix_lsf {
   $self->logger->info("Waiting for jobs to finish...\n", 0, 'stamped');
 
   my $dependent_job =
-    qq{bsub -K -w "ended($lsf_name)" -q production-rh7 } .
+    qq{bsub -K -w "ended($lsf_name)" -q production-rh74 } .
     qq{-M 1000 -R 'select[mem>1000]' -R 'rusage[mem=1000]' } .
     qq{-o $logpath/synteny_rescore_depend.out /bin/true};
 


### PR DESCRIPTION
…-rh74

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The "production-rh7" was hardcoded in many places. I replaced them with production-rh74. 
_Using one or more sentences, describe in detail the proposed changes._

## Use case

we are not using production-rh7, so jobs couldn't run.  
_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

## Benefits

Now things are running.
_If applicable, describe the advantages the changes will have._

## Possible Drawbacks
We many need to remove hardcoded parts. 
_If applicable, describe any possible undesirable consequence of the changes._

## Testing

I did run a full run and it looks ok. 
_Have you added/modified unit tests to test the changes?_
no
_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

