### PR TITLE
Feature/annual copyright warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ We also invite you to read our code of conduct (http://www.ensembl.org/info/abou
 
 1. Fork the ensembl repository
 2. Switch to the branch you want to edit
-  * Consider using feature branches over editing master
+  * Consider using feature branches over editing main
 3. Hack away and commit with a useful commit message
   * First line is short but descriptive
   * Other lines are more explanatory
-4. Make sure your forked master is up-to date with origin and rebase if needed
+4. Make sure your forked main is up-to date with origin and rebase if needed
 6. Push
 7. Create a pull request
 8. Communicate what the change is
@@ -69,19 +69,19 @@ git remote add upstream https://github.com/Ensembl/ensembl.git
 
 ## Switching Branch
 
-By default Ensembl projects have a default branch of the **latest stable release**. If you are contributing a fix for a specific release then please remain there; otherwise switch to master.
+By default Ensembl projects have a default branch of the **latest stable release**. If you are contributing a fix for a specific release then please remain there; otherwise switch to main.
 
 ```
-git checkout --track -b master origin/master
+git checkout --track -b main origin/main
 ```
 
-To help improve your hacking time consider developing on a branch from master. This will allow you to bring in changes from upstream and integrate them into your fork without fear of merge conflicts. The following prefixes are available to use:
+To help improve your hacking time consider developing on a branch from main. This will allow you to bring in changes from upstream and integrate them into your fork without fear of merge conflicts. The following prefixes are available to use:
 
 * _feature/_ - A new feature going into a repository
 * _hotfix/_ - Fixes to be integrated into a branch
 * _experimental/_ - Experimental feature with no guarentee about hash stability
 
-Switch to a new branch once you are on master:
+Switch to a new branch once you are on main:
 
 ```
 git checkout -b hotfix/quickfixtoadaptor
@@ -106,19 +106,19 @@ retrieval system but rather the MySQL last insert id variable.
 
 Try also to minimise branches within your code base. If we see too many we will ask you to rebase/squish.
 
-## Syncing master with upstream, rebasing your changes and pushing
+## Syncing main with upstream, rebasing your changes and pushing
 
-First switch to master and pull in new changes from upstream held on master. This will bring those changes down and attempt to merge your local master with _upstream/master_. If you have changes on master be aware that this will probably require a merge commit. Staying away from master is a good idea.
+First switch to main and pull in new changes from upstream held on main. This will bring those changes down and attempt to merge your local main with _upstream/main_. If you have changes on main be aware that this will probably require a merge commit. Staying away from main is a good idea.
 
 ```
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 ```
-Once the changes are down rebase your branch against master:
+Once the changes are down rebase your branch against main:
 
 ```
 git checkout hotfix/quickfixtoadaptor
-git rebase master
+git rebase main
 ```
 Now push to origin:
 
@@ -132,7 +132,7 @@ https://help.github.com/articles/using-pull-requests
 
 Go to your GitHub fork's page, switch to your branch and click on the _Compare and Review_ button. This will start the merge. Then click on the top left +- file icon and edit accordingly:
 
-* Switch the base branch to _master_
+* Switch the base branch to _main_
 
 This ensures you are submitting your change against the right branch in Ensembl. For more information see [GitHub's documentation on doing this](https://help.github.com/articles/using-pull-requests#changing-the-branch-range-and-destination-repository).
 

--- a/misc-scripts/annual_copyright_updater.sh
+++ b/misc-scripts/annual_copyright_updater.sh
@@ -37,15 +37,32 @@ for var in $dirs; do
   search="^\(.*\)\\[\([0-9]*\)\(-*[0-9]*\)\\] EMBL-European Bioinformatics Institute"
   replacement="\1[\2-$year] EMBL-European Bioinformatics Institute"
 
+  likely_copyright_line=".*[0-9].* EMBL-European Bioinformatics Institute"
+  exception_line="Copyright \\[1999-2015\\] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute"
+
   echo "About to scan $(pwd) for files to replace '$search' with '$replacement'"
 
-  for file in $(grep -r --files-with-matches "$search" --exclude-dir=.git .); do
-    echo "Replacing date in $file"
+  for file in $(grep -r --files-with-matches "$likely_copyright_line" --exclude-dir=.git .); do
+
+    if [[ $(grep "$search" $file) ]]; then
+      echo "Replacing date in $file"
+    fi
+
     if [ "$(uname)" = "Darwin" ]; then
       LC_CTYPE=C LANG=C sed -i '' -e "s/$search/$replacement/g" $file
     else
       sed --in-place -e "s/$search/$replacement/g" $file
     fi
+
+    # If the line matches the more general $likely_copyright_line, but not the more specific $search regex that we
+    # know how to update, and isn't the $exception_line, then we warn the user that the line is likely a copyright
+    # line that we don't know how to update.
+    grep "$likely_copyright_line" $file | while read -r line ; do
+      if [[ $(echo $line | grep -v "$search") && $(echo $line | grep -v "$exception_line") ]]; then
+        echo "Unable to replace date in $file.  The line is: $line"
+      fi
+    done
+
   done
 
   cd $original_wd


### PR DESCRIPTION
## Description

_Using one or more sentences, describe in detail the proposed changes._

This PR contains two changes:
1. I have added a warning to `annual_copyright_updater.sh` for lines which probably need the year updating, but the script was unable to successfully update.
2. CONTRIBUTING.md has outdated references to `master` which I have updated to `main`.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

The annual_copyright_updater script currently misses some lines that are likely to need updating.  For example, one of my repos contained the line `Copyright 2022 EMBL-European Bioinformatics Institute` which the script misses.  Rather than try to handle different formats, this change adds a check against a looser regex to warn the user that there are probably copyright lines that the script was unable to replace.

## Benefits

_If applicable, describe the advantages the changes will have._

The Ensembl group will catch more instances of copyright notices that need updating.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

I have tested the change manually with these inputs:
1. A file with a well-formatted copyright notice that the script successfully replaces
2. A file with a badly-formatted copyright notice that the script successfully flags

_If so, do the tests pass/fail?_

The modified script passes my manual testing.

_Have you run the entire test suite and no regression was detected?_

I have not run the test suite.  I cannot see any test for `annual_copyright_updater.sh` in the package and I do not believe this change could break any tests.

If this change still requires me to run unit tests, could you please link me to some documentation on how to run them?