### PR TITLE
Update Registry.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -2507,16 +2507,13 @@ sub load_registry_from_db {
 
 sub _group_to_adaptor_class {
   my ($self, $group) = @_;
-  my $class = {
-    core => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    cdna => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    otherfeatures => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    rnaseq => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    vega => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    variation => 'Bio::EnsEMBL::Variation::DBSQL::DBAdaptor',
-    funcgen => 'Bio::EnsEMBL::Funcgen::DBSQL::DBAdaptor',
-    compara => 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor',
-  }->{$group};
+  my $class = $group2adaptor{$group};
+  if (!defined $class) {
+    $class = {
+      cdna   => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
+      rnaseq => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
+    }->{$group};
+  }
   throw "Group '${group}' is unknown" if ! $class;
   return $class;
 }


### PR DESCRIPTION
Updated _group_to_adaptor_class to use hash and include ontology

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Modified the group_to_adaptor_class to include %group2adaptor.

## Use case

We couldn't load ontology dbs for an unknown reason since 107. We had to modify the _group_to_adaptor within our code. This should prevent that for happening to any of the existing adapters.

## Benefits

This should be more future proof, as it uses the group2adaptor hash rather than its own. It also fixes the problem of not loading ontology.

## Possible Drawbacks

Using the hash could break something, but I can't see what at the moment, but I am no expert on use cases for this pipeline. Should this be undesirable, an alternative is to just add : 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor',  ontology => 'Bio::EnsEMBL::DBSQL::DBAdaptor' to the hash.

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

