### PR TITLE
Bugfix/dump mysql

### DIFF
--- a/misc-scripts/db/dump_mysql.pl
+++ b/misc-scripts/db/dump_mysql.pl
@@ -359,8 +359,8 @@ sub data {
     "-e 'SELECT * FROM ${db}.${table}'",
     '|',
     'sed -r ',
-    '-e \'s/(^|\t)NULL($|\t)/\1\\N\2/g\'',
-    '-e \'s/(^|\t)NULL($|\t)/\1\\N\2/g\'',
+    '-e \'s/(^|\t)NULL($|\t)/\1\\\\N\2/g\'',
+    '-e \'s/(^|\t)NULL($|\t)/\1\\\\N\2/g\'',
     '>',
     $file
   );

--- a/misc-scripts/db/dump_mysql.pl
+++ b/misc-scripts/db/dump_mysql.pl
@@ -266,7 +266,7 @@ sub process {
       }
       foreach my $table (sort { $a cmp $b } @tables_to_process) {
         next if $self->is_view($table);
-        $self->data($table);
+        $self->data($table, $db);
       }
     } else {
       $self->v('-sql mode is on so no data dumping will occur');
@@ -338,16 +338,35 @@ sub modify_sql {
 }
 
 sub data {
-  my ($self, $table) = @_;
+
+  my ($self, $table, $db) = @_;
   return if $self->is_view($table);
   $self->v('Dumping table %s', $table);
   my $q_table      = $self->dbh()->quote_identifier($table);
   my $file         = $self->file($table . '.txt');
-  my $force_escape = q{FIELDS ESCAPED BY '\\\\'};
-  my $sql          = sprintf(q{SELECT * FROM %s INTO OUTFILE '%s' %s},
-                    $q_table, $file, $force_escape);
-  unlink $file if -f $file;
-  $self->dbh()->do($sql);
+
+  my $dbc_params = $self->dbc_params($db);
+
+  my $mysql_exe = 'mysql';
+
+  my @cmd = (
+    $mysql_exe,
+    $dbc_params,
+    '--max_allowed_packet=1024M',
+    '--quick',
+    '--silent',
+    '--skip-column-names',
+    "-e 'SELECT * FROM ${db}.${table}'",
+    '|',
+    'sed -r ',
+    '-e \'s/(^|\t)NULL($|\t)/\1\\N\2/g\'',
+    '-e \'s/(^|\t)NULL($|\t)/\1\\N\2/g\'',
+    '>',
+    $file
+  );
+  my $cmd = join(' ', @cmd);
+  my $output = `$cmd 2>&1`;
+
   $self->compress($file) if ! $self->opts()->{testcompatible};
   return;
 }
@@ -397,6 +416,23 @@ sub dbh {
     $self->{dbh} = $dbh;
   }
   return $self->{'dbh'};
+}
+
+sub dbc_params {
+  my ($self, $database) = @_;
+  my $o = $self->opts();
+    my %args = (host => $o->{host}, port => $o->{port});
+    $args{database} = $database if defined $database;
+
+  my $dbc_params = join(' ', (
+    '--host='.$o->{host},
+    '--port='.$o->{port},
+    '--user='.$o->{username},
+    '--password='.$o->{password}
+    )
+  );
+
+  return $dbc_params;
 }
 
 sub clear_dbh {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The dump_mysql script assumed direct access to the MySQL server
As this is not often the case in production environment, the script has been updated to not use server-restricted SQL commands

## Use case

As part of the move to a new production infrastructure, access to MySQL servers has been restricted.
Some old scripts assumed direct access, which is less secure and now seldom allowed.
This change allows the script to be used from any environment against a remote SQL server

## Benefits

Script can be run in any environment

## Possible Drawbacks

The code is more complex

## Testing

_Have you added/modified unit tests to test the changes?_
No unit tests per say, the script was tested by Infrastructure and Variation though
_If so, do the tests pass/fail?_
Script runs successfully in the new infrastructure

_Have you run the entire test suite and no regression was detected?_
NA
