### PR TITLE
Fix/update trans canonical attr

### DIFF
--- a/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
+++ b/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
@@ -260,6 +260,7 @@ if ($write) {
     # Prepare transcript canonical attribute sqls
     my $trans_select_sth = $dba->dbc->prepare("SELECT value FROM transcript_attrib WHERE transcript_id=? AND attrib_type_id=?");
     my $trans_update_sth = $dba->dbc->prepare("UPDATE transcript_attrib SET value=? WHERE transcript_id=? AND attrib_type_id=?");
+    my $trans_insert_sth = $dba->dbc->prepare("INSERT INTO transcript_attrib (transcript_id, attrib_type_id, value) values (?,?,?)");
     my $trans_delete_sth = $dba->dbc->prepare("DELETE FROM transcript_attrib WHERE transcript_id=? AND attrib_type_id=?");
 
     print "Updating database with new canonical transcripts...\n";
@@ -272,6 +273,9 @@ if ($write) {
         if (my ($new_canonical_exists) = $trans_select_sth->fetchrow_array()) {
           # Update new canonical transcript attribute
           $trans_update_sth->execute(1, $change->[1], $attrib_type_id);
+        } else {
+          # Insert new canonical transcript attribute
+          $trans_insert_sth->execute($change->[1], $attrib_type_id, 1);
         }
 
         # Check if old canonical transcript attribute exists

--- a/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
+++ b/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
@@ -258,9 +258,9 @@ if ($write) {
         print "Changin' ". $change->[1]. " on ". $change->[0]."\n" if $verbose;
         $gene_sth->execute( $change->[1], $change->[0]);
 
-	# Updating canonical flag in transcript_attrib table, if exists
-	$trans_select_sth->execute($change->[1], 554);
-	if (my @exists = $trans_select_sth->fetchrow_array()) {
+        # Updating canonical flag in transcript_attrib table, if exists
+        $trans_select_sth->execute($change->[1], 554);
+        if (my @exists = $trans_select_sth->fetchrow_array()) {
           if ($exists[0]) {
             $trans_update_sth->execute(1, $change->[1], 554);
           }

--- a/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
+++ b/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
@@ -248,10 +248,23 @@ if ($write) {
     my $gene_update_sql = "UPDATE gene SET canonical_transcript_id = ? where gene_id = ?";
     my $gene_sth = $dba->dbc->prepare($gene_update_sql);
 
+    my $trans_select_sql = "SELECT value FROM transcript_attrib WHERE transcript_id=? AND attrib_type_id=?";
+    my $trans_select_sth = $dba->dbc->prepare($trans_select_sql);
+    my $trans_update_sql = "UPDATE transcript_attrib SET value=? WHERE transcript_id=? AND attrib_type_id=?";
+    my $trans_update_sth = $dba->dbc->prepare($trans_update_sql);
+
     print "Updating database with new canonical transcripts...\n";
     foreach my $change (@change_list) {
         print "Changin' ". $change->[1]. " on ". $change->[0]."\n" if $verbose;
         $gene_sth->execute( $change->[1], $change->[0]);
+
+	# Updating canonical flag in transcript_attrib table, if exists
+	$trans_select_sth->execute($change->[1], 554);
+	if (my @exists = $trans_select_sth->fetchrow_array()) {
+          if ($exists[0]) {
+            $trans_update_sth->execute(1, $change->[1], 554);
+          }
+        }
     }
     print "Done\n";
 }


### PR DESCRIPTION
## Description

Checking if a canonical attribute exists for a transcript and updating accordingly.

## Use case

When updating the db with canonical transcripts ids, we also need to update the newly added transcript attribute related to the canonical flag. We check if the new canonical transcript exists, we update if it does and insert if it doesn't. We also delete the old canonical attribute if it exists.

## Benefits

Updating canonical transcript data in the db.

## Possible Drawbacks

None, but changes to the API should accompany this.

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

