### PR TITLE
Fixed incorrect escape for percent in SQL stmt

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
@@ -243,8 +243,9 @@ sub find_and_add_species_id {
 
   my $dbc = $self->dbc;
   my $sth = $dbc->prepare(sprintf "SELECT DISTINCT species_id FROM %s.meta " .
-			  "WHERE meta_key='species.alias' AND meta_value LIKE '%%s%'", 
-			  $dbc->db_handle->quote_identifier($dbc->dbname), $species);
+              "WHERE meta_key='species.alias' AND INSTR(meta_value, ?) > 0", 
+              $dbc->db_handle->quote_identifier($dbc->dbname));
+  $sth->bind_param(1, $species);
   $sth->execute() or
     throw "Error querying for species_id: perhaps the DB doesn't have a meta table?\n" .
       "$DBI::err .... $DBI::errstr\n";


### PR DESCRIPTION
## Description

Fix incorrect escape for percent char in SQL statement.
Sister PR to #691 

## Use case

Bug fixing.
The method `find_and_add_species_id ` would not work as expected otherwise.

## Benefits

Avoid seldom, but annoying, errors

## Possible Drawbacks

None

## Testing

The test suite ran fine.
