### PR TITLE
Add test for nowarnings to catch Undefined value error

### DIFF
--- a/modules/t/compara.t
+++ b/modules/t/compara.t
@@ -1,12 +1,12 @@
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 # Copyright [2016-2021] EMBL-European Bioinformatics Institute
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,8 @@ use Bio::EnsEMBL::Transcript;
 use Bio::EnsEMBL::Translation;
 use Bio::EnsEMBL::Gene;
 use Bio::EnsEMBL::DnaDnaAlignFeature;
+use Test::Warnings;
+use Test::Warn;
 
 my $human = Bio::EnsEMBL::Test::MultiTestDB->new('homo_sapiens');
 my $mouse = Bio::EnsEMBL::Test::MultiTestDB->new('mus_musculus');
@@ -44,45 +46,53 @@ Bio::EnsEMBL::Registry->add_alias('multi', 'compara');
 ## Gene::get_all_homologous_Genes()
 
 my $human_gene = $core_db->get_GeneAdaptor->fetch_by_stable_id('ENSG00000174852');
-my $homologues = $human_gene->get_all_homologous_Genes();
-is(scalar(@$homologues), 46, 'Got all the homologues');
 
-sub _check_consistency {
-    my $triplet = shift;
-        subtest $triplet->[2], sub {
-            isa_ok($triplet->[0], 'Bio::EnsEMBL::Gene');
-            isa_ok($triplet->[1], 'Bio::EnsEMBL::Compara::Homology');
-            my $members = $triplet->[1]->get_all_Members;
-            is($members->[0]->gene_member->stable_id, 'ENSG00000174852', 'The query gene is correct');
-            is($triplet->[0]->stable_id, $members->[1]->gene_member->stable_id, 'The target gene is consistent between Gene and Homology');
-            is($members->[1]->genome_db->name, $triplet->[2], 'The species name is correct');
-        };
-};
+warnings_exist {
+  my $homologues = $human_gene->get_all_homologous_Genes();
 
-my $mouse_gene = $mouse->get_DBAdaptor('core')->get_GeneAdaptor->fetch_by_stable_id('ENSMUSG00000088524');
-my @mouse_triplets = grep {$_->[2] eq 'mus_musculus'} @$homologues;
-is(scalar(@mouse_triplets), 1, 'One with mouse');
-my $mouse_triplet = $mouse_triplets[0];
-_check_consistency($mouse_triplet);
-subtest 'Mouse triplet', sub {
-    ok($mouse_gene->equals($mouse_triplet->[0]), 'The mouse gene is correct');
-    is($mouse_triplet->[1]->method_link_species_set_id, 50976, 'mouse homology mlss_id');
-    is($mouse_triplet->[1]->dbID, 100972489, 'mouse homology dbID');
-};
+  is(scalar(@$homologues), 46, 'Got all the homologues');
 
-# For species with no core database, the Gene object is an empty shell
-my @dog_triplets = grep {$_->[2] eq 'canis_familiaris'} @$homologues;
-is(scalar(@dog_triplets), 1, 'One with dog');
-my $dog_triplet = $dog_triplets[0];
-_check_consistency($dog_triplet);
-subtest 'Dog triplet', sub {
-    ok(!$dog_triplet->[0]->dbID, 'The dog gene is made up and has no dbID');
-    is($dog_triplet->[0]->stable_id, 'ENSCAFG00000027814', 'dog stable_id');
-    is($dog_triplet->[0]->description, 'Small nucleolar RNA SNORD2 [Source:RFAM;Acc:RF01299]', 'dog description');
-    is($dog_triplet->[1]->method_link_species_set_id, 50981, 'dog homology mlss_id');
-    is($dog_triplet->[1]->dbID, 100972657, 'dog homology dbID');
-};
+  sub _check_consistency {
+      my $triplet = shift;
+          subtest $triplet->[2], sub {
+              isa_ok($triplet->[0], 'Bio::EnsEMBL::Gene');
+              isa_ok($triplet->[1], 'Bio::EnsEMBL::Compara::Homology');
+              my $members = $triplet->[1]->get_all_Members;
+              is($members->[0]->gene_member->stable_id, 'ENSG00000174852', 'The query gene is correct');
+              is($triplet->[0]->stable_id, $members->[1]->gene_member->stable_id, 'The target gene is consistent between Gene and Homology');
+              is($members->[1]->genome_db->name, $triplet->[2], 'The species name is correct');
+          };
+  };
 
+  my $mouse_gene = $mouse->get_DBAdaptor('core')->get_GeneAdaptor->fetch_by_stable_id('ENSMUSG00000088524');
+  my @mouse_triplets = grep {$_->[2] eq 'mus_musculus'} @$homologues;
+  is(scalar(@mouse_triplets), 1, 'One with mouse');
+  my $mouse_triplet = $mouse_triplets[0];
+  _check_consistency($mouse_triplet);
+
+  subtest 'Mouse triplet', sub {
+      ok($mouse_gene->equals($mouse_triplet->[0]), 'The mouse gene is correct');
+      is($mouse_triplet->[1]->method_link_species_set_id, 50976, 'mouse homology mlss_id');
+      is($mouse_triplet->[1]->dbID, 100972489, 'mouse homology dbID');
+  };
+
+  # For species with no core database, the Gene object is an empty shell
+  my @dog_triplets = grep {$_->[2] eq 'canis_familiaris'} @$homologues;
+  is(scalar(@dog_triplets), 1, 'One with dog');
+
+
+
+  my $dog_triplet = $dog_triplets[0];
+  _check_consistency($dog_triplet);
+  subtest 'Dog triplet', sub {
+      ok(!$dog_triplet->[0]->dbID, 'The dog gene is made up and has no dbID');
+      is($dog_triplet->[0]->stable_id, 'ENSCAFG00000027814', 'dog stable_id');
+      is($dog_triplet->[0]->description, 'Small nucleolar RNA SNORD2 [Source:RFAM;Acc:RF01299]', 'dog description');
+      is($dog_triplet->[1]->method_link_species_set_id, 50981, 'dog homology mlss_id');
+      is($dog_triplet->[1]->dbID, 100972657, 'dog homology dbID');
+  };
+
+} [qr/Cannot find all the core databases in the Registry/], "Expected warning is thrown";
 
 ## Slice::get_all_compara_Syntenies()
 


### PR DESCRIPTION
## Requirements

Small adition, to check no unexpected warnings. Was proposed in August, but was waiting until compara resolve their issue and make this test pass.

## Description
The issue is -
Sometimes we had undetected warnings in compara tests, and we cought them manually by looking through build. That should be done automatically.

A code changes performed - is only about the code block that makes expected warning is moved under expected warning cover without changes.

## Benefits

Now all failed test will be catched

## Possible Drawbacks

Not found

## Testing

Yes, it's test modification

_If so, do the tests pass/fail?_

YEs

