### PR TITLE
Added check that coordinate system alias_to exists before comparing t…

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -254,7 +254,7 @@ sub fetch_by_region {
 
     # if chromosome alias is defined, use karyotype_cache to access seq region data
     # rather than a database query
-    if ( $cs->alias_to() eq "chromosome" ) {
+    if ( defined($cs->alias_to()) && $cs->alias_to() eq "chromosome" ) {
 
       $key = "karyotype_cache";
 


### PR DESCRIPTION
## Description

Sister PR to #653 
Added check that coordinate system `alias_to()` exists before comparing to 'chromosome' in SliceAdaptor

## Use case

Avoid warning message when `alias_to()` returns `undef`

## Benefits

No warnings because of `undef`

## Possible Drawbacks

None

## Testing

No tests have been added
