### PR TITLE
Fix load_registry_from_url

### DIFF
--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -2507,16 +2507,13 @@ sub load_registry_from_db {
 
 sub _group_to_adaptor_class {
   my ($self, $group) = @_;
-  my $class = {
-    core => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    cdna => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    otherfeatures => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    rnaseq => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    vega => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
-    variation => 'Bio::EnsEMBL::Variation::DBSQL::DBAdaptor',
-    funcgen => 'Bio::EnsEMBL::Funcgen::DBSQL::DBAdaptor',
-    compara => 'Bio::EnsEMBL::Compara::DBSQL::DBAdaptor',
-  }->{$group};
+  my $class = $group2adaptor{$group};
+  if (!defined $class) {
+    $class = {
+      cdna   => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
+      rnaseq => 'Bio::EnsEMBL::DBSQL::DBAdaptor',
+    }->{$group};
+  }
   throw "Group '${group}' is unknown" if ! $class;
   return $class;
 }


### PR DESCRIPTION
## Description

PR sister to #658 . This one against `main`

## Use case

Fix the inability to load ontology DBs.
Modified the _group_to_adaptor_class - affecting the `load_registry_from_url` method - to include the otherwise adopted %group2adaptor, instead of _ad-hoc_ hardcoded adaptors

## Benefits

Ability to load ontology DBs.
Removed (some of the) hardcoded logic.

## Possible Drawbacks

Some edge case in some "hidden" pipeline may fail.

## Testing

_Have you added/modified unit tests to test the changes?_
No

_Have you run the entire test suite and no regression was detected?_
The test suite ran successfully
