### PR TITLE
Set $cs after fetch by fuzzy match

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -358,14 +358,15 @@ sub fetch_by_region {
         } else { # if no slice object with a match returned, try using a fuzzy match
           if (!$no_fuzz) {
 
-            my ($fuzzy_matched_name, $cs) = $self->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
-
+            my ($fuzzy_matched_name, $cs_new) = $self->_fetch_by_fuzzy_matching( $cs, $seq_region_name, $sql, $constraint, \@bind_params );
+	    $cs = $cs_new;
+	    
             if (!$fuzzy_matched_name) {
               return;
             }
 
             # define arr
-            my $tmp_key_string = $fuzzy_matched_name . ":" . $cs->dbID();
+            my $tmp_key_string = $fuzzy_matched_name . ":" . $cs_new->dbID();
             if (exists $self->{'sr_name_cache'}->{$tmp_key_string}) {
               $seq_region_name = $fuzzy_matched_name;
               $arr = $self->{'sr_name_cache'}->{$tmp_key_string};


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description
After `_fetch_by_fuzzy_matching` is called, the value for `$cs` remains undef on line: https://github.com/Ensembl/ensembl/compare/release/105...msmanoj:patch-1#diff-cb19b7e2cd91a60f1ac5117d8722fe002e75279535767baff667131d1bb81612L430

This is because the $cs defined on L361 is only available within that block.

This change was introduced in the following commit:
https://github.com/Ensembl/ensembl/commit/948057af657426df9bd0cc10290a8ec36473f54d#diff-cb19b7e2cd91a60f1ac5117d8722fe002e75279535767baff667131d1bb81612

## Use case
This PR fixes the issue reported in the following ticket:
https://helpdesk.ebi.ac.uk/Ticket/Display.html?id=552711

## Benefits

_If applicable, describe the advantages the changes will have._

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

