### PR TITLE
Bugfix/enscoresw 3827

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ensembl Core API
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=release/106)][travis]
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=release/106)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=master)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=master)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl


### PR DESCRIPTION
## Requirements

added **gene2phenotype** DB type to _schema_patcher.pl_

## Description

_Using one or more sentences, describe in detail the proposed changes._

## Use case

Creating/patching test DBs.
The script _schema_patcher.pl_ is now aware of the **gene2phenotype** type DB.

## Benefits

Tests for assessing **core** type DBs and **gene2phenotype** type DB can be developed going forward.

## Possible Drawbacks

Stricter SOP for DB patching and Release management is required to **gene2phenotype** repo.

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes