### PR TITLE
Added support for the new 'gencode_primary' transcript attribute

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3154,7 +3154,7 @@ sub summary_as_hash {
 
 =head2 gencode_basic
 
-  Example       : $gencode_basic = $transcript->tag();
+  Example       : $gencode_basic = $transcript->get_all_Attributes('gencode_basic')->[0];
   Description   : Returns true if gencode_basic is set
   Returns       : boolean
 =cut
@@ -3165,6 +3165,21 @@ sub gencode_basic {
   my $basic = 0;
   $basic = 1 if scalar(@attributes) > 0;
   return $basic;
+}
+
+=head2 gencode_primary
+
+  Example       : $gencode_basic = $transcript->get_all_Attributes('gencode_primary')->[0];
+  Description   : Returns true if gencode_primary is set
+  Returns       : boolean
+=cut
+
+sub gencode_basic {
+  my $self = shift;
+  my @attributes = @{ $self->get_all_Attributes('gencode_primary') };
+  my $primary = 0;
+  $primary = 1 if scalar(@attributes) > 0;
+  return $primary;
 }
 
 =head2 tsl


### PR DESCRIPTION
## Description

A new transcript attribute "gencode_primary" has being introduced (for human).
This attribute is meant to eventually - i.e. in the long run - replace GENCODE basic.

This change is necessary to support the displaying of the new attribute on the web site, as well as having it available in the published annotation files.

## Use case

Check a transcript for the "gencode_primary" attribute.
This is entirely similar to the already available check for the GENCODE Basic attribute.

## Benefits

It's a must have to properly handle the new attribute.

## Possible Drawbacks

None

## Testing

TBC

