### PR TITLE
Bug fix for generating new exon stable ids

### DIFF
--- a/misc-scripts/generate_stable_ids.pl
+++ b/misc-scripts/generate_stable_ids.pl
@@ -145,7 +145,7 @@ sub get_max_stable_id_from_gene_archive {
   my ( $dbi, $type ) = @_;
 
   # Try to get from relevant archive.
-  my $sth = $dbi->prepare("SELECT MAX($type) FROM gene_archive");
+  my $sth = $dbi->prepare("SELECT MAX($type) FROM gene_archive WHERE stable_id LIKE 'ENS%'");
   $sth->execute();
 
   my $rs;
@@ -241,9 +241,7 @@ sub get_highest_stable_id {
   # G/T/P for gene etc. (Exon dealt with above.)
 
   my ( $prefix, $suffix ) = $max =~ /([a-zA-Z]+)([0-9]+)/;
-  if ( $type eq 'exon' ) {
-    $prefix =~ s/E$//;
-  } elsif ( $type eq 'gene' ) {
+  if ( $type eq 'gene' ) {
     $prefix =~ s/G$//;
   } elsif ( $type eq 'transcript' ) {
     $prefix =~ s/T$//;

--- a/misc-scripts/generate_stable_ids.pl
+++ b/misc-scripts/generate_stable_ids.pl
@@ -118,7 +118,7 @@ sub increment_stable_id {
   } elsif ( $stable_id =~ m/([a-zA-Z]+)/ ) {
     $prefix = $stable_id;
   } else {
-    die(   "unrecongnized stable_id format "
+    die(   "unrecognized stable_id format: $stable_id "
          . "- should match ([a-zA-Z]+)([0-9]+) or ([a-zA-Z]+) !!\n" );
   }
 
@@ -171,7 +171,7 @@ sub get_highest_stable_id {
 
   # Get highest stable ID from the relevant table.
 
-  my $sth = $dbi->prepare("SELECT MAX(stable_id) FROM $type");
+  my $sth = $dbi->prepare("SELECT MAX(stable_id) FROM $type WHERE stable_id LIKE 'ENS%'");
   $sth->execute();
 
   if ( my @row = $sth->fetchrow_array() ) {
@@ -214,7 +214,11 @@ sub get_highest_stable_id {
       }
     } ## end if ( length($highest_from_current...))
 
-    return $highest_from_current;
+    # remove the 'E' from exon stable id prefix
+    my ( $prefix, $suffix ) = $highest_from_current =~ /([a-zA-Z]+)([0-9]+)/;
+    $prefix =~ s/E$//;
+
+    return $prefix . $suffix;
   } ## end if ( $type eq "exon" )
 
   # and from relevant archive
@@ -234,7 +238,7 @@ sub get_highest_stable_id {
   }
 
   # Assuming that this is a correctly formatted stable id -> remove the
-  # G/T/P/E for exon etc.
+  # G/T/P for gene etc. (Exon dealt with above.)
 
   my ( $prefix, $suffix ) = $max =~ /([a-zA-Z]+)([0-9]+)/;
   if ( $type eq 'exon' ) {

--- a/misc-scripts/generate_stable_ids.pl
+++ b/misc-scripts/generate_stable_ids.pl
@@ -281,6 +281,9 @@ sub usage {
   gene_archive table (only for gene, translation and transcript, not for
   exon stable IDs!)
 
+  Please note that this script only works for "ENS..."-type stable ids.
+  It does not work for LRG ids or other types of stable ids.
+
   Note:
 
   The -start option requires to not submit an initial stable ID without


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

I've recently used the `generate_stable_id.pl` script to create new stable ids for various genes/transcripts/exons/translations. I was not able to provide information for the `start` parameter and so required the program to find the maximum current stable id for each of these types.

I found 2 issues when trying to run this script on my data, which I've tried to fix in this PR.

1. When the start parameter is not defined and the program looks for the maximum gene stable id, I found that it would return 'LRG_999' and not an 'ENSG'-based stable id. I've added in a WHERE clause to the relevant SQL query to refine the search to 'ENS' stable ids, as I (perhaps wrongly?) assumed we are not interested in incrementing 'LRG'-ids.
2. The SQL UPDATE string generated for exons was incorrect as it started with 'ENSEE', rather than 'ENSE'. This was due to the current highest stable id being returned before the 'E' in the prefix could be removed.

## Use case

I've recently used the `generate_stable_id.pl` script to create new stable ids for various genes/transcripts/exons/translations. I was not able to provide information for the `start` parameter and so required the program to find the maximum current stable id for each of these types.

To give more context, I've used this script to create new stable ids for genes/transcripts/exons/translations transferred from X chromosome PAR regions onto Y chromosome PAR regions. These objects have been transferred onto the correct coordinates and stored in a test database, and now require new stable ids creating for each. This script is being used to generate the SQL I need to update the stable ids in my test database.

## Benefits

In this context, the script will now generate the correctly formatted stable ids for new exons.

## Possible Drawbacks

The assumption that gene stable ids start with 'ENS' may not be correct and needs clarifying. For example, at the moment the SQL query returns 'LRG_999' (when no start parameter is defined) and it may be that some users need to update LRG-based stable ids.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

