### PR TITLE
Add db schema patches for Release 110 core db

### DIFF
--- a/sql/patch_109_110_b.sql
+++ b/sql/patch_109_110_b.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2022] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_109_110_b.sql
+#
+# Title: Add 'IS_PAR' relationship
+#
+# Description:
+#   Add 'IS_PAR' relationship to link X- and Y-PAR genes via alt allele data
+
+ALTER TABLE alt_allele_attrib MODIFY attrib ENUM('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED', 'IS_PAR');
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes');

--- a/sql/patch_109_110_c.sql
+++ b/sql/patch_109_110_c.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-# patch_109_110_b.sql
+# patch_109_110_c.sql
 #
 # Title: Allow a gene to belong to multiple alt allele groups
 #

--- a/sql/patch_109_110_c.sql
+++ b/sql/patch_109_110_c.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2022] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_109_110_b.sql
+#
+# Title: Allow a gene to belong to multiple alt allele groups
+#
+# Description:
+#   Relax database constraint to allow a given gene id to belong to one or more alt allele groups
+
+ALTER TABLE alt_allele DROP KEY gene_idx;
+CREATE INDEX gene_idx ON alt_allele(gene_id);
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Adding in database schema patches for Release 110 core database. This are schema changes that support the code changes in PR # 577, which has just been merged in.

## Use case

There are 2 patch files as the changes fall into 2 categories. The first relates to the 'IS_PAR' relationship that has been added to the alt_allele_attrib table's `attrib` column, allowing for X- and Y-PAR genes to be explicitly linked. The second relates to the relaxing of the unique constraint on `gene_id` in the `alt_allele` table. This allows a given gene id to now belong to one or more alt allele groups, as is the case where a X-/Y-PAR gene belong to an 'IS_PAR'-based group and also a patch-based group.

## Benefits

The core database will now contain the required schema changes to support these 'IS_PAR' relationships and genes belonging to (potentially) multiple alt allele groups.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Test suite passes