### PR TITLE
Added check that coordinate system alias_to exists before comparing to 'chromosome'

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -254,7 +254,7 @@ sub fetch_by_region {
 
     # if chromosome alias is defined, use karyotype_cache to access seq region data
     # rather than a database query
-    if ( $cs->alias_to() eq "chromosome" ) {
+    if ( defined($cs->alias_to()) && $cs->alias_to() eq "chromosome" ) {
 
       $key = "karyotype_cache";
 


### PR DESCRIPTION
# Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Add a check at line 257 of SliceAdaptor.pm to confirm that the result of cs->alias_to() is defined prior to comparing the output to the hardcoded string 'chromosome'.

## Use case

In a script pulling pairwise alignment info from Ensembl (human-> mouse, fugu, xenopus) there is a consistent error at line 257 of SliceAdaptor.pm. No other error information is provided.

```
Use of uninitialized value in string eq at <snip>/ensembl/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm line 257, <GEN0> line 1.
```

## Benefits

Bug fix

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

No - not sure where best to add this in t/sliceAdaptor.t - please advise in review.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

