### PR TITLE
Use old parsers when needed

### DIFF
--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -1477,6 +1477,7 @@ source          = EntrezGene::MULTI
 source          = Reactome::MULTI
 source          = RNACentral::MULTI
 source          = RefSeq_dna::MULTI-vertebrate
+source          = RefSeq_peptide::MULTI-vertebrate
 source          = RefSeq_import::otherfeatures
 source          = Uniprot/SPTREMBL::MULTI
 source          = Uniprot/SWISSPROT::MULTI

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -520,6 +520,7 @@ order           = 15
 priority        = 2
 prio_descr      = refseq
 parser          = RefSeqDatabaseParser
+old_parser      = RefSeqGPFFParser
 
 [source RefSeq_dna::gencode]
 # Used by human and mouse
@@ -543,6 +544,7 @@ order           = 15
 priority        = 2
 prio_descr      = refseq
 parser          = RefSeqDatabaseParser
+old_parser      = RefSeqGPFFParser
 
 [source RefSeq_dna::MULTI-complete]
 # Used by phaeodactylum_tricornutum
@@ -822,6 +824,7 @@ order           = 20
 priority        = 3
 prio_descr      = sequence_mapped
 parser          = UniProtDatabaseParser
+old_parser      = UniProtParser
 dependent_on    = MIM
 
 [source Uniprot/SPTREMBL::gencode]
@@ -850,6 +853,7 @@ order           = 20
 priority        = 3
 prio_descr      = sequence_mapped
 parser          = UniProtDatabaseParser
+old_parser      = UniProtParser
 dependent_on    = MIM
 
 [source Uniprot/SWISSPROT::gencode]

--- a/misc-scripts/xref_mapping/xref_config2sql.pl
+++ b/misc-scripts/xref_mapping/xref_config2sql.pl
@@ -187,9 +187,10 @@ foreach my $species_section ( sort( $config->GroupMembers('species') ) )
     print(   "INSERT INTO source_url "
            . "(source_id, species_id, parser)\n" );
 
+    my $parser = (defined($config->val($source_section, 'old_parser')) ? $config->val($source_section, 'old_parser') : $config->val($source_section, 'parser'));
     printf( "VALUES (%d, %d, '%s') ;\n",
             $source_ids{$source_section}, $species_id,
-            $config->val( $source_section, 'parser' ) );
+            $parser );
 
     print("\n");
     


### PR DESCRIPTION
## Description

Making the xref config backwards compatible, to allow users to run the old Xref_update_conf pipeline without errors.

## Use case

Setting values for old parsers (used before new xref update) to be used if running the old xref pipeline or running the new one without pre-parsing.
The code only enters xref_config2sql.pl if no xref_source_dbi is provided, which is the case in the old pipeline or when pre-parsing is off.

## Benefits

Can run old pipeline with updated runnables without errors.

## Possible Drawbacks

N/A

## Testing

Ran the old pipeline (Xref_update_conf) with the 107 code and it ran without errors.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Note: Will need to add this change to main later on.
