### PR TITLE
Fix/xref refseq

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
@@ -40,32 +40,39 @@ sub run {
     croak "Need to pass source_id, species_id and xref_source";
   }
 
+  my $source_name = $self->get_source_name_for_source_id($source_id, $dbi);
   my @source_ids;
-  my $peptide_source_id =
-    $self->get_source_id_for_source_name('RefSeq_peptide', undef, $dbi);
-  push @source_ids, $peptide_source_id;
-  my $mrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_mRNA','refseq', $dbi);
-  push @source_ids, $mrna_source_id;
-  my $ncrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_ncRNA', undef, $dbi);
-  push @source_ids, $ncrna_source_id;
 
-  my $pred_peptide_source_id =
-    $self->get_source_id_for_source_name('RefSeq_peptide_predicted', undef, $dbi);
-  push @source_ids, $pred_peptide_source_id;
-  my $pred_mrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_mRNA_predicted','refseq', $dbi);
-  push @source_ids, $pred_mrna_source_id;
-  my $pred_ncrna_source_id =
-    $self->get_source_id_for_source_name('RefSeq_ncRNA_predicted', undef, $dbi);
-  push @source_ids, $pred_ncrna_source_id;
+  if ($source_name =~ /RefSeq_dna/) {
+    my $mrna_source_id = $self->get_source_id_for_source_name('RefSeq_mRNA','refseq', $dbi);
+    push @source_ids, $mrna_source_id;
+    my $pred_mrna_source_id = $self->get_source_id_for_source_name('RefSeq_mRNA_predicted','refseq', $dbi);
+    push @source_ids, $pred_mrna_source_id;
+    my $ncrna_source_id = $self->get_source_id_for_source_name('RefSeq_ncRNA', undef, $dbi);
+    push @source_ids, $ncrna_source_id;
+    my $pred_ncrna_source_id = $self->get_source_id_for_source_name('RefSeq_ncRNA_predicted', undef, $dbi);
+    push @source_ids, $pred_ncrna_source_id;
+  } elsif ($source_name =~ /RefSeq_peptide/) {
+    my $peptide_source_id = $self->get_source_id_for_source_name('RefSeq_peptide', undef, $dbi);
+    push @source_ids, $peptide_source_id;
+    my $pred_peptide_source_id = $self->get_source_id_for_source_name('RefSeq_peptide_predicted', undef, $dbi);
+    push @source_ids, $pred_peptide_source_id;
+  }
 
   my $entrez_source_id = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
   my $wiki_source_id = $self->get_source_id_for_source_name('WikiGene', undef, $dbi);
 
   # Retrieve existing NCBIGene xrefs
   my (%entrez)     = %{$self->get_acc_to_label("EntrezGene",$species_id, undef, $dbi)};
+
+  # Get existing mrna, entrezgene and wikigene accession => xref_id
+  my (%refseq_ids, %entrez_ids, %wiki_ids, $add_dependent_xref_sth);
+  if ($source_name =~ /RefSeq_peptide/) {
+    (%refseq_ids) = %{ $self->get_valid_codes("RefSeq_mRNA", $species_id, $dbi) };
+    (%entrez_ids) = %{ $self->get_valid_codes("EntrezGene", $species_id, $dbi) };
+    (%wiki_ids) = %{ $self->get_valid_codes("WikiGene", $species_id, $dbi) };
+    $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id, dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)");
+  }
 
   my $get_xref_sql = "SELECT xref_id, accession, version, label, description, info_type ".
   "FROM xref WHERE species_id = ? AND source_id = ?";
