### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ before_install:
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
   - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
   - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
-  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-test
-  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-io
-  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-variation
-  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-compara
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-test
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-io
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-variation
+  - git-ensembl --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-compara
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ addons:
     - unzip
 
 before_install:
+  - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+  - export PATH=$PWD/ensembl-git-tools/bin:$PATH
   - export ENSEMBL_BRANCH='main'
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
   - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
@@ -56,7 +58,7 @@ jobs:
     - perl: '5.26'
       env: COVERALLS=false DB=mysql
     - perl: '5.30'
-      env: COVERALLS=false DB=mysql
+      env: COVERALLS=true DB=mysql
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ before_install:
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
   - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
   - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
-  - git --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-test
-  - git --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-io
-  - git --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-variation
-  - git --clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-compara
+  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-test
+  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-io
+  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-variation
+  - git clone --depth 1 --branch $ENSEMBL_BRANCH ensembl-compara
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: perl
 
 dist:
-  - focal
+  - trusty
 
 services:
   - mysql
@@ -54,11 +54,15 @@ script:
   - "./travisci/harness.sh"
 
 jobs:
+  include:
+    - perl: '5.30'
+      env: COVERALLS=false DB=mysql
+      dist: focal
   exclude:
     - perl: '5.26'
       env: COVERALLS=false DB=mysql
     - perl: '5.30'
-      env: COVERALLS=true DB=mysql
+      dist: trusty
 
 notifications:
   email:


### PR DESCRIPTION
Fixing the broken travis run:
- reverting back to testing perl 5.26 on trusty while resting 5.30 on focal (errors when testing 5.26 with focal)
- adding back ensembl-git-tools

If we really don't want to use ensembl-git-tools, we can update the repo names to include the full link