### PR TITLE
Feature/seq region mapping index

### DIFF
--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:01 2021
+-- Created on Wed Oct 27 10:58:05 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:09 2021
+-- Created on Wed Oct 27 10:58:13 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:17 2021
+-- Created on Wed Oct 27 10:58:20 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:25 2021
+-- Created on Wed Oct 27 10:58:28 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:27 2021
+-- Created on Wed Oct 27 10:58:30 2021
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:33 2021
+-- Created on Wed Oct 27 10:58:37 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:40 2021
+-- Created on Wed Oct 27 10:58:44 2021
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:47 2021
+-- Created on Wed Oct 27 10:58:51 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:31:54 2021
+-- Created on Wed Oct 27 10:58:58 2021
 --
 
 BEGIN TRANSACTION;
@@ -847,6 +847,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -766,6 +766,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:34:36 2021
+-- Created on Wed Oct 27 10:59:01 2021
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/parus_major1/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:34:43 2021
+-- Created on Wed Oct 27 10:59:08 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/parus_major1/core/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:34:51 2021
+-- Created on Wed Oct 27 10:59:15 2021
 --
 
 BEGIN TRANSACTION;
@@ -858,6 +858,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -776,6 +776,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Wed Oct 27 10:34:58 2021
+-- Created on Wed Oct 27 10:59:22 2021
 --
 
 BEGIN TRANSACTION;
@@ -847,6 +847,8 @@ CREATE TABLE "seq_region_mapping" (
   "internal_seq_region_id" integer NOT NULL,
   "mapping_set_id" integer NOT NULL
 );
+
+CREATE UNIQUE INDEX "seq_region_mapping_uindex" ON "seq_region_mapping" ("external_seq_region_id", "internal_seq_region_id", "mapping_set_id");
 
 --
 -- Table: "seq_region_synonym"

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -766,6 +766,7 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/sql/patch_106_107_b.sql
+++ b/sql/patch_106_107_b.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-# patch_105_106_b.sql
+# patch_106_107_b.sql
 #
 # Title: Added index
 #

--- a/sql/patch_106_107_b.sql
+++ b/sql/patch_106_107_b.sql
@@ -1,0 +1,23 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2021] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_105_106_b.sql
+#
+# Title: Added index
+#
+# Description:
+#   Added unique index on seq_region_mapping
+
+CREATE UNIQUE INDEX seq_region_mapping_uindex on seq_region_mapping (external_seq_region_id, internal_seq_region_id, mapping_set_id);

--- a/sql/patch_106_107_b.sql
+++ b/sql/patch_106_107_b.sql
@@ -21,3 +21,8 @@
 #   Added unique index on seq_region_mapping
 
 CREATE UNIQUE INDEX seq_region_mapping_uindex on seq_region_mapping (external_seq_region_id, internal_seq_region_id, mapping_set_id);
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_106_107_b.sql|Added index for seq_region_mapping');
+

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -2027,7 +2027,8 @@ CREATE TABLE seq_region_mapping (
         internal_seq_region_id  INT(10) UNSIGNED NOT NULL,
         mapping_set_id          INT(10) UNSIGNED NOT NULL,
 
-        KEY mapping_set_idx (mapping_set_id)
+        KEY mapping_set_idx (mapping_set_id),
+	UNIQUE KEY seq_region_mapping_uindex (external_seq_region_id, internal_seq_region_id, mapping_set_id)
 
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -315,6 +315,8 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 # NOTE: Avoid line-breaks in values.
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_106_107_a.sql|schema_version');
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_106_107_b.sql|Added index for seq_region_mapping');
 
 
 /**


### PR DESCRIPTION
## Description

Added index in seq_region_mapping table for core DB. See ENSPROD-7014 for details.

## Use case

Avoid duplicate records

## Benefits

Avoid duplicate records

## Possible Drawbacks

None

## Testing

No changes

