### PR TITLE
Maintaining manually inserted xrefs

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
@@ -446,10 +446,6 @@ sub set_display_xrefs{
 
   print "Using xref_off set of $xref_offset\n" if($self->verbose);
 
-  #my $reset_sth = $core_dbi->prepare("UPDATE gene SET display_xref_id = null");
-  #$reset_sth->execute();
-  #$reset_sth->finish;
- 
   my $reset_sth = $core_dbi->prepare("UPDATE transcript SET display_xref_id = null WHERE biotype NOT IN ('LRG_gene')");
   $reset_sth->execute();
   $reset_sth->finish;

--- a/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
@@ -239,7 +239,7 @@ sub genes_and_transcripts_attributes_set{
     $self->mapper->set_gene_descriptions();
   }
   else{
-      $self->set_gene_descriptions();
+      $self->set_gene_descriptions(1);
   }	
 
   $self->build_meta_timestamp;
@@ -446,15 +446,15 @@ sub set_display_xrefs{
 
   print "Using xref_off set of $xref_offset\n" if($self->verbose);
 
-  my $reset_sth = $core_dbi->prepare("UPDATE gene SET display_xref_id = null");
-  $reset_sth->execute();
-  $reset_sth->finish;
+  #my $reset_sth = $core_dbi->prepare("UPDATE gene SET display_xref_id = null");
+  #$reset_sth->execute();
+  #$reset_sth->finish;
  
-  $reset_sth = $core_dbi->prepare("UPDATE transcript SET display_xref_id = null WHERE biotype NOT IN ('LRG_gene')");
+  my $reset_sth = $core_dbi->prepare("UPDATE transcript SET display_xref_id = null WHERE biotype NOT IN ('LRG_gene')");
   $reset_sth->execute();
   $reset_sth->finish;
 
-  my $update_gene_sth = $core_dbi->prepare("UPDATE gene g SET g.display_xref_id= ? WHERE g.gene_id=?");
+  my $update_gene_sth = $core_dbi->prepare("UPDATE gene g SET g.display_xref_id= ? WHERE g.gene_id=? and g.display_xref_id IS NULL");
   my $update_tran_sth = $core_dbi->prepare("UPDATE transcript t SET t.display_xref_id= ? WHERE t.transcript_id=?");
 
 
@@ -765,7 +765,7 @@ sub set_gene_descriptions{
   my $core_dbi = $self->core->dbc;
   my $xref_dbi = $self->xref->dbc;
 
-  my $update_gene_desc_sth =  $core_dbi->prepare("UPDATE gene SET description = ? where gene_id = ?");
+  my $update_gene_desc_sth =  $core_dbi->prepare("UPDATE gene SET description = ? where gene_id = ? and description IS NULL");
 
   if(!$only_those_not_set){
     my $reset_sth = $core_dbi->prepare("UPDATE gene SET description = null");

--- a/misc-scripts/xref_mapping/XrefMapper/XrefLoader.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/XrefLoader.pm
@@ -159,6 +159,8 @@ sub update{
   my $xref_sth     =  $core_dbi->prepare('DELETE FROM xref WHERE xref.external_db_id = ?');
   my $unmapped_sth =  $core_dbi->prepare('DELETE FROM unmapped_object WHERE type="xref" and external_db_id = ?');
 
+  my $gene_reset_sth = $core_dbi->prepare('UPDATE gene g INNER JOIN xref x ON g.display_xref_id=x.xref_id SET g.display_xref_id=NULL,g.description=NULL WHERE x.external_db_id=?');
+
 
   my $transaction_start_sth  =  $core_dbi->prepare('start transaction');
   my $transaction_end_sth    =  $core_dbi->prepare('commit');
@@ -179,6 +181,10 @@ sub update{
     }
 
     my $ex_id = $name_to_external_db_id{$name};
+
+    print "Setting display_xref_id and description to NULL if it refers to xrefs that are to be deleted\n" if ($verbose);
+    $affected_rows = $gene_reset_sth->execute($ex_id);
+    print "\tSet display_xref_id=NULL and description=NULL for $affected_rows gene row(s)\n" if ($verbose);
 
     print "Deleting data for $name from core before updating from new xref database\n" if ($verbose);
     $affected_rows = $synonym_sth->execute($ex_id);


### PR DESCRIPTION
## Description

Changes to allow harmonization of the vertebrates xref pipeline with plants species.

## Use case

In order to be able to run the current vertebrates xref pipeline for plants, there was a requirement to maintain manually inserted xrefs as the main display xrefs for plants species, as that is a case common to these species. The usual behavior of the xref pipeline already did that in the sense that it doesn't delete any existing xrefs that don't belong to sources that the pipeline itself retrieves. However, when reaching the point of setting display xref IDs for genes (which in turn sets the gene name), only xrefs that are retrieved in the current pipeline run would be considered. Thus, many plants genes lost their previous names (replaced with other names coming for other sources), and that wasn't optimal for these species. Thus, this change maintains the display xref IDs that belong to these manually curated xrefs and only sets new ones if no manual ones are already set.

## Benefits

Harmonization of the xref pipeline to run for both vertebrates and plants species.

## Possible Drawbacks

No pipeline option/flag has been added to make this change configurable, so it now applies to all species and all runs. However, since manually curated xrefs have a higher value than any other xrefs, they should always be treated as a priority.

## Testing

The full xref flow, download and process parts, was run for 3 different plants species as well as 2 different vertebrates. The results seem okay and Guy is happy with the plants results. The vertebrates species have not been affected by this change as they don't have manually curated xrefs.

