### PR TITLE
Final clause check

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -617,8 +617,10 @@ sub _generate_sql {
     $sql .= "\n WHERE $default_where ";
   }
 
-  #append additional clauses which may have been defined
-  $sql .= "\n$final_clause";
+  #append additional clauses which may have been defined, don't append ORDER BY twice
+  if (index($final_clause, "ORDER") == -1 || index($sql, "ORDER") == -1) {
+    $sql .= "\n$final_clause";
+  }
   
   # FOR DEBUG:
   #printf(STDERR "SQL:\n%s\n", $sql);


### PR DESCRIPTION
## Description

This check prevents adding ORDER BY twice

## Use case

The problem occurs when using otter with ensebmbl 104+
Otter has its own sorting for gene, exon and transcript adaptors, it makes conflict withh new added ORDER by in ensembl (due to mysql version upgrade, new myswl requiers explicit ordering)

## Benefits

We can use otter with new ensembl

## Possible Drawbacks

not found

## Testing

_Have you added/modified unit tests to test the changes?_

no, its a bug fix

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

all tests run fine

