### PR TITLE
Updated core meta table definition to allow NULL meta_value and exten…

### DIFF
--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:25 2022
+-- Created on Wed Feb  7 13:57:25 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -150,3 +150,4 @@
 150	\N	patch	patch_109_110_a.sql|schema_version
 151	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 152	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+153	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=153 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=154 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:29 2022
+-- Created on Wed Feb  7 13:58:55 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -133,3 +133,4 @@
 207	\N	patch	patch_109_110_a.sql|schema_version
 208	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 209	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+210	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=210 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=211 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:33 2022
+-- Created on Wed Feb  7 14:00:22 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -129,3 +129,4 @@
 178	\N	patch	patch_109_110_a.sql|schema_version
 179	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 180	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+181	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=181 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=182 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:38 2022
+-- Created on Wed Feb  7 14:01:53 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -134,3 +134,4 @@
 2141	\N	patch	patch_109_110_a.sql|schema_version
 2142	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 2143	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+2144	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2144 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=2145 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:39 2022
+-- Created on Wed Feb  7 14:01:55 2024
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:44 2022
+-- Created on Wed Feb  7 14:03:24 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -90,3 +90,4 @@
 183	\N	patch	patch_109_110_a.sql|schema_version
 184	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 185	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+186	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=186 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=187 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:47 2022
+-- Created on Wed Feb  7 14:04:34 2024
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:52 2022
+-- Created on Wed Feb  7 14:06:00 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -207,3 +207,4 @@
 1719	\N	patch	patch_109_110_a.sql|schema_version
 1720	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 1721	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+1722	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1722 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=1723 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:56 2022
+-- Created on Wed Feb  7 14:07:22 2024
 --
 
 BEGIN TRANSACTION;
@@ -535,8 +535,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/nameless/core/meta.txt
+++ b/modules/t/test-genome-DBs/nameless/core/meta.txt
@@ -128,3 +128,4 @@
 182	\N	patch	patch_109_110_a.sql|schema_version
 183	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 184	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+185	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -475,12 +475,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=185 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=186 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:27:58 2022
+-- Created on Wed Feb  7 14:07:45 2024
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/parus_major1/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:28:02 2022
+-- Created on Wed Feb  7 14:09:11 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/parus_major1/core/meta.txt
+++ b/modules/t/test-genome-DBs/parus_major1/core/meta.txt
@@ -101,3 +101,4 @@
 142	\N	patch	patch_109_110_a.sql|schema_version
 143	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 144	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+145	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/parus_major1/core/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=145 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=146 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:28:09 2022
+-- Created on Wed Feb  7 14:10:33 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,8 +546,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -183,3 +183,4 @@
 263	\N	patch	patch_109_110_a.sql|schema_version
 264	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 265	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+266	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=266 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=267 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Fri Dec 16 17:28:13 2022
+-- Created on Wed Feb  7 14:11:53 2024
 --
 
 BEGIN TRANSACTION;
@@ -535,8 +535,8 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
-  "meta_value" varchar(255) NOT NULL
+  "meta_key" varchar(64) NOT NULL,
+  "meta_value" varchar(255)
 );
 
 CREATE UNIQUE INDEX "species_key_value_idx" ON "meta" ("species_id", "meta_key", "meta_value");

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -203,3 +203,4 @@
 245	\N	patch	patch_109_110_a.sql|schema_version
 246	\N	patch	patch_109_110_b.sql|Add IS_PAR relationship to link X- and Y-PAR genes
 247	\N	patch	patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups
+248	\N	patch	patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -475,12 +475,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=248 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=249 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/sql/patch_109_110_d.sql
+++ b/sql/patch_109_110_d.sql
@@ -1,0 +1,28 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2023] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_109_110_d.sql
+#
+# Title: Update meta table definition
+#
+# Description:
+#   Extend meta_key length to 64 - allow NULL in meta_value
+
+alter table meta modify meta_key varchar(64) not null;
+alter table meta modify meta_value varchar(255) null;
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value');

--- a/sql/patch_109_110_d.sql
+++ b/sql/patch_109_110_d.sql
@@ -21,7 +21,7 @@
 #   Extend meta_key length to 64 - allow NULL in meta_value
 
 alter table meta modify meta_key varchar(64) not null;
-alter table meta modify meta_value varchar(255) null;
+alter table meta modify meta_value varchar(255) default null;
 
 # patch identifier
 INSERT INTO meta (species_id, meta_key, meta_value)

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -322,6 +322,9 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_109_110_c.sql|Allow gene id to belong to multiple alt allele groups');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_109_110_d.sql|Extend meta_key length to 64 - allow NULL in meta_value');
+
 /**
 @table meta_coord
 @colour #C70C09

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -296,7 +296,7 @@ CREATE TABLE IF NOT EXISTS meta (
   meta_id                     INT NOT NULL AUTO_INCREMENT,
   species_id                  INT UNSIGNED DEFAULT 1,
   meta_key                    VARCHAR(64) NOT NULL,
-  meta_value                  VARCHAR(255) NULL,
+  meta_value                  VARCHAR(255) DEFAULT NULL,
 
   PRIMARY   KEY (meta_id),
   UNIQUE    KEY species_key_value_idx (species_id, meta_key, meta_value),

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -295,8 +295,8 @@ CREATE TABLE IF NOT EXISTS meta (
 
   meta_id                     INT NOT NULL AUTO_INCREMENT,
   species_id                  INT UNSIGNED DEFAULT 1,
-  meta_key                    VARCHAR(40) NOT NULL,
-  meta_value                  VARCHAR(255) NOT NULL,
+  meta_key                    VARCHAR(64) NOT NULL,
+  meta_value                  VARCHAR(255) NULL,
 
   PRIMARY   KEY (meta_id),
   UNIQUE    KEY species_key_value_idx (species_id, meta_key, meta_value),


### PR DESCRIPTION
…d the meta_key VARCHAR length


## Description

For concurrent MVP/RR handover, we need to extend the length of meta_key for some stats to be inserted the right way. 
As of now the compute of stats try to insert <NULL> values in meta table as well, even if the web requirement is obsolete now. we still need to allow this for the this particular release branch and script version.   

## Use case

Concurrent handover allowing NULL values and inserting non truncated meta_key names used for MVP.

## Benefits

Enable concurrent Handover without DC failures.

## Possible Drawbacks

None. 

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

