### PR TITLE
ENSCORESW-4084 - Ensure new Ensembl stable ids have correct prefix

### DIFF
--- a/misc-scripts/generate_stable_ids.pl
+++ b/misc-scripts/generate_stable_ids.pl
@@ -145,7 +145,7 @@ sub get_max_stable_id_from_gene_archive {
   my ( $dbi, $type ) = @_;
 
   # Try to get from relevant archive.
-  my $sth = $dbi->prepare("SELECT MAX($type) FROM gene_archive WHERE $type LIKE 'ENS%'");
+  my $sth = $dbi->prepare("SELECT MAX($type) FROM gene_archive WHERE $type LIKE 'ENS_0%'");
   $sth->execute();
 
   my $rs;
@@ -171,7 +171,7 @@ sub get_highest_stable_id {
 
   # Get highest stable ID from the relevant table.
 
-  my $sth = $dbi->prepare("SELECT MAX(stable_id) FROM $type WHERE stable_id LIKE 'ENS%'");
+  my $sth = $dbi->prepare("SELECT MAX(stable_id) FROM $type WHERE stable_id LIKE 'ENS_0%'");
   $sth->execute();
 
   if ( my @row = $sth->fetchrow_array() ) {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Following the Genes on Patches / Y-PAR project work, a case has occurred where newly-generated Ensembl stable ids contain a ENS[G|T|P|E]1 prefix, instead of a 0. This PR ensures that the number portion of the stable id starts with a zero. 

## Use case

Related ticket at: https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-4084

Jose discovered in his data checks that the transcripts, exons and translations from genes in the Y PAR regions of the havana database (nwillhoft_yattrib_test) have non-standard stable ids, eg. ENST10010355966, ENSE10028847446, ENSP10000364511.

Background of these data from Jose: "There are a number of stable ids starting with 'ENST1' instead of 'ENST0' in the database, which were introduced to tag dubious transcript models when the so-called 'nomerge' database was created. The 'nomerge' database is the current havana database. Those stable ids would have been replaced by the stable id mapping script in the former version of the script, but this script was recently modified to honour new stable ids coming from the havana database for another reason. This is an unintended consequence of that change. I am guessing that you used these 'ENST100' stable ids as the starting point to create new transcript stable ids for the chrY PAR transcripts, and the same for exons and translation stable ids. Gene stable ids look correct though. Could you please ensure that the stable ids assigned to features on the chrY PAR use the standard 'ENST0'/'ENSP0'/'ENSE0' prefixes when the final modified havana database is prepared?"

## Benefits

Explicitly checks the stable id prefix.

## Possible Drawbacks


## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

