### PR TITLE
Update PomBase URLs

### DIFF
--- a/modules/Bio/EnsEMBL/OntologyXref.pm
+++ b/modules/Bio/EnsEMBL/OntologyXref.pm
@@ -453,7 +453,7 @@ sub get_all_associated_xrefs {
               'source' => '<a href="<Link to CiteXplore>">11937031</a>',
               'evidence' => 'IDA',
               'description' => '<strong>has_direct_input</strong> 
-                   <a href="http://www.pombase.org/spombe/result/SPBC32F12.09">
+                   <a href="http://www.pombase.org/gene/SPBC32F12.09">
                      SPBC32F12.09
                    </a>'
             };
@@ -482,8 +482,8 @@ sub get_extensions {
     'GO_REF' => 'http://www.geneontology.org/cgi-bin/references.cgi#',
     'SO'     => 'http://www.sequenceontology.org/miso/current_cvs/term/',
     #'MOD'    => 'href=mod',
-    'PomBase' => 'http://www.pombase.org/spombe/result/',
-    'PomBase_Systematic_ID' => 'http://www.pombase.org/spombe/result/',
+    'PomBase' => 'http://www.pombase.org/gene/',
+    'PomBase_Systematic_ID' => 'http://www.pombase.org/gene/',
     'PUBMED' => 'http://europepmc.org/abstract/MED/'
   );
   


### PR DESCRIPTION
This PR updates links to PomBase.

[Sandbox test page](http://wp-np2-1d.ebi.ac.uk:1640/Schizosaccharomyces_pombe/Gene/Summary?db=core;g=SPAC2F7.03c;r=I:534120-537869;t=SPAC2F7.03c.1)
[Webteam JIRA ticket](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6651)


