### PR TITLE
Add c patch to 111_112 test databases

### DIFF
--- a/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:41:15 2023
+-- Created on Tue Apr 16 13:13:30 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -153,3 +153,4 @@
 153	\N	patch	patch_110_111_a.sql|schema_version
 154	\N	patch	patch_111_112_a.sql|schema_version
 155	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+156	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=156 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=157 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:42:10 2023
+-- Created on Tue Apr 16 13:16:06 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -136,3 +136,4 @@
 210	\N	patch	patch_110_111_a.sql|schema_version
 211	\N	patch	patch_111_112_a.sql|schema_version
 212	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+213	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -103,7 +103,7 @@ CREATE TABLE `attrib_type` (
   `description` text COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
-) ENGINE=MyISAM AUTO_INCREMENT=555 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=577 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
   `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=213 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=214 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:43:02 2023
+-- Created on Tue Apr 16 13:18:40 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -132,3 +132,4 @@
 181	\N	patch	patch_110_111_a.sql|schema_version
 182	\N	patch	patch_111_112_a.sql|schema_version
 183	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+184	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=184 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=185 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:43:56 2023
+-- Created on Tue Apr 16 13:21:14 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -137,3 +137,4 @@
 2144	\N	patch	patch_110_111_a.sql|schema_version
 2145	\N	patch	patch_111_112_a.sql|schema_version
 2146	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+2147	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2147 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=2148 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/meta.txt
@@ -72,3 +72,5 @@
 72	\N	patch	patch_110_111_a.sql|schema version
 73	\N	patch	patch_110_111_b.sql|Update transcript_variation primary key
 74	\N	patch	patch_111_112_a.sql|schema_version
+75	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+76	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -181,12 +181,12 @@ CREATE TABLE `individual_type` (
 CREATE TABLE `meta` (
   `meta_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=75 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=79 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/xref/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:43:58 2023
+-- Created on Tue Apr 16 13:21:16 2024
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:44:46 2023
+-- Created on Tue Apr 16 13:23:50 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -93,3 +93,4 @@
 186	\N	patch	patch_110_111_a.sql|schema_version
 187	\N	patch	patch_111_112_a.sql|schema_version
 188	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+189	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=189 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=190 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:45:27 2023
+-- Created on Tue Apr 16 13:25:49 2024
 --
 
 BEGIN TRANSACTION;

--- a/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:46:26 2023
+-- Created on Tue Apr 16 13:28:23 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -210,3 +210,4 @@
 1722	\N	patch	patch_110_111_a.sql|schema_version
 1723	\N	patch	patch_111_112_a.sql|schema_version
 1724	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+1725	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1725 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=1726 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/mus_musculus/variation/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/variation/meta.txt
@@ -99,3 +99,5 @@
 105	\N	patch	patch_110_111_a.sql|schema version
 106	\N	patch	patch_110_111_b.sql|Update transcript_variation primary key
 107	\N	patch	patch_111_112_a.sql|schema_version
+108	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+109	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/mus_musculus/variation/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/variation/table.sql
@@ -181,12 +181,12 @@ CREATE TABLE `individual_type` (
 CREATE TABLE `meta` (
   `meta_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=108 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=112 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:47:17 2023
+-- Created on Tue Apr 16 13:30:53 2024
 --
 
 BEGIN TRANSACTION;
@@ -535,7 +535,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/nameless/core/meta.txt
+++ b/modules/t/test-genome-DBs/nameless/core/meta.txt
@@ -131,3 +131,4 @@
 185	\N	patch	patch_110_111_a.sql|schema_version
 186	\N	patch	patch_111_112_a.sql|schema_version
 187	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+188	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -475,12 +475,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=188 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=189 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:47:30 2023
+-- Created on Tue Apr 16 13:31:33 2024
 --
 
 BEGIN TRANSACTION;
@@ -213,7 +213,7 @@ CREATE UNIQUE INDEX "closure_child_parent_idx" ON "closure" ("child_term_id", "p
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "meta_key" varchar(64) NOT NULL,
-  "meta_value" varchar(128),
+  "meta_value" varchar(255) NOT NULL,
   "species_id" integer
 );
 

--- a/modules/t/test-genome-DBs/ontology/ontology/meta.txt
+++ b/modules/t/test-genome-DBs/ontology/ontology/meta.txt
@@ -55,3 +55,5 @@
 58	patch	patch_109_110_a.sql|schema_version	\N
 59	patch	patch_110_111_a.sql|schema_version	\N
 60	patch	patch_111_112_a.sql|schema_version	\N
+61	patch	patch_111_112_b.sql|Allow meta_value to be null	\N
+62	patch	patch_111_112_c.sql|Extend meta_key length to 64	\N

--- a/modules/t/test-genome-DBs/ontology/ontology/table.sql
+++ b/modules/t/test-genome-DBs/ontology/ontology/table.sql
@@ -137,11 +137,11 @@ CREATE TABLE `closure` (
 CREATE TABLE `meta` (
   `meta_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `meta_key` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
-  `meta_value` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `meta_value` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `species_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `key_value_idx` (`meta_key`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=61 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=65 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology` (
   `ontology_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/modules/t/test-genome-DBs/parus_major1/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:48:22 2023
+-- Created on Tue Apr 16 13:34:08 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/parus_major1/core/meta.txt
+++ b/modules/t/test-genome-DBs/parus_major1/core/meta.txt
@@ -104,3 +104,4 @@
 145	\N	patch	patch_110_111_a.sql|schema_version
 146	\N	patch	patch_111_112_a.sql|schema_version
 147	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+148	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/parus_major1/core/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=148 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=149 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:49:14 2023
+-- Created on Tue Apr 16 13:37:01 2024
 --
 
 BEGIN TRANSACTION;
@@ -546,7 +546,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -186,3 +186,4 @@
 266	\N	patch	patch_110_111_a.sql|schema_version
 267	\N	patch	patch_111_112_a.sql|schema_version
 268	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+269	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=269 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=270 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/SQLite/table.sql
@@ -1,6 +1,6 @@
 --
 -- Created by SQL::Translator::Producer::SQLite
--- Created on Tue Aug 22 11:50:03 2023
+-- Created on Tue Apr 16 13:39:31 2024
 --
 
 BEGIN TRANSACTION;
@@ -535,7 +535,7 @@ CREATE TABLE "marker_synonym" (
 CREATE TABLE "meta" (
   "meta_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "species_id" integer DEFAULT 1,
-  "meta_key" varchar(40) NOT NULL,
+  "meta_key" varchar(64) NOT NULL,
   "meta_value" varchar(255)
 );
 

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -206,3 +206,4 @@
 248	\N	patch	patch_110_111_a.sql|schema_version
 249	\N	patch	patch_111_112_a.sql|schema_version
 250	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+251	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -475,12 +475,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=251 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=252 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',


### PR DESCRIPTION
Before bumping version to 113, we need to add the c patch (extend meta_key value) to the 112 test databases.

This also adds the missing 111_112 b and c patch data to variation and ontology-based test db data.