### PR TITLE
Update ftp links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To clone the Ensembl Core API, use the following command:
 ```
 git clone https://github.com/Ensembl/ensembl.git
 ```
-Alternatively, you can download the files in gzipped TAR format from our [FTP site](ftp://ftp.ensembl.org/pub/ensembl-api.tar.gz).
+Alternatively, you can download the files in gzipped TAR format from our [FTP site](https://ftp.ensembl.org/pub/ensembl-api.tar.gz).
 
 ## API requirements
 In order to use the Ensembl Core API, an installation of [BioPerl 1.6.924 core modules](https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip) (bioperl-live) is required.

--- a/misc-scripts/assembly_patches/README.TXT
+++ b/misc-scripts/assembly_patches/README.TXT
@@ -14,12 +14,12 @@ See file thjat was attached to get ref->hap mappings.
 NOW use....
 -----------
 
- wget ftp://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/PATCHES/patch_release_1/FASTA/alt.scaf.fa.gz
+ wget https://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/PATCHES/patch_release_1/FASTA/alt.scaf.fa.gz
 gunzip alt.scaf.fa.gz
 
- wget ftp://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/PATCHES/patch_release_1/alt_scaffold_placement.txt
+ wget https://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/PATCHES/patch_release_1/alt_scaffold_placement.txt
 
-wget ftp://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/PATCHES/patch_release_1/AGP/alt.scaf.agp.gz
+wget https://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh37/PATCHES/patch_release_1/AGP/alt.scaf.agp.gz
 gunzip alt.scaf.agp.gz
 
 

--- a/misc-scripts/import/import_bed_simple_feature.pl
+++ b/misc-scripts/import/import_bed_simple_feature.pl
@@ -16,7 +16,7 @@
 
 
 # Designed to work on BED data such as that available from UCSC or 1KG:
-# ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase1/analysis_results/supporting/accessible_genome_masks
+# https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase1/analysis_results/supporting/accessible_genome_masks
 #
 
 use strict;

--- a/misc-scripts/import/import_recombinant_hotspots.pl
+++ b/misc-scripts/import/import_recombinant_hotspots.pl
@@ -16,7 +16,7 @@
 
 
 # Designed to work on data retrieved from 
-# ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20110106_recombination_hotspots/
+# https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20110106_recombination_hotspots/
 #
 # Imports the recombination hotspots from 1000 Genomes into Ensembl
 
@@ -103,7 +103,7 @@ sub process_file {
 The map was then converted from NCBI35 to GRCh37 coordinates and inspected for regions in which
 the genome assembly had be rearranged.
 
-See ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20110106_recombination_hotspots/",
+See https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20110106_recombination_hotspots/",
         -display_label => 'HapMap Phase II genetic recombination map',
         -displayable => 1,
         -logic_name => 'human_1kg_hapmap_phase_2',

--- a/misc-scripts/import/karyotype_rank_assigner.pl
+++ b/misc-scripts/import/karyotype_rank_assigner.pl
@@ -26,7 +26,7 @@ use Getopt::Long;
 my ($db_name, $db_host, $db_user, $db_pass, $db_port, $help, $species, $group, $no_interactive);
 my @user_karyotype;
 
-my $NCBI_BASE = 'ftp://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/All';
+my $NCBI_BASE = 'https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/All';
 
 $db_port = 3306;
 $species = 'human';

--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -32,7 +32,7 @@ XrefParser::VGNCParser
 A parser class to parse the VGNC source.
 VGNC is the official naming source for some vertebrates species
 
--data_uri = ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
+-data_uri = https://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz
 -file_format = TSV
 -columns = [
     taxon_id

--- a/misc-scripts/xref_mapping/t/test-data/hgnc.tsv
+++ b/misc-scripts/xref_mapping/t/test-data/hgnc.tsv
@@ -7,7 +7,7 @@ HGNC:27057	A2M-AS1	A2M antisense RNA 1			144571	ENSG00000245105	NR_026971
 HGNC:41022	A2ML1-AS1	A2ML1 antisense RNA 1				ENSG00000256661			
 HGNC:8	A2MP1	alpha-2-macroglobulin pseudogene 1	A2MP		3	ENSG00000256069	NG_001067		
 HGNC:30005	A3GALT2	alpha 1,3-galactosyltransferase 2	A3GALT2P	IGBS3S, IGB3S	127550	ENSG00000184389	NM_001080438	CCDS60080	
-HGNC:18149	A4GALT	alpha 1,4-galactosyltransferase (P blood group)	P1	A14GALT, Gb3S, P(k)	53947	ENSG00000128274	NM_017436	CCDS14041	 "Global Variome shared LOVD|https://databases.lovd.nl/shared/genes/ABCB7","LRG_795|http://ftp.ebi.ac.uk/pub/databases/lrgex/pending/LRG_795.xml"
+HGNC:18149	A4GALT	alpha 1,4-galactosyltransferase (P blood group)	P1	A14GALT, Gb3S, P(k)	53947	ENSG00000128274	NM_017436	CCDS14041	 "Global Variome shared LOVD|https://databases.lovd.nl/shared/genes/ABCB7","LRG_795|https://ftp.ebi.ac.uk/pub/databases/lrgex/pending/LRG_795.xml"
 HGNC:17968	A4GNT	alpha-1,4-N-acetylglucosaminyltransferase		alpha4GnT	51146	ENSG00000118017	NM_016161	CCDS3097	"Global Variome shared LOVD|https://databases.lovd.nl/shared/genes/ACE2"
 HGNC:13666	AAAS	aladin WD repeat nucleoporin			8086	ENSG00000094914		CCDS8856, CCDS53797	
 HGNC:30205	AAMDC	adipogenesis associated Mth938 domain containing	C11orf67	PTD015, FLJ21035, CK067	28971	ENSG00000087884	NM_024684	CCDS8254, CCDS81604, CCDS81605, CCDS86232	
@@ -15,7 +15,7 @@ HGNC:18	AAMP	angio associated migratory cell protein			14	ENSG00000127837	NM_001
 HGNC:19	AANAT	aralkylamine N-acetyltransferase		SNAT	15	ENSG00000129673	NM_001088	CCDS11745, CCDS54169	
 HGNC:15886	AAR2	AAR2 splicing factor homolog	C20orf4	bA234K24.2	25980	ENSG00000131043	NM_015511	CCDS13273	
 HGNC:33842	AARD	alanine and arginine rich domain containing protein	C8orf85	LOC441376	441376	ENSG00000205002	NM_001025357	CCDS34935	
-HGNC:20	AARS	alanyl-tRNA synthetase		CMT2N, AlaRS	16	ENSG00000090861	NM_001605	CCDS32474	"LRG_359|http://ftp.ebi.ac.uk/pub/databases/lrgex/LRG_359.xml"
+HGNC:20	AARS	alanyl-tRNA synthetase		CMT2N, AlaRS	16	ENSG00000090861	NM_001605	CCDS32474	"LRG_359|https://ftp.ebi.ac.uk/pub/databases/lrgex/LRG_359.xml"
 HGNC:21022	AARS2	alanyl-tRNA synthetase 2, mitochondrial	AARSL	KIAA1270, bA444E17.1	57505	ENSG00000124608	NM_020745	CCDS34464	
 HGNC:28417	AARSD1	alanyl-tRNA synthetase domain containing 1		MGC2744	80755	ENSG00000266967	NM_001261434	CCDS11447, CCDS45691, CCDS58552	
 HGNC:49894	AARSP1	alanyl-tRNA synthetase pseudogene 1				ENSG00000249038		

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -1043,7 +1043,7 @@ name            = RFAM
 order           = 70
 priority        = 1
 parser          = RFAMParser
-#data_uri        = script:wget=>ftp://ftp.ebi.ac.uk/pub/databases/Rfam/CURRENT/Rfam.seed.gz,host=>mysql-ens-genebuild-prod-3,port=>4529,dbname=>kb15_mesocricetus_auratus_core_89_1,
+#data_uri        = script:wget=>https://ftp.ebi.ac.uk/pub/databases/Rfam/CURRENT/Rfam.seed.gz,host=>mysql-ens-genebuild-prod-3,port=>4529,dbname=>kb15_mesocricetus_auratus_core_89_1,
 
 [source RFAM::EG]
 name            = RFAM

--- a/modules/Bio/EnsEMBL/Utils/Net.pm
+++ b/modules/Bio/EnsEMBL/Utils/Net.pm
@@ -46,7 +46,7 @@ Bio::EnsEMBL::Utils::Net
   my $google_contents = do_GET('http://www.google.co.uk/');
   
   #Doing a FTP request; delegates onto LWP
-  my $ftp_contents = do_GET('ftp://ftp.ensembl.org/pub/current_README');
+  my $ftp_contents = do_GET('https://ftp.ensembl.org/pub/current_README');
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
This PR updates all ftp URLs to use https (to be compatible with web browsers).
The affected hostnames have been tested to work with https.
Other affected repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680