### PR TITLE
Fix EMBL-format sequence print outs for lengths over 1Gb

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
@@ -1273,7 +1273,7 @@ sub write_embl_seq {
   # chunk the sequence to conserve memory, and print
   my $here = $start;
   my $EMBL_SEQ = 
-    '     ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<<@>>>>>>>>>~
+    '     ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< ^<<<<<<<<< @>>>>>>>>>~
 ';
   my $acgt;
 


### PR DESCRIPTION
## Description

For sequence regions over 1 billion bases in length, when these are printed out in EMBL file format, a space is currently missing on lines between the sequence and the sequence coordinates (when the coordinates go over 1 billion).

This PR fixes the issue by adding a space character to the EMBL sequence string. 

This is back porting #670 to EnsEMBL release branch `release/111`

## Use case

A number of metazoan species now have sequence regions over one billion bases in length.

One example is the sequence region `NC_064626.1` from species (with production name) `schistocerca_cancellata_gca023864275v2rs` with the length of 1288847234 bases.

In the [current FTP file](https://ftp.ensembl.org/pub/rapid-release/species/Schistocerca_cancellata/GCA_023864275.2/refseq/geneset/2023_03/Schistocerca_cancellata-GCA_023864275.2-2023_03-genes.embl.gz), a space is missing between the DNA sequence and the sequence position coordinates:

```
$ grep -C 10 '1288847220' Schistocerca_cancellata-GCA_023864275.2-2023_03-genes.embl
     ATGTTGAATA CACCGGTTCT CGTCCGATCA CCGAAGTTAA GCAACATCGG GCCCGGTTAG1288846620
     TACTTGGATG GGTGACCGCC TGGGAACACC GGGTGCTGTT GGCTCTATCT CATTTTTTCC1288846680
     TTCTTACGTC GCTGCACCTG CCAGGCCTCT TTTTCATGCT AACTATCAGG TGTGACAAAG1288846740
     ATGCTTCCAC AAGCATTTTA AACTACTGTA TCAAACGTAA GATACGAAAT TACAGTAATG1288846800
     AACTCAGTTT GCGCAAGAAT GCGCGAAAGA AGAGAGTGCT GGAACGCCTT GAAAATAACA1288846860
     AACACACTAC GAATCGACAG ATGAGTTCTG AAATAAGTCA GGGCCTACTG TTTTGTAGCA1288846920
     GTGCTGAATT CCACAAAGTA AATAAACAAA AAAAAAAAAA AAAAACAAAA AAAACAAAAA1288846980
     ATCTTCCGTT CTCGTCCGAT CACCGAAGTG AAGCAACAAC GTTAGTACTC GGAAGGGTGA1288847040
     GCGCCTGGGA ACTCTGGCTG TCTTCATTTT TCGCTTTTTA GTCGCTACTC CTGCCAGCCC1288847100
     TCTTTCCATA GCAATTTTCT GTTGTGACAA AGAGACTTCC TTAAGCATTT GAAACGGCCG1288847160
     TAAGGTACGA AACTGCAGTA ATTAACTCAG TTTGAAGGAG AATGTGGCAA CCAAGTTTGC1288847220
     CAGGAAGTCT TTGA                                                  1288847234
```

After applying the fix, this is the same region printed out, which now has a space:
```
$ tail out.schistocerca_cancellata_gca023864275v2rs.embl.dat
     AACTCAGTTT GCGCAAGAAT GCGCGAAAGA AGAGAGTGCT GGAACGCCTT GAAAATAACA 1288846860
     AACACACTAC GAATCGACAG ATGAGTTCTG AAATAAGTCA GGGCCTACTG TTTTGTAGCA 1288846920
     GTGCTGAATT CCACAAAGTA AATAAACAAA AAAAAAAAAA AAAAACAAAA AAAACAAAAA 1288846980
     ATCTTCCGTT CTCGTCCGAT CACCGAAGTG AAGCAACAAC GTTAGTACTC GGAAGGGTGA 1288847040
     GCGCCTGGGA ACTCTGGCTG TCTTCATTTT TCGCTTTTTA GTCGCTACTC CTGCCAGCCC 1288847100
     TCTTTCCATA GCAATTTTCT GTTGTGACAA AGAGACTTCC TTAAGCATTT GAAACGGCCG 1288847160
     TAAGGTACGA AACTGCAGTA ATTAACTCAG TTTGAAGGAG AATGTGGCAA CCAAGTTTGC 1288847220
     CAGGAAGTCT TTGA                                                   1288847234
```

## Benefits

A space between the sequence and the sequence coordinates will be retained for sequences over the length of 1 billion.

## Possible Drawbacks

None

## Testing

Tested manually OK.
No impact on the test suite.