@@ -77,7 +84,7 @@ sub run {
   my $get_sequence_sth = $xref_source->prepare($get_sequence_sql);
   my $get_synonym_sql = "SELECT synonym FROM synonym WHERE xref_id = ?";
   my $get_synonym_sth = $xref_source->prepare($get_synonym_sql);
-  my $get_pair_sql = "SELECT accession1 FROM pairs where accession2 = ?";
+  my $get_pair_sql = "SELECT accession2 FROM pairs where accession1 = ?";
   my $get_pair_sth = $xref_source->prepare($get_pair_sql);
   my ($xref_id, $accession, $version, $label, $description, $info_type, $parsed_seq, $type, $status, $dep_xref_id, $dep_accession, $dep_version, $dep_label, $dep_description, $dep_source_id, $dep_species_id, $linkage_source_id, $synonym, $refseq_pair);
 
@@ -129,7 +136,7 @@ sub run {
 	if (defined $entrez{$dep_accession}) {
           my %dep;
 	  $dep{ACCESSION} = $dep_accession;
-	  $dep{LABEL} = $dep_label;
+	  $dep{LABEL} = $entrez{$dep_accession};
 	  $dep{VERSION} = $dep_version;
 	  $dep{DESCRIPTION} = $dep_description;
 	  $dep{SOURCE_ID} = $entrez_source_id;
@@ -138,12 +145,28 @@ sub run {
 
 	  my %dep2;
 	  $dep2{ACCESSION} = $dep_accession;
-	  $dep2{LABEL} = $dep_label;
+	  $dep2{LABEL} = $entrez{$dep_accession};
 	  $dep2{VERSION} = $dep_version;
 	  $dep2{DESCRIPTION} = $dep_description;
 	  $dep2{SOURCE_ID} = $wiki_source_id;
 	  $dep2{LINKAGE_SOURCE_ID} = $linkage_source_id;
 	  push @{$xref->{DEPENDENT_XREFS}}, \%dep2;
+
+	  # Add dependent xrefs for RefSeq mRNA as well where available
+          # only after they are added in priorit 1
+	  $refseq_pair =~ s/\.[0-9]*// if $refseq_pair;
+          if (defined $refseq_pair) {
+            if ($refseq_ids{$refseq_pair}) {
+              foreach my $refseq_id (@{ $refseq_ids{$refseq_pair} }) {
+                foreach my $entrez_id (@{ $entrez_ids{$dep_accession} }) {
+                  $add_dependent_xref_sth->execute($refseq_id, $entrez_id);
+                }
+                foreach my $wiki_id (@{ $wiki_ids{$dep_accession} }) {
+                  $add_dependent_xref_sth->execute($refseq_id, $wiki_id);
+                }
+              }
+            }
+          }
         }
       }
   

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
@@ -96,7 +96,7 @@ sub run {
     while ($get_xref_sth->fetch()) {
       my $xref = {};
       $count++;
-  
+
       $xref->{ACCESSION} = $accession;
       $xref->{LABEL} = $label;
       $xref->{VERSION} = $version;
@@ -133,45 +133,45 @@ sub run {
       $get_dependent_sth->bind_columns(\$dep_xref_id, \$dep_accession, \$dep_version, \$dep_label, \$dep_description, \$dep_source_id, \$dep_species_id, \$linkage_source_id);
       while ($get_dependent_sth->fetch) {
         if ($dep_species_id != $species_id) { next; }
-	if (defined $entrez{$dep_accession}) {
+        if (defined $entrez{$dep_accession}) {
           my %dep;
-	  $dep{ACCESSION} = $dep_accession;
-	  $dep{LABEL} = $entrez{$dep_accession};
-	  $dep{VERSION} = $dep_version;
-	  $dep{DESCRIPTION} = $dep_description;
-	  $dep{SOURCE_ID} = $entrez_source_id;
-	  $dep{LINKAGE_SOURCE_ID} = $linkage_source_id;
-	  push @{$xref->{DEPENDENT_XREFS}}, \%dep;
+          $dep{ACCESSION} = $dep_accession;
+          $dep{LABEL} = $entrez{$dep_accession};
+          $dep{VERSION} = $dep_version;
+          $dep{DESCRIPTION} = $dep_description;
+          $dep{SOURCE_ID} = $entrez_source_id;
+          $dep{LINKAGE_SOURCE_ID} = $linkage_source_id;
+          push @{$xref->{DEPENDENT_XREFS}}, \%dep;
 
-	  my %dep2;
-	  $dep2{ACCESSION} = $dep_accession;
-	  $dep2{LABEL} = $entrez{$dep_accession};
-	  $dep2{VERSION} = $dep_version;
-	  $dep2{DESCRIPTION} = $dep_description;
-	  $dep2{SOURCE_ID} = $wiki_source_id;
-	  $dep2{LINKAGE_SOURCE_ID} = $linkage_source_id;
-	  push @{$xref->{DEPENDENT_XREFS}}, \%dep2;
+          my %dep2;
+          $dep2{ACCESSION} = $dep_accession;
+          $dep2{LABEL} = $entrez{$dep_accession};
+          $dep2{VERSION} = $dep_version;
+          $dep2{DESCRIPTION} = $dep_description;
+          $dep2{SOURCE_ID} = $wiki_source_id;
+          $dep2{LINKAGE_SOURCE_ID} = $linkage_source_id;
+          push @{$xref->{DEPENDENT_XREFS}}, \%dep2;
 
-	  # Add dependent xrefs for RefSeq mRNA as well where available
-         # only after they are added in priority 1
-	  $refseq_pair =~ s/\.[0-9]*// if $refseq_pair;
-         if (defined $refseq_pair) {
-           if ($refseq_ids{$refseq_pair}) {
-             foreach my $refseq_id (@{ $refseq_ids{$refseq_pair} }) {
-               foreach my $entrez_id (@{ $entrez_ids{$dep_accession} }) {
-                 $add_dependent_xref_sth->execute($refseq_id, $entrez_id);
-               }
-               foreach my $wiki_id (@{ $wiki_ids{$dep_accession} }) {
-                 $add_dependent_xref_sth->execute($refseq_id, $wiki_id);
-               }
-             }
-           }
-         }
+          # Add dependent xrefs for RefSeq mRNA as well where available
+          # only after they are added in priority 1
+          $refseq_pair =~ s/\.[0-9]*// if $refseq_pair;
+          if (defined $refseq_pair) {
+            if ($refseq_ids{$refseq_pair}) {
+              foreach my $refseq_id (@{ $refseq_ids{$refseq_pair} }) {
+                foreach my $entrez_id (@{ $entrez_ids{$dep_accession} }) {
+                  $add_dependent_xref_sth->execute($refseq_id, $entrez_id);
+                }
+                foreach my $wiki_id (@{ $wiki_ids{$dep_accession} }) {
+                  $add_dependent_xref_sth->execute($refseq_id, $wiki_id);
+                }
+              }
+            }
+          }
         }
       }
-  
+
       push @xrefs, $xref;
-  
+
       if ($count > 1000) {
         $self->upload_xref_object_graphs( \@xrefs, $dbi );
         $count = 0;

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
@@ -153,20 +153,20 @@ sub run {
 	  push @{$xref->{DEPENDENT_XREFS}}, \%dep2;
 
 	  # Add dependent xrefs for RefSeq mRNA as well where available
-          # only after they are added in priorit 1
+         # only after they are added in priority 1
 	  $refseq_pair =~ s/\.[0-9]*// if $refseq_pair;
-          if (defined $refseq_pair) {
-            if ($refseq_ids{$refseq_pair}) {
-              foreach my $refseq_id (@{ $refseq_ids{$refseq_pair} }) {
-                foreach my $entrez_id (@{ $entrez_ids{$dep_accession} }) {
-                  $add_dependent_xref_sth->execute($refseq_id, $entrez_id);
-                }
-                foreach my $wiki_id (@{ $wiki_ids{$dep_accession} }) {
-                  $add_dependent_xref_sth->execute($refseq_id, $wiki_id);
-                }
-              }
-            }
-          }
+         if (defined $refseq_pair) {
+           if ($refseq_ids{$refseq_pair}) {
+             foreach my $refseq_id (@{ $refseq_ids{$refseq_pair} }) {
+               foreach my $entrez_id (@{ $entrez_ids{$dep_accession} }) {
+                 $add_dependent_xref_sth->execute($refseq_id, $entrez_id);
+               }
+               foreach my $wiki_id (@{ $wiki_ids{$dep_accession} }) {
+                 $add_dependent_xref_sth->execute($refseq_id, $wiki_id);
+               }
+             }
+           }
+         }
         }
       }
   

--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -124,7 +124,8 @@ sub run {
 
   my $input_file = Text::CSV->new({
     sep_char       => "\t",
-    empty_is_undef => 1
+    empty_is_undef => 1,
+    binary => 1
   }) or confess "Cannot use file '$file': ".Text::CSV->error_diag();
 
   # header must contain these columns

--- a/misc-scripts/xref_mapping/sql/table.sql
+++ b/misc-scripts/xref_mapping/sql/table.sql
@@ -40,7 +40,8 @@ CREATE TABLE xref (
                                     'UNMAPPED_NO_STABLE_ID', 'UNMAPPED_INTERPRO') DEFAULT null,
 
   PRIMARY KEY (xref_id),
-  UNIQUE acession_idx(accession,label,source_id,species_id)
+  UNIQUE acession_idx(accession,label,source_id,species_id),
+  INDEX species_source_idx(species_id, source_id)
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
@@ -201,7 +202,8 @@ CREATE TABLE pairs (
   accession1                     varchar(255) not null,
   accession2                     varchar(255) not null,
 
-  KEY ac2_idx(accession2)
+  KEY ac2_idx(accession2),
+  KEY ac1_idx(accession1)
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 ################################################################################

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -737,7 +737,8 @@ name            = RefSeq_peptide
 order           = 25
 priority        = 2
 prio_descr      = refseq
-parser          = RefSeqGPFFParser
+parser          = RefSeqDatabaseParser
+old_parser      = RefSeqGPFFParser
 
 [source SGD_GENE::saccharomyces_cerevisiae]
 # Used by saccharomyces_cerevisiae

--- a/misc-scripts/xref_mapping/xref_config2sql.pl
+++ b/misc-scripts/xref_mapping/xref_config2sql.pl
@@ -177,10 +177,6 @@ foreach my $species_section ( sort( $config->GroupMembers('species') ) )
     my $source_section = sprintf( "source %s", $source_name );
     $source_section =~ s/\s$//;
 
-    # If preparsing, remove RefSeq_peptide for vertebrates (7742)
-    # since this will be parsed with RefSeq_dna
-    next if ($preparse && $species_id == 7742 && $source_name eq 'RefSeq_peptide::MULTI-vertebrate');
-
     if ( !exists( $source_ids{$source_section} ) ) {
       die( sprintf( "Can not find source section '[%s]'\n"
                       . "while reading species section '[%s]'\n",


### PR DESCRIPTION
## Description

This change includes what was added in #620 with a few additions that were put in as a temporary patch in the change merged into release/108. This change includes the addition of code that was missed when the new RefSeq parsers (pre-parser and central db parser) were devised. This also fixes a typo in selecting from the pairs table from the central DB. In addition, the RefSeq parser needs to run twice, once for dna and once for peptide, in order to add all the relevant data, and thus this behavior was restored (after it was removed in #612 ). Lastly, this change also includes the addition of 2 indexes into the xref and pairs tables to make accessing the central DB quicker.

## Use case

The missing RefSeq parser code was leading to a decrease in the number of xrefs for EntrezGene, WikiGene, and RefSeq_peptide.

## Benefits

Correct xrefs are read from the central DB and inserted into the species xref DB.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

