### PR TITLE
Restrain using DBD::mysql version 5.x

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';


### PR DESCRIPTION
## Description

Sister to PR #666 

## Use case

Keep support for MySQL 5x

## Benefits

Keep support for MySQL 5x

## Possible Drawbacks

Using outdated DBD::mysql

## Testing

Automated tests ran fine

