### PR TITLE
Trim the DOS/Windows line ending from files

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
@@ -112,6 +112,8 @@ sub run {
   # ENSG00000138685 REACT_111045    http://www.reactome.org/PathwayBrowser/#REACT_111045    Developmental Biology   TAS     Homo sapiens
     while (my $line = $reactome_io->getline() ) {
       chomp $line;
+      $line =~ s/\r//g;
+
       my ($ensembl_stable_id, $reactome_id, $url, $description, $evidence, $species) = split /\t+/,$line;
       if ($description!~ /^[A-Za-z0-9_,\(\)\/\-\.:\+'&;"\/\?%>\s\[\]]+$/) { next; }
   


### PR DESCRIPTION
## Description

Trimming the Reactome lines to remove the DOS/Windows newline character "\r".

## Use case

The Reactome files have recently changed their newline format (DOS/Windows). This creates a problem when parsing the lines and extracting the data from them, specifically the species name which happens to be at the end of the line.

A solution proposed by Jose Gonzalez (who discovered this problem) includes removing any non-word character "\W" at the end of the species name. However, this is limited to Latin characters and might cause problems if a species name has a special character at the end. I decided that specifically removing the "\r" instead is a safer way to go. In addition, if the Reactome files go back to the previous format, this won't break anything.

## Benefits

The Reactome parser can correctly read the species names.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

