### PR TITLE
Changed constraint to DBD::mysql to allow bugfixes for release/112

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
+requires 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
 requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';


### PR DESCRIPTION
## Description

Sister to PR #667 

We currently want to use MySQL 5.x, which is unsupported by DBD::mysql v5.
However, we do want to use the latest DBD::mysql v4, and we are already at 4.052 at the time of writing this.

## Use case

We want to use the latest DBD::mysql v4.

## Benefits

Allowing bug fixing patches to DBD::mysql

## Possible Drawbacks

None

## Testing

The test suite worked just fine.
