### PR TITLE
Change use of bareword dir handle for new ProhibitBarewordDirHandles…

### DIFF
--- a/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
@@ -456,17 +456,17 @@ sub run_exonerate {
   # delete exonerate output from previous runs
   my $dump_path = $self->cache->dump_path;
 
-  opendir(DUMPDIR, $dump_path) or
+  opendir(my $dumpdir, $dump_path) or
     $self->logger->error("Can't open $dump_path for reading: $!");
 
-  while (defined(my $file = readdir(DUMPDIR))) {
+  while (defined(my $file = readdir($dumpdir))) {
     next unless /exonerate_map\.\d+/;
 
     unlink("$dump_path/$file") or
       $self->logger->error("Can't delete $dump_path/$file: $!");
   }
   
-  closedir(DUMPDIR);
+  closedir($dumpdir);
 
   # determine number of jobs to split task into
   my $bytes_per_job = $self->conf->param('exonerate_bytes_per_job')
@@ -690,13 +690,13 @@ sub parse_exonerate_results {
   my $num_files = 0;
   my $num_lines = 0;
 
-  opendir( DUMPDIR, $dump_path ) or
+  opendir( my $dumpdir, $dump_path ) or
     $self->logger->error("Can't open $dump_path for reading: $!");
 
   my $penalised = 0;
   my $killed    = 0;
 
-  while ( defined( my $file = readdir(DUMPDIR) ) ) {
+  while ( defined( my $file = readdir($dumpdir) ) ) {
     unless ( $file =~ /exonerate_map\.\d+/ ) { next }
 
     $num_files++;
@@ -761,7 +761,7 @@ sub parse_exonerate_results {
     close($fh);
   } ## end while ( defined( my $file...))
 
-  closedir(DUMPDIR);
+  closedir($dumpdir);
 
   $self->logger->info(
         "Done parsing $num_lines lines from $num_files result files.\n",


### PR DESCRIPTION
## Description

Fixing the use of bareword directory handles due to a new policy in Perl::Critic added recently.

## Use case

A new policy was recently added into the Perl::Critic module that prohibits the use of bareword directory handles. This is causing the test housekeeping_perlCritic.t to fail.

## Benefits

No failure in housekeeping_perlCritic.t

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

