### PR TITLE
Extend meta_key length on main branch

### DIFF
--- a/sql/patch_111_112_c.sql
+++ b/sql/patch_111_112_c.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_111_112_c.sql
+#
+# Title: Extend meta_key length
+#
+# Description:
+#   Extend meta_key length to 64
+
+ALTER TABLE meta MODIFY COLUMN meta_key VARCHAR(64) NOT NULL;
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_111_112_c.sql|Extend meta_key length to 64');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -295,7 +295,7 @@ CREATE TABLE IF NOT EXISTS meta (
 
   meta_id                     INT NOT NULL AUTO_INCREMENT,
   species_id                  INT UNSIGNED DEFAULT 1,
-  meta_key                    VARCHAR(40) NOT NULL,
+  meta_key                    VARCHAR(64) NOT NULL,
   meta_value                  VARCHAR(255) DEFAULT NULL,
 
   PRIMARY   KEY (meta_id),
@@ -318,6 +318,9 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_111_112_b.sql|Allow meta_value to be null');
+
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_111_112_c.sql|Extend meta_key length to 64');
 
 /**
 @table meta_coord


### PR DESCRIPTION
Have extended `meta_key` length in Release 112 branch and needs bringing in `main` branch.

Related to 112-based PR https://github.com/Ensembl/ensembl/pull/683.