### PR TITLE
Xref/new source genecards

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@
     - apt-get install -y libssl-dev sqlite3
     - git clone --branch=main --depth=1 https://github.com/Ensembl/ensembl-test.git
     - git clone --branch=main --depth=1 https://github.com/Ensembl/ensembl-io.git
-    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl-variation.git
+    - git clone --branch=main --depth=1 https://github.com/Ensembl/ensembl-variation.git
     - git clone --branch=main --depth=1 https://github.com/Ensembl/ensembl-compara.git
     - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git
     - cpanm -v --installdeps --notest . --with-all-features

--- a/misc-scripts/xref_mapping/XrefMapper/BasicMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/BasicMapper.pm
@@ -1213,7 +1213,7 @@ sub get_gene_specific_list {
 
   $dbi = $self->xref->dbc unless defined $dbi;
 
-  my @list = qw(DBASS3 DBASS5 EntrezGene miRBase RFAM TRNASCAN_SE RNAMMER UniGene Uniprot_gn WikiGene MIM_GENE MIM_MORBID HGNC MGI ZFIN_ID FlyBaseName_gene RGD SGD_GENE VGNC wormbase_gseqname wormbase_locus Xenbase);
+  my @list = qw(DBASS3 DBASS5 EntrezGene miRBase RFAM TRNASCAN_SE RNAMMER UniGene Uniprot_gn WikiGene MIM_GENE MIM_MORBID HGNC MGI ZFIN_ID FlyBaseName_gene RGD SGD_GENE VGNC wormbase_gseqname wormbase_locus Xenbase GeneCards);
 
   # Check the sources are used in the database considered
   my (@used_list, $sql, $sth, $count);

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -330,7 +330,7 @@ CCDS
 
       $self->add_synonyms_for_hgnc({
           source_id  => $self->{source_ids}->{'genecards'},
-          name       => $acc,
+          name       => $hgnc_id,
           species_id => $species_id,
           dbi        => $dbi,
           dead       => $previous_symbols,

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -316,14 +316,15 @@ CCDS
       $name_count{'ensembl_manual'}++;
 
       # GeneCards
-      $self->add_xref({
-          acc        => $acc,
-          label      => $symbol,
-          desc       => $name,
-          source_id  => $self->{source_ids}->{'genecards'},
-          species_id => $species_id,
-          dbi        => $dbi,
-          info_type  => 'DEPENDENT'
+      my $direct_id = $self->get_xref($acc, $self->{source_ids}->{'ensembl_manual'}, $species_id, $dbi);
+      $self->add_dependent_xref({
+          master_xref_id => $direct_id,
+          acc            => $acc,
+          label          => $symbol,
+          desc           => $name,
+          source_id      => $self->{source_ids}->{'genecards'},
+          dbi            => $dbi,
+          species_id     => $species_id
       });
 
       $self->add_synonyms_for_hgnc({

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -124,6 +124,7 @@ sub run_script {
     $self->{source_ids}->{$source_name} = $self->get_source_id_for_source_name( $self_source_name, $source_name , $dbi );
   }
   $self->{source_ids}->{'lrg'} = $self->get_source_id_for_source_name( 'LRG_HGNC_notransfer', undef, $dbi );
+  $self->{source_ids}->{'genecards'} = $self->get_source_id_for_source_name('GeneCards', undef, $dbi);
 
   # statistics counts
   my %name_count;
@@ -313,6 +314,27 @@ CCDS
           alias      => $synonyms
       });
       $name_count{'ensembl_manual'}++;
+
+      # GeneCards
+      $self->add_xref({
+          acc        => $acc,
+          label      => $symbol,
+          desc       => $name,
+          source_id  => $self->{source_ids}->{'genecards'},
+          species_id => $species_id,
+          dbi        => $dbi,
+          info_type  => 'DEPENDENT'
+      });
+
+      $self->add_synonyms_for_hgnc({
+          source_id  => $self->{source_ids}->{'genecards'},
+          name       => $acc,
+          species_id => $species_id,
+          dbi        => $dbi,
+          dead       => $previous_symbols,
+          alias      => $synonyms
+      });
+      $name_count{'genecards'}++;
     }
 
     # RefSeq

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -317,9 +317,10 @@ CCDS
 
       # GeneCards
       my $direct_id = $self->get_xref($acc, $self->{source_ids}->{'ensembl_manual'}, $species_id, $dbi);
+      my ($hgnc_id) = $acc =~ /HGNC:(\d+)/;
       $self->add_dependent_xref({
           master_xref_id => $direct_id,
-          acc            => $acc,
+          acc            => $hgnc_id,
           label          => $symbol,
           desc           => $name,
           source_id      => $self->{source_ids}->{'genecards'},

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -444,6 +444,10 @@ sub create_xrefs {
         if ($source =~ "MIM_GENE" || $source =~ "MIM_MORBID" || $source =~ "MIM") {
             next;
         }
+        # GeneCards xrefs are imported through the HGNC file
+        if ($source =~ "GeneCards") {
+          next;
+        }
 # If mapped to Ensembl, add as direct xref
         if ($source eq "Ensembl") {
 # Example line:

--- a/misc-scripts/xref_mapping/t/hgnc.t
+++ b/misc-scripts/xref_mapping/t/hgnc.t
@@ -78,6 +78,9 @@ $db->schema->resultset('Source')->populate([
     source_id            => 54,
     name                 => 'LRG_HGNC_notransfer',
   },{
+    source_id            => 55,
+    name                 => 'GeneCards',
+  },{
     source_id            => 23,
     name                 => 'EntrezGene',
   },{
@@ -101,8 +104,9 @@ $parser->run_script( {
 } );
 
 # Test if all the rows were inserted
-is($db->schema->resultset('Xref')->count, 22, "All 22 HGNC xrefs were inserted");
-is($db->schema->resultset('Synonym')->count, 42, "All 42 HGNC synonyms were inserted");
+is($db->schema->resultset('Xref')->count, 42, "All 42 xrefs were inserted: 22 HGNC and 20 GeneCards");
+is($db->schema->resultset('Xref')->count({info_type => 'DEPENDENT'}), 20, "All 20 dependent GeneCards xrefs were inserted");
+is($db->schema->resultset('Synonym')->count, 78, "All 78 synonyms were inserted: 42 HGNC and 36 GeneCards");
 
 ok(
   $db->schema->resultset('Xref')->check_direct_xref({

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -443,6 +443,13 @@ priority        = 1
 parser          = Mim2GeneParser
 dependent_on    = MIM,EntrezGene
 
+[source GeneCards::homo_sapiens]
+# used via the HGNCParser, for homo_sapiens
+name            = GeneCards
+order           = 100
+priority        = 1
+parser          = HGNCParser
+
 [source MGI::mus_musculus#01]
 # Used by mus_musculus
 name            = MGI

--- a/sql/patch_108_109_b.sql
+++ b/sql/patch_108_109_b.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2022] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_108_109_b.sql
+#
+# Title: Added external_db
+#
+# Description:
+#   Added xref source GeneCards into external_db
+
+INSERT INTO external_db (db_name, status, priority, db_display_name, type) VALUES ('GeneCards', 'XREF', 50, 'GeneCards', 'MISC');
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_108_109_b.sql|Added xref source GeneCards into external_db');


### PR DESCRIPTION
## Description

A new xref source, GeneCards, was added into the xref pipeline. It is a dependent source and it depends on the HGNC direct mapping to Ensembl. Since the UniProt files also include mentions of the GeneCards source, a skip was necessary there as the number of xrefs we get from UniProt is almost half the ones we get from HGNC, and almost all of them are a subset of the HGNC ones. This change also includes an update to the HGNC test script.

The accession value for these GeneCards xref is set to only the HGNC ID (instead of "HGNC:ID". That was done in order to accommodate the way that web reads this info to display the xref link on the website.

Note: For adding the new source into the external_db tables, the patch created is suffixed with "_b" instead of "_a" to reserve the latter for the schema version bump to 109.

## Use case

We've been asked to reciprocate the GeneCards mapping.

## Benefits

Another xref source is added which enriches our xref data.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

hgnc.t was modified to handle the new changes

_If so, do the tests pass/fail?_

tests are passing

_Have you run the entire test suite and no regression was detected?_

