### PR TITLE
Add BRAKER stable_id prefix

### DIFF
--- a/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/EnsemblGeneric.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/EnsemblGeneric.pm
@@ -148,6 +148,7 @@ sub initial_stable_id {
     FROM ${type}
     WHERE stable_id LIKE "ENS%"
       OR stable_id LIKE "ASMPATCH%"
+       OR stable_id LIKE "BRAKER%"
     );
 
   $init_stable_id = $self->fetch_value_from_db( $s_dbh, $sql );
@@ -214,7 +215,7 @@ sub increment_stable_id {
                     $stable_id ) );
   }
 
-  $stable_id =~ /^(ENS|ASMPATCH)([A-Z]+)(\d+)$/;
+  $stable_id =~ /^(ENS|ASMPATCH|BRAKER)([A-Z]+)(\d+)$/;
 
   my $number = $3;
   my $new_stable_id = $1 . $2 . ( ++$number );
@@ -243,7 +244,7 @@ sub is_valid {
   my ( $self, $stable_id ) = @_;
 
   if ( defined($stable_id) ) {
-    if (    $stable_id =~ /^(ENS|ASMPATCH)([A-Z]+)(\d+)$/
+    if (    $stable_id =~ /^(ENS|ASMPATCH|BRAKER)([A-Z]+)(\d+)$/
          || $stable_id =~ /^LRG/ )
     {
       return 1;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Updating the stable_id mapping code to allow mapping between BRAKER annotations

## Use case

The stable_id mapping pipeline was failing for BRAKER annotations as these have the prefix "BRAKER" rather than "ENS"

## Benefits

Mapping between BRAKER annotation will now work!

## Possible Drawbacks

I see none :) 

## Testing

Didn't add/change any tests, but don't suspect this small change will affect anything.
I have tested the pipeline with these changes and it was successful!

