### PR TITLE
Fixed double init

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -604,7 +604,7 @@ sub remove {
   }
 
   # remove all protein_features on this translation
-  my $sth = $self->prepare
+  $sth = $self->prepare
     ("DELETE FROM protein_feature WHERE translation_id = ?");
   $sth->bind_param(1,$translation->dbID,SQL_INTEGER);
   $sth->execute();


### PR DESCRIPTION
## Description

Sister PR to #687 - this one against `main` branch
Fixing warning because of double "init".

## Benefits

Get rid of unwanted warnings.

## Possible Drawbacks

None

## Testing

Test suite ran fine.

