### PR TITLE
Update Travis and Coveralls badges to 107

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ensembl Core API
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=master)][travis]
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=master)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=release/107)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=release/107)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl


### PR DESCRIPTION
## Description

Skipped updating the Travis and Coveralls badges when branching 107. Might review and merge this myself as it was supposed to be part of the branching.

## Use case

## Benefits

## Possible Drawbacks

## Testing

