### PR TITLE
Update tags to fix GTF/GFF3 tag data

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3144,9 +3144,9 @@ sub summary_as_hash {
   $summary_ref->{'transcript_support_level'} = $self->tsl() if $self->tsl();
 
   my @tags;
-  push @tags, 'basic' if $self->gencode_basic();
+  push @tags, 'GENCODE Basic' if $self->gencode_basic();
   push @tags, 'Ensembl_canonical' if $self->is_canonical();
-  push @tags, 'primary' if $self->gencode_primary();
+  push @tags, 'GENCODE Primary' if $self->gencode_primary();
 
   my $mane = $self->mane_transcript();
   if ($mane) {

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3146,7 +3146,7 @@ sub summary_as_hash {
   my @tags;
   push @tags, 'basic' if $self->gencode_basic();
   push @tags, 'Ensembl_canonical' if $self->is_canonical();
-  push @tags, 'GENCODE Primary' if $self->gencode_primary();
+  push @tags, 'gencode_primary' if $self->gencode_primary();
 
   my $mane = $self->mane_transcript();
   if ($mane) {

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3144,7 +3144,7 @@ sub summary_as_hash {
   $summary_ref->{'transcript_support_level'} = $self->tsl() if $self->tsl();
 
   my @tags;
-  push @tags, 'GENCODE Basic' if $self->gencode_basic();
+  push @tags, 'basic' if $self->gencode_basic();
   push @tags, 'Ensembl_canonical' if $self->is_canonical();
   push @tags, 'GENCODE Primary' if $self->gencode_primary();
 

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3146,7 +3146,7 @@ sub summary_as_hash {
   my @tags;
   push @tags, 'basic' if $self->gencode_basic();
   push @tags, 'Ensembl_canonical' if $self->is_canonical();
-  push @tags, 'gencode_primary' if $self->gencode_primary();
+  push @tags, $self->get_all_Attributes('gencode_primary')->[0]->code if $self->gencode_primary();
 
   my $mane = $self->mane_transcript();
   if ($mane) {


### PR DESCRIPTION
Found that GTF and GFF3 file tests are failing in `ensembl-io` due to tags having different values to those expected. For example, have found that modifying tags in this repo now allows `ensembl-io` to dump out "GENCODE Primary" instead of "primary" in GTF and GFF3 file tests.

Related PR: https://github.com/Ensembl/ensembl-io/pull/160.