### PR TITLE
Bugfix/master rename 106

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ before_install:
   - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export SECONDARY_BRANCH=$TRAVIS_BRANCH; fi
   - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
   - echo "SECONDARY_BRANCH=$SECONDARY_BRANCH"
-  - git-ensembl --clone --depth 1 --branch master ensembl-test
-  - git-ensembl --clone --depth 1 --branch master ensembl-io
-  - git-ensembl --clone --depth 1 --branch master ensembl-variation
-  - git-ensembl --clone --depth 1 --branch master ensembl-compara
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-test
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-io
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-variation
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH ensembl-compara
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,18 @@ addons:
     - unzip
 
 before_install:
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-io.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-compara.git
+  - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+  - export PATH=$PWD/ensembl-git-tools/bin:$PATH
+  - export ENSEMBL_BRANCH='master'
+  - export SECONDARY_BRANCH='main'
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+  - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export SECONDARY_BRANCH=$TRAVIS_BRANCH; fi
+  - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
+  - echo "SECONDARY_BRANCH=$SECONDARY_BRANCH"
+  - git-ensembl --clone --depth 1 --branch master ensembl-test
+  - git-ensembl --clone --depth 1 --branch master ensembl-io
+  - git-ensembl --clone --depth 1 --branch master ensembl-variation
+  - git-ensembl --clone --depth 1 --branch master ensembl-compara
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This is the same fix to the travis config, addressing the master/main branch name issue, that has been applied to the master branches of most ensembl repos. In addition, this fixes an issue where the travis config was cloning the master branches of dependent repos even on released branches. Example: release/106 should (I think) be cloning release/106 of compara, variation, etc. but for a long, long time it's been cloning master.

## Use case

Makes travis builds more robust in the face of branch name changes

## Benefits

Travis won't fail because it can't clone a dependent repo, yay!

## Possible Drawbacks

Adds a dependency to ensembl git tools

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

We need to verify that the build on travis is successful.