### PR TITLE
Release 112 - fix Perl 5.30 build with List::MoreUtils

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'IO::Compress::Gzip';
 requires 'URI::Escape';
 requires 'Config::IniFiles';
 requires 'Gzip::Faster';
+requires 'List::MoreUtils';
 
 test_requires 'Test::Warnings';
 test_requires 'Test::Differences';


### PR DESCRIPTION
The Perl 5.30 build on Travis is failing (and blocking other PRs) as it cannot find the List::MoreUtils module. This PR adds the requirement into the cpanfile.