### PR TITLE
Bugfix/sqlupdate master

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
@@ -153,7 +153,7 @@ sub fetch_by_stable_id {
   # a version number in the stable_id
   if(!defined($arch_id)) {
       my $vindex = rindex($stable_id, '.');
-      if ($vindex !~ /[0-9]{1,5}/) { return $arch_id; }
+      if ($vindex !~ /^[0-9]{1,5}$/) { return $arch_id; }
       $arch_id = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
 						   substr($stable_id,$vindex+1),
 						   @_);
@@ -260,7 +260,7 @@ sub fetch_by_stable_id_version {
      -adaptor => $self
   );
 
-  if ($version !~ /[0-9]{1,5}/) {
+  if ($version !~ /^[0-9]{1,5}$/) {
     throw("$version is not valid, should be a small int");
   }
   

--- a/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
@@ -151,7 +151,9 @@ sub fetch_by_stable_id {
 
   # If we didn't get anything back, desperately try to see if there's
   # a version number in the stable_id
-  if(!defined($arch_id) && (my $vindex = rindex($stable_id, '.'))) {
+  if(!defined($arch_id)) {
+      my $vindex = rindex($stable_id, '.');
+      if ($vindex !~ /[0-9]{1,5}/) { return $arch_id; }
       $arch_id = $self->fetch_by_stable_id_version(substr($stable_id,0,$vindex),
 						   substr($stable_id,$vindex+1),
 						   @_);
@@ -257,6 +259,10 @@ sub fetch_by_stable_id_version {
      -version => $version,
      -adaptor => $self
   );
+
+  if ($version !~ /[0-9]{1,5}/) {
+    throw("$version is not valid, should be a small int");
+  }
   
   @_ ? $arch_id->type(shift) : $self->_resolve_type($arch_id);
 

--- a/modules/t/archiveStableId.t
+++ b/modules/t/archiveStableId.t
@@ -23,6 +23,8 @@ use Test::Warnings;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::DBSQL::ArchiveStableIdAdaptor;
 use Bio::EnsEMBL::Test::TestUtils;
+use Test::Exception;
+use Test::Warnings qw(warning);
 
 our $verbose = 0;
 
@@ -50,6 +52,13 @@ is( $asi->release, 3, "T2 is from release 3");
 
 $asi = $asia->fetch_by_stable_id_dbname("T1", "release_2");
 is( $asi->release, 2, "T1 is from release 2");
+
+#
+# Check version is correct field
+#
+
+throws_ok { $asia->fetch_by_stable_id_version("T1", 'invalid_version') } qr/is not valid, should be a small int/, "version must be an integer";
+warning { throws_ok { $asia->fetch_by_stable_id("T1.invalid_version") } qr/is not valid, should be a small int/, "Stable ID must have an integer as version" };
 
 
 #

--- a/modules/t/archiveStableId.t
+++ b/modules/t/archiveStableId.t
@@ -59,6 +59,7 @@ is( $asi->release, 2, "T1 is from release 2");
 
 throws_ok { $asia->fetch_by_stable_id_version("T1", 'invalid_version') } qr/is not valid, should be a small int/, "version must be an integer";
 warning { throws_ok { $asia->fetch_by_stable_id("T1.invalid_version") } qr/is not valid, should be a small int/, "Stable ID must have an integer as version" };
+throws_ok { $asia->fetch_by_stable_id_version("T1", "invalid12345_version") } qr/is not valid, should be a small int/, "version must be only an integer";
 
 
 #


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Include sanity checking on stable ID version field
## Use case

According to the core schema, the version of a stable ID is a small int, which is an integer of maximum 5 digits.
In the API, there is no validation of this field, but it is used in an extra sql query that can be anything.
This can create very long queries that are not going to return anything as the input field is invalid.
Here, we add some checking on the value in the field before running the SQL query, providing a result faster without needlessly querying the database.

## Benefits

Queries get resolved quicker if input does not make sense.

## Possible Drawbacks

Might add a small performance penalty with the extra check.

## Testing

_Have you added/modified unit tests to test the changes?_
New tests have been added, both with valid and invalid inputs

_If so, do the tests pass/fail?_
Yes

_Have you run the entire test suite and no regression was detected?_
Yes

