### PR TITLE
add allele_string for variation_features

### DIFF
--- a/modules/t/test-genome-DBs/homo_sapiens/variation/variation_feature.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/variation_feature.txt
@@ -1,3 +1,3 @@
-1	469283	30252800	30252800	1	1	\N	\N	rs12345	1	genotyped	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
-2	469283	30252900	30252900	1	2	\N	\N	rs67890	1	\N	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
-3	469283	30253900	30253900	1	3	\N	\N	rs54321	1	\N	1	intergenic_variant		0	1	\N	\N	\N	\N	\N	\N	1
+1	469283	30252800	30252800	1	1	T/A	\N	rs12345	1	genotyped	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
+2	469283	30252900	30252900	1	2	T/C	\N	rs67890	1	\N	1	intergenic_variant	1	0	0	\N	\N	\N	\N	\N	\N	1
+3	469283	30253900	30253900	1	3	G/A	\N	rs54321	1	\N	1	intergenic_variant		0	1	\N	\N	\N	\N	\N	\N	1


### PR DESCRIPTION
## Description
The sliceVariation.t was throwing a warning "Use of uninitialized value $allele_string in substitution (s///) at ...VariationFeatureAdaptor.pm line 1413." because of missing allele_string data in the variation feature table.

## Use case

We need to test fetching variation data from slice objects.

## Benefits

NA

## Possible Drawbacks

NA
## Testing

sliceVariation.t runs without warning messages.
