### PR TITLE
Replace deprecated `GeneMember::fetch_by_stable_id` with `GeneMember:…

### DIFF
--- a/modules/Bio/EnsEMBL/Gene.pm
+++ b/modules/Bio/EnsEMBL/Gene.pm
@@ -858,7 +858,7 @@ sub get_all_homologous_Genes {
 
   # Get the compara 'member' corresponding to self
   my $member_adaptor   = $compara_dba->get_adaptor('GeneMember');
-  my $query_member = $member_adaptor->fetch_by_stable_id($self->stable_id);
+  my $query_member = $member_adaptor->fetch_by_Gene($self);
   unless( $query_member ){ return $self->{'homologues'}->{$compara_species} };
 
   # Get the compara 'homologies' corresponding to 'member'


### PR DESCRIPTION
…:fetch_by_Gene`

### Description

In e109 compara are deprecating the method `MemberAdaptor::fetch_by_stable_id()` - this PR addresses the replacement of this method with new method `MemberAdaptor::fetch_by_stable_id_GenomeDB()`.
See ticket: [ENSCOMPARASW-5270](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-5270).
Related PR: https://github.com/Ensembl/ensembl-compara/pull/469

### Use case

A `stable_id` is only unique within a genome and not across a compara database. This has always been a case, but until recently, and purely by chance, there have been no overlapping `stable_id`. As the number of species included in EnsEMBL increases this becomes a big problem, and so the change is urgent-ish and necessary.

### Benefits

The benefits include not breaking `ensembl-compara` or `ensembl` and the ability to include all/any combination of species within compara, regardless of duplicated `stable_ids` in genes/proteins etc.
This also looks cleaner and makes much better use of Compara API.
 
### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

The individual tests passed locally ~~- will see how it goes here.~~

_Have you run the entire test suite and no regression was detected?_

No regression was detected between changed and unchanged ~~- however it was noticed in local testing that there is/was an issue Variation side. Will find out here.~~
