### PR TITLE
Patching variation test db for versions 102, 103, 104, and 105

### DIFF
--- a/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	variation
-2	\N	schema_version	101
+2	\N	schema_version	104
 3	\N	patch	patch_84_85_a.sql|schema version
 4	\N	patch	patch_84_85_b.sql|create sample_synonym
 5	\N	patch	patch_84_85_c.sql|drop column moltype from variation_synonym
@@ -53,3 +53,7 @@
 53	\N	patch	patch_99_100_c.sql|add class_attrib_id column to phenotype
 54	\N	patch	patch_100_101_a.sql|schema version
 55	\N	patch	patch_100_101_b.sql|Add new data_source_attrib to variation_citation
+56	\N	patch	patch_101_102_a.sql|schema version
+57	\N	patch	patch_101_102_b.sql|Add new clinical_significance to variation, variation_feature and structural_variation
+58	\N	patch	patch_102_103_a.sql|schema version
+59	\N	patch	patch_103_104_a.sql|schema version

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	variation
-2	\N	schema_version	104
+2	\N	schema_version	105
 3	\N	patch	patch_84_85_a.sql|schema version
 4	\N	patch	patch_84_85_b.sql|create sample_synonym
 5	\N	patch	patch_84_85_c.sql|drop column moltype from variation_synonym
@@ -57,3 +57,4 @@
 57	\N	patch	patch_101_102_b.sql|Add new clinical_significance to variation, variation_feature and structural_variation
 58	\N	patch	patch_102_103_a.sql|schema version
 59	\N	patch	patch_103_104_a.sql|schema version
+60	\N	patch	patch_104_105_a.sql|schema_version

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=60 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=61 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=56 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=60 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -433,7 +433,7 @@ CREATE TABLE `structural_variation` (
   `source_id` int(10) unsigned NOT NULL,
   `study_id` int(10) unsigned DEFAULT NULL,
   `class_attrib_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
+  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects') DEFAULT NULL,
   `validation_status` enum('validated','not validated','high quality') DEFAULT NULL,
   `is_evidence` tinyint(4) DEFAULT '0',
   `somatic` tinyint(1) NOT NULL DEFAULT '0',
@@ -585,7 +585,7 @@ CREATE TABLE `variation` (
   `minor_allele` varchar(50) DEFAULT NULL,
   `minor_allele_freq` float DEFAULT NULL,
   `minor_allele_count` int(10) unsigned DEFAULT NULL,
-  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
+  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects') DEFAULT NULL,
   `evidence_attribs` set('367','368','369','370','371','372','418','421','573','585') DEFAULT NULL,
   `display` int(1) DEFAULT '1',
   PRIMARY KEY (`variation_id`),
@@ -631,7 +631,7 @@ CREATE TABLE `variation_feature` (
   `minor_allele_count` int(10) unsigned DEFAULT NULL,
   `alignment_quality` double DEFAULT NULL,
   `evidence_attribs` set('367','368','369','370','371','372','418','421','573','585') DEFAULT NULL,
-  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
+  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects') DEFAULT NULL,
   `display` int(1) DEFAULT '1',
   PRIMARY KEY (`variation_feature_id`),
   KEY `pos_idx` (`seq_region_id`,`seq_region_start`,`seq_region_end`),

--- a/modules/t/test-genome-DBs/mus_musculus/variation/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/variation/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	variation
-2	\N	schema_version	101
+2	\N	schema_version	104
 6	1	species.production_name	mus_musculus
 15	1	web_config	sv_study#Keane 2011 (DGVa study estd118)#Keane 2011#estd118
 14	1	web_config	set#All failed variants#All failed variants#variation_set_fail_all#failed
@@ -80,3 +80,7 @@
 86	\N	patch	patch_99_100_c.sql|add class_attrib_id column to phenotype
 87	\N	patch	patch_100_101_a.sql|schema version
 88	\N	patch	patch_100_101_b.sql|Add new data_source_attrib to variation_citation
+89	\N	patch	patch_101_102_a.sql|schema version
+90	\N	patch	patch_101_102_b.sql|Add new clinical_significance to variation, variation_feature and structural_variation
+91	\N	patch	patch_102_103_a.sql|schema version
+92	\N	patch	patch_103_104_a.sql|schema version

--- a/modules/t/test-genome-DBs/mus_musculus/variation/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/variation/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	variation
-2	\N	schema_version	104
+2	\N	schema_version	105
 6	1	species.production_name	mus_musculus
 15	1	web_config	sv_study#Keane 2011 (DGVa study estd118)#Keane 2011#estd118
 14	1	web_config	set#All failed variants#All failed variants#variation_set_fail_all#failed
@@ -84,3 +84,4 @@
 90	\N	patch	patch_101_102_b.sql|Add new clinical_significance to variation, variation_feature and structural_variation
 91	\N	patch	patch_102_103_a.sql|schema version
 92	\N	patch	patch_103_104_a.sql|schema version
+93	\N	patch	patch_104_105_a.sql|schema_version

--- a/modules/t/test-genome-DBs/mus_musculus/variation/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=89 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=93 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -433,7 +433,7 @@ CREATE TABLE `structural_variation` (
   `source_id` int(10) unsigned NOT NULL,
   `study_id` int(10) unsigned DEFAULT NULL,
   `class_attrib_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
+  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects') DEFAULT NULL,
   `validation_status` enum('validated','not validated','high quality') DEFAULT NULL,
   `is_evidence` tinyint(4) DEFAULT '0',
   `somatic` tinyint(1) NOT NULL DEFAULT '0',
@@ -591,7 +591,7 @@ CREATE TABLE `variation` (
   `minor_allele` varchar(50) DEFAULT NULL,
   `minor_allele_freq` float DEFAULT NULL,
   `minor_allele_count` int(10) unsigned DEFAULT NULL,
-  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
+  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects') DEFAULT NULL,
   `evidence_attribs` set('367','368','369','370','371','372','418','421','573','585') DEFAULT NULL,
   `display` int(1) DEFAULT '1',
   PRIMARY KEY (`variation_id`),
@@ -637,7 +637,7 @@ CREATE TABLE `variation_feature` (
   `minor_allele_count` int(10) unsigned DEFAULT NULL,
   `alignment_quality` double DEFAULT NULL,
   `evidence_attribs` set('367','368','369','370','371','372','418','421','573','585') DEFAULT NULL,
-  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective') DEFAULT NULL,
+  `clinical_significance` set('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects') DEFAULT NULL,
   `display` int(1) DEFAULT '1',
   PRIMARY KEY (`variation_feature_id`),
   KEY `pos_idx` (`seq_region_id`,`seq_region_start`,`seq_region_end`),

--- a/modules/t/test-genome-DBs/mus_musculus/variation/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=93 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=94 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,


### PR DESCRIPTION
## Description

Adding patches for homo sapiens and mus musculus variation test dbs for versions 102 till 105. Patches which were missed by several version bumps.

## Use case

## Benefits

## Possible Drawbacks

## Testing

