### PR TITLE
Fix package name for renamed parsers

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2021] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ limitations under the License.
 
 # Parse RefSeq data from central database to create species specific xrefs.
 
-package XrefParser::RefSeqGPFFParser;
+package XrefParser::RefSeqDatabaseParser;
 
 use strict;
 use warnings;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtDatabaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2021] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ limitations under the License.
 
 
 
-package XrefParser::UniProtParser;
+package XrefParser::UniProtDatabaseParser;
 
 use strict;
 use warnings;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixing package names for new xref parsers.

## Use case

The UniProt and RefSeq parsers used for the new pre-parsing step of the xref pipeline were renamed to include "Database" so as not to be confused with the old parsers and to have some separation between the pre-parsing step and the parsing step. At renaming, however, the package name wasn't updated to reflect the new name. This PR fixes that.
Also, these 2 files were skipped during the yearly license update (not sure why) and thus the yearly license update was also added here.

## Benefits

New xref download fails without this change.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
N/A

_Have you run the entire test suite and no regression was detected?_
Test suite succeeds

