### PR TITLE
Add dependenses installation for submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,12 @@ before_install:
 
 install:
   - cpanm -v --sudo --installdeps --notest . --with-all-features
-  - cpanm -n --sudo Devel::Cover Devel::Cover::Report::Coveralls Test::Exception Moose Devel::Cycle Test::Warnings 
-  - cpanm -n --sudo DBD::SQLite JSON 
+  - cpanm -v --sudo --installdeps --notest ./ensembl-compara --with-all-features
+  - cpanm -v --sudo --installdeps --notest ./ensembl-io --with-all-features
+  - cpanm -v --sudo --installdeps --notest ./ensembl-variation --with-all-features
+  - cpanm -v --sudo --installdeps --notest ./ensembl-test --with-all-features
+  - cpanm -n --sudo Devel::Cover Devel::Cover::Report::Coveralls Test::Exception Moose Devel::Cycle Test::Warnings
+  - cpanm -n --sudo DBD::SQLite JSON
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - cp travisci/testdb.conf.travisci.mysql  testdb.conf.mysql
@@ -45,13 +49,13 @@ install:
 before_script:
   - rm -f "$HOME/.ensemblapi_no_version_check"
 
-script: 
+script:
   - "./travisci/harness.sh"
 
 jobs:
   include:
     - dist: focal
-      perl: '5.30' 
+      perl: '5.30'
       env: COVERALLS=false  DB=mysql
   exclude:
     - perl: '5.14'


### PR DESCRIPTION
## Description

Add installation of sub-modules dependences for perl

## Use case

Not to add manually each dependence, all deps of submodules must be installed
## Benefits

We will have all deps whenever they changed

## Possible Drawbacks

Slower build
## Testing

yes
_If so, do the tests pass/fail?_

yes

