### PR TITLE
Remove UNIQUE constraint on alt_allele table

### DIFF
--- a/misc-scripts/xref_mapping/sql/table.sql
+++ b/misc-scripts/xref_mapping/sql/table.sql
@@ -349,7 +349,7 @@ CREATE TABLE alt_allele (
   gene_id               INT(10) UNSIGNED NOT NULL,
   is_reference          INT UNSIGNED DEFAULT 0,
 
-  UNIQUE KEY gene_idx (gene_id),
+  KEY gene_idx (gene_id),
   UNIQUE KEY allele_idx (alt_allele_id, gene_id)
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;


### PR DESCRIPTION
## Description

Removing UNIQUE constraint from alt_allele table in xref DB.

## Use case

This change is added to mirror #645 in removing the UNIQUE constraint from the alt_allele table, allowing for the possibility of having the same gene belonging to multiple alt allele groups.

Note: no need to add this change into the 110 branch as the xref pipeline is currently being run and this can be fixed directly in the database.

## Benefits

Consistency with core DB changes

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

