### PR TITLE
Add info_text for Y chromosome xrefs

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
@@ -539,6 +539,7 @@ sub run_coordinatemapping {
                 delete( $unmapped{$coord_xref_id} );
                 $mapped{$coord_xref_id}{'reason'}      = undef;
                 $mapped{$coord_xref_id}{'reason_full'} = undef;
+                $mapped{$coord_xref_id}{'chr_name'} = $chr_name;
               }
 
               push( @{ $mapped{$coord_xref_id}{'mapped_to'} }, {
@@ -673,6 +674,8 @@ sub dump_xref {
     my ($version) = ( $accession =~ /\.(\d+)$/ );
     $version ||= 0;
 
+    my $info_text = (defined($xref->{'chr_name'}) && $xref->{'chr_name'} eq 'Y' ? "Y Chromosome" : "");
+
     $fh->printf("%d\t%d\t%s\t%s\t%d\t%s\t%s\t%s\n",
                 $xref->{'xref_id'},
                 $xref->{'external_db_id'},
@@ -681,7 +684,7 @@ sub dump_xref {
                 $version,
                 '\N',
                 'COORDINATE_OVERLAP',
-                ''                                  # FIXME (possibly)
+                $info_text
     );
   }
   $fh->close();


### PR DESCRIPTION
## Description

The core DB has dangling object_xref records related to Y-PAR genes after the xref pipeline is run on the new core DB (containing Y-PAR genes and and genes on patches).

## Use case

When running the xref pipeline using the core DB with the new Y-PAR genes, xrefs are duplicated from X-PAR ones and dumped into the file created by CoordinateMapper.pm in the dump_xref method. However, when this data is uploaded into the core DB, these duplicated xrefs cause a duplicate unique key error in the database `UNIQUE KEY id_index (dbprimary_acc, external_db_id, info_type, info_text, version)`. Also, since the object_xref data is uploaded before the xref is, all object xrefs telated to these duplicated xrefs would already be added. This leads to having dangling object xrefs int he core DB with no parent xref rows. To fix that, a string "Y Chromosome" has been added into the info_text field (which was previously kept empty) to differentiate the Y-PAR xrefs and allow inserting them into the DB.

## Benefits

No duplicate unique key error, leading to no dangling object_xref records.

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Test suite is failing due to the Perl::Critic issue which was fixed in #635 . Once that is merged in, the tests can be re-run.

