### PR TITLE
Xref fixes

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'IO::Compress::Gzip';
 requires 'URI::Escape';
 requires 'Config::IniFiles';
 requires 'Gzip::Faster';
+requires 'List::MoreUtils';
 
 test_requires 'Test::Warnings';
 test_requires 'Test::Differences';

--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -135,12 +135,8 @@ sub create {
 sub populate {
   my ( $self, $sql_dir, $force, $preparse, $xref_source_dbi ) = @_;
   my $table_file = catfile( $sql_dir, 'sql', 'table.sql' );
-  my $metadata_file;
-  if ($xref_source_dbi) {
-    $metadata_file = $self->copy_source_metadata_file($xref_source_dbi);
-  } else {
-    $metadata_file = $self->prepare_metadata_file( $sql_dir, $force, $preparse );
-  }
+  my $metadata_file = $self->prepare_metadata_file( $sql_dir, $force, $preparse );
+  
   $self->populate_with_file($table_file);
   $self->populate_with_file($metadata_file);
 }
@@ -202,8 +198,10 @@ sub copy_source_metadata_file {
 
 sub prepare_metadata_file {
   my ( $self, $sql_dir, $force, $preparse ) = @_;
-  my $metadata_file =
-    catfile( $sql_dir, 'sql', 'populate_metadata.sql' );
+
+  $preparse = 0 if (!defined($preparse));
+
+  my $metadata_file = catfile( $sql_dir, 'sql', "populate_metadata_$preparse.sql" );
   my $ini_file = catfile( $sql_dir, 'xref_config.ini' );
 
   local $| = 1;    # flush stdout
@@ -212,8 +210,6 @@ sub prepare_metadata_file {
   # the timestamps on 'xref_config.ini' and 'sql/populate_metadata.sql'.
   my $ini_tm  = ( stat $ini_file )[9];
   my $meta_tm = ( stat $metadata_file )[9];
-
-  $preparse = 0 if (!defined($preparse));
 
   if ( !defined($meta_tm) || $ini_tm > $meta_tm ) {
     my $reply;

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -348,7 +348,7 @@ sub create_xrefs {
         if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
         my $gene_name = undef;
 
-        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s]+)/s) { #/s for multi-line entries ; is the delimiter
+        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s:]+)/s) { #/s for multi-line entries ; is the delimiter
 # Example line 
 # GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
           my $name = $1;


### PR DESCRIPTION
## Description

Fixes for some xref bugs that were discovered in the 112 run.

## Use case

There was a bug in parsing UniProt gene names that was discovered in the recent 112 xref run which didn't include the colon ":" character in the regex used.
Another bug that was found was related to populating the xref intermediate DBs where data was being copied over from the central DB. The way the data was copied was by creating a .sql file with the insert statements. However, when running the pipeline for multiple species at once (normal process), they were all rewriting the same sql file over and over again which lead to some of the intermediate DBs having no data. The added fix removed this copying of the central DB data altogether, as there already exists a file that has this data (populate_metadata.sql) which is created when the central DB is created. Instead, the preparse flag value was added into this metadata filename in order to handle multiple runs of the pipeline (maybe with different preparse flags).

## Benefits

No rewriting of the same file for no reason, no corrupted intermediate DBs, and no wrong UniProt gene names.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

