### PR TITLE
Feature/trans canonical attrib

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -1405,6 +1405,9 @@ sub store {
 
     $sth->execute();
     $sth->finish();
+
+    my $transcript_adaptor = $db->get_TranscriptAdaptor();
+    $transcript_adaptor->update_canonical_attribute($new_canonical_transcript_id);
   }
 
   # update gene to point to display xref if it is set
@@ -1588,6 +1591,12 @@ sub update {
     throw("Must update a gene object, not a $gene");
   }
 
+  # Get old canonical transcript id
+  my $sth = $self->prepare("SELECT canonical_transcript_id FROM gene WHERE gene_id=?");
+  $sth->execute($gene->dbID());
+  my ($old_canonical_transcript_id) = $sth->fetchrow_array();
+  $sth->finish();
+
   my $update_gene_sql = qq(
        UPDATE gene
           SET stable_id = ?,
@@ -1610,7 +1619,7 @@ sub update {
     $display_xref_id = undef;
   }
 
-  my $sth = $self->prepare($update_gene_sql);
+  $sth = $self->prepare($update_gene_sql);
 
   $sth->bind_param(1, $gene->stable_id(),      SQL_VARCHAR);
   $sth->bind_param(2, $gene->get_Biotype->name, SQL_VARCHAR);
@@ -1628,6 +1637,11 @@ sub update {
   $sth->bind_param(9, $gene->dbID(), SQL_INTEGER);
 
   $sth->execute();
+
+  if (defined($gene->canonical_transcript())) {
+    my $transcript_adaptor = $self->db()->get_TranscriptAdaptor();
+    $transcript_adaptor->update_canonical_attribute($gene->canonical_transcript()->dbID(), $old_canonical_transcript_id);
+  }
 
 } ## end sub update
 

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
@@ -1401,8 +1401,9 @@ sub store {
 
   # Check if transcript is canonical
   if ($transcript->is_canonical()) {
-    my $gene = $transcript->get_Gene();
     my $gene_adaptor = $self->db()->get_GeneAdaptor();
+    my $gene = $gene_adaptor->fetch_by_dbID($gene_dbID);
+    $transcript->dbID($transc_dbID);
     $gene->canonical_transcript($transcript);
     $gene_adaptor->update($gene);
   }

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -475,6 +475,27 @@ ok($newgene->biotype eq 'dummy');
 ok($newgene->description eq 'dummy');
 ok($newgene->version == 5);
 
+# Check that canonical transcript attribute exists
+is_rows(1, $db, "attrib_type", "where code = ? ", ["is_canonical"]);
+
+# test updating canonical transcript
+$gene = $ga->fetch_by_stable_id("ENSG0000017145556");
+my $transcript = $dbTranscriptAdaptor->fetch_by_dbID($gene->canonical_transcript->dbID());
+my ($attrib) = @{$transcript->get_all_Attributes('is_canonical')};
+ok($attrib->value() == 1, 'Canonical transcript attribute set to 1');
+
+$gene->canonical_transcript($dbTranscriptAdaptor->fetch_by_stable_id("ENST00000278995"));
+$ga->update($gene);
+$newgene = $ga->fetch_by_stable_id("ENSG0000017145556");
+my $new_transcript = $dbTranscriptAdaptor->fetch_by_dbID($newgene->canonical_transcript->dbID());
+ok($new_transcript->stable_id() eq "ENST00000278995", 'Updated canonical transcript');
+
+($attrib) = @{$new_transcript->get_all_Attributes('is_canonical')};
+ok($attrib->value() == 1, 'New canonical transcript attribute set to 1');
+$transcript = $dbTranscriptAdaptor->fetch_by_stable_id($transcript->stable_id());
+($attrib) = @{$transcript->get_all_Attributes('is_canonical')};
+ok(!defined($attrib), 'Old canonical transcript attribute deleted');
+
 $gene->is_current(0); 
 $ga->update($gene);
 $newgene = $ga->fetch_by_stable_id("ENSG0000017145556");

--- a/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
@@ -23,4 +23,4 @@
 23	_stop_codon_rt	Stop Codon Readthrough	\N
 24	appris	APPRIS	\N
 535	MANE_Select	MANE Select v0.92	MANE Select (v0.92) is the preliminary release (phase 7) of the MANE Select data set. The Matched Annotation from NCBI and EMBL-EBI project (MANE) is a collaboration between Ensembl-GENCODE and RefSeq to select a default transcript per human protein coding locus that is representative of biology, well-supported, expressed and conserved. This transcript set matches GRCh38 and is 100% identical between RefSeq and Ensembl-GENCODE for 5' UTR, CDS, splicing and 3' UTR.
-554	is_canonical	Is Canonical		Flag to state that a feature is a canonical one.
+554	is_canonical	Is Canonical	Flag to state that a feature is a canonical one.

--- a/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
@@ -23,3 +23,4 @@
 23	_stop_codon_rt	Stop Codon Readthrough	\N
 24	appris	APPRIS	\N
 535	MANE_Select	MANE Select v0.92	MANE Select (v0.92) is the preliminary release (phase 7) of the MANE Select data set. The Matched Annotation from NCBI and EMBL-EBI project (MANE) is a collaboration between Ensembl-GENCODE and RefSeq to select a default transcript per human protein coding locus that is representative of biology, well-supported, expressed and conserved. This transcript set matches GRCh38 and is 100% identical between RefSeq and Ensembl-GENCODE for 5' UTR, CDS, splicing and 3' UTR.
+554	is_canonical	Is Canonical		Flag to state that a feature is a canonical one.

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/attrib_type.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/attrib_type.txt
@@ -16,3 +16,4 @@
 16	_selenocysteine	Selenocysteine	\N
 17	codon_table	Codon Table	Alternate codon table
 18	non_ref	Non Reference	Non Reference Sequence Region
+554	is_canonical	Is Canonical	Flag to state that a feature is a canonical one.

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -257,40 +257,48 @@ is_rows(1, $db, "attrib_type", "where code = ? ", ["is_canonical"]);
 my $aa = $db->get_AttributeAdaptor();
 my $canonical_attrib_id = $aa->fetch_by_code('is_canonical');
 
-# Test updating transcript canonical attribute
-my ($canonical_attrib) = @{$tr->get_all_Attributes('is_canonical')};
-ok($canonical_attrib->value() == 1, 'Canonical transcript attribute set to 1');
-$tr->stable_id("ENSTEST00000217347");
-$ta->update($tr);
-
-$up_tr = $ta->fetch_by_stable_id( "ENSTEST00000217347" );
-($canonical_attrib) = @{$up_tr->get_all_Attributes('is_canonical')};
-ok($canonical_attrib->value() == 1, 'New canonical transcript attribute set to 1');
-is_rows(0, $db, "transcript_attrib", "where transcript_id = ? and attrib_type_id = ? ", [$up_tr->dbID(), $canonical_attrib_id->[0]]);
-
-my $canonical_gene = $up_tr->get_Gene;
-ok($canonical_gene->canonical_transcript->dbID() == $up_tr->dbID(), 'Updated canonical transcript in gene table');
+is_rows(1, $db, "transcript_attrib", "where transcript_id = ? and attrib_type_id = ? ", [$up_tr->dbID(), $canonical_attrib_id->[0]]);
 
 # Test adding new canonical transcript
-my $new_tr = $ta->fetch_by_stable_id( "ENSTEST00000217347" );
-$new_tr->stable_id("ENSTEST200000217347");
-foreach my $ex (@{$new_tr->get_all_Exons()}) {
-  $ex->dbID(undef);
-  $ex->adaptor(undef);
+my $new_tr = $ta->fetch_by_stable_id( "ENST00000217347" );
+my $canonical_gene = $new_tr->get_Gene;
+
+for (my $index=1; $index<3; $index++) {
+  $new_tr = $ta->fetch_by_stable_id( "ENST00000217347" );
+  $new_tr->stable_id("ENSTEST".$index."0000217347");
+  foreach my $ex (@{$new_tr->get_all_Exons()}) {
+    $ex->dbID(undef);
+    $ex->adaptor(undef);
+  }
+  $new_tr->adaptor(undef);
+  $new_tr->dbID(undef);
+  $new_tr->{'is_canonical'} = ($index == 1 ? 1 : 0);
+  $canonical_gene->add_Transcript($new_tr);
+  $ta->store($new_tr, $canonical_gene->dbID());
 }
-$new_tr->adaptor(undef);
-$new_tr->dbID(undef);
-$canonical_gene->canonical_transcript(undef);
-$new_tr->{'is_canonical'} = 1;
-$ta->store($new_tr, $canonical_gene->dbID());
 
-$new_tr = $ta->fetch_by_stable_id( "ENSTEST200000217347" );
-($canonical_attrib) = @{$new_tr->get_all_Attributes('is_canonical')};
-ok($canonical_attrib->value() == 1, 'New canonical transcript attribute set to 1');
+my $trans1 = $ta->fetch_by_stable_id("ENSTEST10000217347");
+my $trans2 = $ta->fetch_by_stable_id("ENSTEST20000217347");
+$canonical_gene = $trans1->get_Gene;
+
+my ($canonical_attrib) = @{$trans1->get_all_Attributes('is_canonical')};
+ok($canonical_attrib->value() == 1, 'Canonical transcript attribute set to 1');
 is_rows(0, $db, "transcript_attrib", "where transcript_id = ? and attrib_type_id = ? ", [$up_tr->dbID(), $canonical_attrib_id->[0]]);
+ok($canonical_gene->canonical_transcript->dbID() == $trans1->dbID(), 'Updated canonical transcript in gene table');
 
-$canonical_gene = $new_tr->get_Gene;
-ok($canonical_gene->canonical_transcript->dbID() == $new_tr->dbID(), 'Updated canonical transcript in gene table');
+# Test updating transcript canonical attribute
+$canonical_gene->remove_Transcript($trans1);
+$trans2->{'is_canonical'} = 1;
+$ta->update($trans2);
+
+$trans1 = $ta->fetch_by_stable_id("ENSTEST10000217347");
+$trans2 = $ta->fetch_by_stable_id("ENSTEST20000217347");
+$canonical_gene = $trans2->get_Gene;
+
+($canonical_attrib) = @{$trans2->get_all_Attributes('is_canonical')};
+ok($canonical_attrib->value() == 1, 'Canonical transcript attribute set to 1');
+is_rows(0, $db, "transcript_attrib", "where transcript_id = ? and attrib_type_id = ? ", [$trans1->dbID(), $canonical_attrib_id->[0]]);
+
 
 $tr->is_current(0);
 $ta->update($tr);

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -302,7 +302,7 @@ is_rows(0, $db, "transcript_attrib", "where transcript_id = ? and attrib_type_id
 
 $tr->is_current(0);
 $ta->update($tr);
-$up_tr = $ta->fetch_by_stable_id( "ENSTEST00000217347" );
+$up_tr = $ta->fetch_by_stable_id( "ENST00000217347" );
 ok(!$up_tr);
 
 $multi->restore('core', 'transcript', 'meta_coord');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

JIRA ticket: [3844](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3844)

Recently, the attribute 'is_canonical' was introduced into the transcript_attrib table and it serves as a duplication to the canonical_transcript_id column in the gene table. This change it concerned with adding consistency to the APIs by having the canonical transcript attribute be updated both in gene and transcript_attrib tables whenever it changes in one of them. This change is also added into the select_canonical_transcripts.pl (which uses sql queries for now, but testing is still ongoing to consider using APIs instead). Finally, new tests were added in gene.t and transcript.t in order to test this change moving forward.

## Use case

- When the store or update methods for gene are called with a change to the canonical_transcript_id, the is_canonical attribute in the transcript_attrib table is changed (set to 1 for new canonical transcript and deleted for old canonical transcript).
- When the store or update methods for transcript are called with a change to the is_canonical attribute, the canonical_transcript_id in the gene table is also updated.
- Running the select_canonical_transcripts.pl script now also updates transcript_attrib table whenever the canonical transcript is updated in the gene table

## Benefits

Having consistency in the data.

## Possible Drawbacks

This would be my first real change to the core APIs, and thus I might have missed something or added changes in a way that is not usually done when updating the APIs. Thus, I would appreciate any feedback and am open to any fixes.

## Testing

Added new tests for store and update methods into gene.t and transcript.t. These tests succeed, and so does the full test suite (after adding the is_canonical attribute to the core and empty test-gennome-DBs for homo sapiens).

