### PR TITLE
Xref/config bckwrds compat

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -213,6 +213,8 @@ sub prepare_metadata_file {
   my $ini_tm  = ( stat $ini_file )[9];
   my $meta_tm = ( stat $metadata_file )[9];
 
+  $preparse = 0 if (!defined($preparse));
+
   if ( !defined($meta_tm) || $ini_tm > $meta_tm ) {
     my $reply;
     if ($force) {

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -520,6 +520,7 @@ order           = 15
 priority        = 2
 prio_descr      = refseq
 parser          = RefSeqDatabaseParser
+old_parser      = RefSeqGPFFParser
 
 [source RefSeq_dna::gencode]
 # Used by human and mouse
@@ -543,6 +544,7 @@ order           = 15
 priority        = 2
 prio_descr      = refseq
 parser          = RefSeqDatabaseParser
+old_parser      = RefSeqGPFFParser
 
 [source RefSeq_dna::MULTI-complete]
 # Used by phaeodactylum_tricornutum
@@ -822,6 +824,7 @@ order           = 20
 priority        = 3
 prio_descr      = sequence_mapped
 parser          = UniProtDatabaseParser
+old_parser      = UniProtParser
 dependent_on    = MIM
 
 [source Uniprot/SPTREMBL::gencode]
@@ -850,6 +853,7 @@ order           = 20
 priority        = 3
 prio_descr      = sequence_mapped
 parser          = UniProtDatabaseParser
+old_parser      = UniProtParser
 dependent_on    = MIM
 
 [source Uniprot/SWISSPROT::gencode]
@@ -1473,6 +1477,7 @@ source          = EntrezGene::MULTI
 source          = Reactome::MULTI
 source          = RNACentral::MULTI
 source          = RefSeq_dna::MULTI-vertebrate
+source          = RefSeq_peptide::MULTI-vertebrate
 source          = RefSeq_import::otherfeatures
 source          = Uniprot/SPTREMBL::MULTI
 source          = Uniprot/SWISSPROT::MULTI

--- a/misc-scripts/xref_mapping/xref_config2sql.pl
+++ b/misc-scripts/xref_mapping/xref_config2sql.pl
@@ -40,6 +40,8 @@ use Config::IniFiles;
 my $file = (defined $ARGV[0] && -f $ARGV[0]) ? $ARGV[0] : 'xref_config.ini';
 warn "using ", $file;
 
+my $preparse = defined $ARGV[1] ? $ARGV[1] : 0;
+
 my $config = Config::IniFiles->new(-file => $file);
 if(! defined $config) {
   foreach my $e (@Config::IniFiles::errors) {
@@ -175,6 +177,8 @@ foreach my $species_section ( sort( $config->GroupMembers('species') ) )
     my $source_section = sprintf( "source %s", $source_name );
     $source_section =~ s/\s$//;
 
+    next if ($preparse && $species_id == 7742 && $source_name eq 'RefSeq_peptide::MULTI-vertebrate');
+
     if ( !exists( $source_ids{$source_section} ) ) {
       die( sprintf( "Can not find source section '[%s]'\n"
                       . "while reading species section '[%s]'\n",
@@ -187,9 +191,11 @@ foreach my $species_section ( sort( $config->GroupMembers('species') ) )
     print(   "INSERT INTO source_url "
            . "(source_id, species_id, parser)\n" );
 
+    my $parser = (defined($config->val($source_section, 'old_parser')) && !$preparse ? $config->val($source_section, 'old_parser') : $config->val($source_section, 'parser'));
+
     printf( "VALUES (%d, %d, '%s') ;\n",
             $source_ids{$source_section}, $species_id,
-            $config->val( $source_section, 'parser' ) );
+            $parser );
 
     print("\n");
     

--- a/misc-scripts/xref_mapping/xref_config2sql.pl
+++ b/misc-scripts/xref_mapping/xref_config2sql.pl
@@ -177,6 +177,8 @@ foreach my $species_section ( sort( $config->GroupMembers('species') ) )
     my $source_section = sprintf( "source %s", $source_name );
     $source_section =~ s/\s$//;
 
+    # If preparsing, remove RefSeq_peptide for vertebrates (7742)
+    # since this will be parsed with RefSeq_dna
     next if ($preparse && $species_id == 7742 && $source_name eq 'RefSeq_peptide::MULTI-vertebrate');
 
     if ( !exists( $source_ids{$source_section} ) ) {


### PR DESCRIPTION
## Description

Final backwards compatibility changes to allow running the new or old xref pipelines. 

## Use case

This change handles the creation of the central xref database and the intermediate xref_update database. It specifically uses the old parsers for RefSeq_dna and UniProt instead of the new ones if no pre-parsing is being performed. It also doesn't include RefSeq_peptide in the vertebrates sources if we're pre-parsing as in that case this will be included with the RefSeq_dna parsing.

Note: This change includes the changes added to release/107 in PR #608 

## Benefits

New pipeline can be run with pre-parsing set to 0, and old pipeline can be run successfully.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

