### PR TITLE
Bugfix: add compara patch required for wheat cultivars

### DIFF
--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Mon Jun 14 15:26:43 2021
+-- Created on Mon Nov 29 12:16:48 2021
 --
 
 BEGIN TRANSACTION;
@@ -263,7 +263,7 @@ CREATE TABLE "gene_tree_root" (
   "root_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "member_type" enum NOT NULL,
   "tree_type" enum NOT NULL,
-  "clusterset_id" varchar(20) NOT NULL DEFAULT 'default',
+  "clusterset_id" varchar(50) NOT NULL DEFAULT 'default',
   "method_link_species_set_id" integer NOT NULL,
   "species_tree_root_id" bigint,
   "gene_align_id" integer,

--- a/modules/t/test-genome-DBs/multi/compara/meta.txt
+++ b/modules/t/test-genome-DBs/multi/compara/meta.txt
@@ -71,3 +71,4 @@
 88	\N	patch	patch_103_104_c.sql|fix_int_types
 90	\N	patch	patch_104_105_a.sql|schema_version
 91	\N	patch	patch_105_106_a.sql|schema_version
+92	\N	patch	patch_105_106_b.sql|clusterset_id_varchar50

--- a/modules/t/test-genome-DBs/multi/compara/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/table.sql
@@ -230,7 +230,7 @@ CREATE TABLE `gene_tree_root` (
   `root_id` int(10) unsigned NOT NULL,
   `member_type` enum('protein','ncrna') NOT NULL,
   `tree_type` enum('clusterset','supertree','tree') NOT NULL,
-  `clusterset_id` varchar(20) NOT NULL DEFAULT 'default',
+  `clusterset_id` varchar(50) NOT NULL DEFAULT 'default',
   `method_link_species_set_id` int(10) unsigned NOT NULL,
   `species_tree_root_id` bigint(20) unsigned DEFAULT NULL,
   `gene_align_id` int(10) unsigned DEFAULT NULL,
@@ -436,7 +436,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=91 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=93 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `method_link` (
   `method_link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Description

Compara has included wheat cultivars protein trees in e106 and this has flagged a requirement to increase the column of one of our tables.

## Use case

To avoid clashes with the default protein trees, we prefix the name of these with `wheat_cultivars_`. As it usually happens, the largest value was 31 characters long (lucky us!). We have increased it to 50 just in case we have larger prefixes in the future, but this should be long enough to "never" have this issue again :crossed_fingers: 

## Benefits

We can now produce new varieties gene trees without concerns on this matter.

## Possible Drawbacks

None.

## Testing

This patch has been successfully applied to all Compara production pipelines and databases in e106 without raising any incompatibilities or issues.