### PR TITLE
Add no warnings to slice variation test

### DIFF
--- a/modules/t/sliceVariation.t
+++ b/modules/t/sliceVariation.t
@@ -1,12 +1,12 @@
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 # Copyright [2016-2021] EMBL-European Bioinformatics Institute
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 
 use Test::More;
-#use Test::Warnings;
+use Test::Warnings;
 
 use Bio::EnsEMBL::Test::TestUtils;
 use Bio::EnsEMBL::Test::MultiTestDB;


### PR DESCRIPTION
## Description

Added no warnings check to Variation tests, for early catch of errors.

## Use case
Sometimes we have warnins at variation tests, that are errors, but still tests pass. So we need to add no warnings check

## Benefits

Early and automatic bug catch

## Possible Drawbacks

This repo will fail until versions are fixed

## Testing

it is test changes

_If so, do the tests pass/fail?_

yes

