### PR TITLE
Allow multiple alt allele groups to be returned

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/AltAlleleGroupAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AltAlleleGroupAdaptor.pm
@@ -238,13 +238,28 @@ sub fetch_by_gene_id {
     my $sth = $self->prepare($gene_id_sql);
     $sth->bind_param(1,$gene_id, SQL_INTEGER);
     
+    my @group_ids;
     my $group_id;
     $sth->execute();
     $sth->bind_col(1,\$group_id);
-    $sth->fetch;
+    while ( $sth->fetch ) {
+        print "group id: $group_id\n";
+        push( @group_ids, $group_id );
+    }
+    print "group ids: @group_ids\n";
+    # $sth->fetch;
     $sth->finish;
     if (!$@ && $group_id) {
-        return $self->fetch_by_dbID($group_id);
+        my @aag;
+        foreach my $group (@group_ids) {
+            print "About to fetch aag object using group id $group\n";
+            my $aag = $self->fetch_by_dbID($group);
+            print "aag object: $aag\n";
+            push(@aag, $aag);
+        }
+        print "@aag\n";
+        return \@aag;
+        # return $self->fetch_by_dbID($group_id); # breaks if turned into an array
     }
     return;
 }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

A given gene id can be associated with one or more alt allele group ids. This relationship was previously defined as 1:1 in the core db, but is now a 1:m relationship as a result of this project work. The code now needs updating so that one or more alt allele group ids can be retrieved via the Perl API, which will allow the web pages to show all the relevant Gene Allele information (not just one alt allele group).

## Use case

Following my recent work on storing genes (transcripts/exons/translations) from Y chromosome PAR regions, the gene PPP2R3B now has alleles associated with two alternate allele groups: 1) a patch-based group, and 2) a PAR region-based group. Beforehand it only had alleles associated with the patch-based group. Both the core database and the Perl API currently assume that a given gene can only be associated with a single alternate allele group. I have modified a test core database to update this relationship from 1:1 to 1:m.

After testing the results in a web sandbox, it was found that the Gene Allele table shows data from a single alternate allele group, e.g. the alleles from the patch-based group or from a PAR region-based group. PPP2R3B is a good example of this, where the gene on the X chromosome shows 2 gene alleles from the patch-based group: http://ves-hx2-76.ebi.ac.uk:7065/Homo_sapiens/Gene/Alleles?db=core;g=ENSG00000167393;r=X:1-964539;t=ENST00000390665. And the gene on the Y chromosome shows a single gene alleles from the PAR region-based group: http://ves-hx2-76.ebi.ac.uk:7065/Homo_sapiens/Gene/Alleles?db=core;g=ENSG00000288704;r=Y:333933-386955;t=ENST00000681977.

The purpose of this work is to modify the code to bring in all the gene allele data together in this table. This will also allow users to retrieve all the gene allele data, not just the first alternate allele group the code comes across.

## Benefits

This work will allow the webpages to accurately show all gene allele data associated with a given gene. For example, if a gene is associated with more than one alternate allele groups, these will be displayed on the web pages. It will also allow users to retrieve such data via the Perl API.

## Possible Drawbacks

Can't think of any right now.

## Testing

_Have you added/modified unit tests to test the changes?_

Not yet.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

