### PR TITLE
Fix/xref synonyms

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -39,6 +39,7 @@ feature 'xref_mapping', 'Xref mapping pipeline' => sub {
   requires 'Text::Glob';
   requires 'URI';
   requires 'XML::LibXML';
+  requires 'Text::Unidecode';
 
   test_requires 'Config::General';
   test_requires 'Perl::Critic::Moose';

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -71,6 +71,7 @@ use warnings;
 use Carp;
 use Text::CSV;
 use utf8;
+use Text::Unidecode;
 
 use parent qw( XrefParser::BaseParser );
 
@@ -456,6 +457,8 @@ sub add_synonyms_for_hgnc {
     $dead_string =~ s/"//xg;
     my @dead_array = split( ',\s', $dead_string );
     foreach my $dead (@dead_array){
+      utf8::decode($dead);
+      $dead = unidecode(uc($dead));
       $self->add_to_syn($name, $source_id, $dead, $species_id, $dbi);
     }
   }
@@ -465,6 +468,8 @@ sub add_synonyms_for_hgnc {
     $alias_string =~ s/"//xg;
     my @alias_array = split( ',\s', $alias_string );
     foreach my $alias (@alias_array){
+      utf8::decode($alias);
+      $alias = unidecode(uc($alias));
       $self->add_to_syn($name, $source_id, $alias, $species_id, $dbi);
     }
   }

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -70,7 +70,8 @@ use strict;
 use warnings;
 use Carp;
 use Text::CSV;
-use utf8;
+#use utf8;
+use Encode;
 use Text::Unidecode;
 
 use parent qw( XrefParser::BaseParser );
@@ -205,7 +206,8 @@ CCDS
   }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
 
   # make sure it's utf8
-  utf8::encode($mem_file);
+  #utf8::encode($mem_file);
+  $mem_file = Encode::encode("UTF-8", $mem_file);
   # get rid of non-conventional " used in the Locus specific databases field
   $mem_file =~ s/"//xg;
 
@@ -457,7 +459,7 @@ sub add_synonyms_for_hgnc {
     $dead_string =~ s/"//xg;
     my @dead_array = split( ',\s', $dead_string );
     foreach my $dead (@dead_array){
-      utf8::decode($dead);
+      $dead = Encode::decode("UTF-8", $dead);
       $dead = unidecode(uc($dead));
       $self->add_to_syn($name, $source_id, $dead, $species_id, $dbi);
     }
@@ -468,7 +470,7 @@ sub add_synonyms_for_hgnc {
     $alias_string =~ s/"//xg;
     my @alias_array = split( ',\s', $alias_string );
     foreach my $alias (@alias_array){
-      utf8::decode($alias);
+      $alias = Encode::decode("UTF-8", $alias);
       $alias = unidecode(uc($alias));
       $self->add_to_syn($name, $source_id, $alias, $species_id, $dbi);
     }

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -70,7 +70,6 @@ use strict;
 use warnings;
 use Carp;
 use Text::CSV;
-#use utf8;
 use Encode;
 use Text::Unidecode;
 
@@ -206,7 +205,6 @@ CCDS
   }) or croak "Cannot use file $file: ".Text::CSV->error_diag ();
 
   # make sure it's utf8
-  #utf8::encode($mem_file);
   $mem_file = Encode::encode("UTF-8", $mem_file);
   # get rid of non-conventional " used in the Locus specific databases field
   $mem_file =~ s/"//xg;


### PR DESCRIPTION
## Description

Handling of Greek characters in HGNC xrefs synonyms.

## Use case

Some synonyms present in the HGNC xref file contain the Greek characters α, β, and γ. Without any special parsing, these synonyms are garbled in the database, leading to them appearing as garbled on the Ensembl browser. To fix this, the Text::Unidecode module is being used to translate these characters into their equivalent English letters.

This solution was chosen instead of translating the character to their corresponding words (α to 'alpha', β to 'beta', etc...) because this solution doesn't require having a hard-coded mapping hash in the code. 

## Benefits

No garbled characters in external synonyms.

## Possible Drawbacks

This change is restricted to the HGNC parser, as this is where the special characters have been noticed. However, this same change can be later added to the wider xref synonym handling for other sources.

## Testing

_Have you added/modified unit tests to test the changes?_

Added Text::Unidecode to the cpanfile used by the test suite

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Test suite is still failing due to another issue fixed in #642 , will be re-run once that is merged in.

