### PR TITLE
Fix column name when selecting from gene_archive table

### DIFF
--- a/misc-scripts/generate_stable_ids.pl
+++ b/misc-scripts/generate_stable_ids.pl
@@ -145,7 +145,7 @@ sub get_max_stable_id_from_gene_archive {
   my ( $dbi, $type ) = @_;
 
   # Try to get from relevant archive.
-  my $sth = $dbi->prepare("SELECT MAX($type) FROM gene_archive WHERE stable_id LIKE 'ENS%'");
+  my $sth = $dbi->prepare("SELECT MAX($type) FROM gene_archive WHERE $type LIKE 'ENS%'");
   $sth->execute();
 
   my $rs;


### PR DESCRIPTION
## Description

Same change as #585 added into release/106

## Use case

Fix sql query to use $type (which could be gene_stable_id, transcript_stable_id, ...) instead of 'stable_id' when selecting from gene_archive.

## Benefits

This script currently fails without this change.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

