### PR TITLE
Restrain using latest DBD::mysql version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';


### PR DESCRIPTION
## Description

DBD::mysql have released new version (5.001) on Oct 4, 2023. This version removes support for MySQL 5 -
https://metacpan.org/dist/DBD-mysql/changes

Hence we need to use lower version than that.

## Use case

Using DBAdaptors to connect to Ensembl databases which use MySQL version 5

## Possible Drawbacks

Should be changed back if anytime in the future Ensembl database servers upgraded to MySQL 8x.

## Testing

Unit test should pass on this PR

