### PR TITLE
Missing Method for Module

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
@@ -60,6 +60,7 @@ use Bio::EnsEMBL::IdentityXref;
 use Bio::EnsEMBL::OntologyXref;
 
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
+use Bio::EnsEMBL::Utils::Scalar qw(check_ref);
 
 use vars qw(@ISA);
 use strict;
@@ -1719,7 +1720,8 @@ $where_sql";
 
       if (    defined($linkage_type)
            && $linkage_type ne ""
-           && !$linkage_types{$refID}->{$linkage_key} )
+           && !$linkage_types{$refID}->{$linkage_key}
+           && check_ref($seen{$refID}, 'Bio::EnsEMBL::OntologyXref') )
       {
         $source_xref = ( defined($source_xref_id)
                             ? $self->fetch_by_dbID($source_xref_id)


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fix for calling a missing method for object.

## Use case

The method add_linkage_type is called on a variable when the linkage_type value exists. The variable can either be an IdentityXref or an OntologyXref object. However, only OntologyXref has this method defined as the linkage_type only makes sense for an ontology xref. A fix was added to only call this method if the correct object is being used.

## Benefits

Bug fix.

## Possible Drawbacks

None.
However, additional checks will be done to figure out if the occurrence of this scenario makes sense in the domain of xrefs (having a linkage_type value when the xref is an IdentityXref one. This fix is needed either way, though.

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

