### PR TITLE
Replace master with main in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ensembl Core API
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=master)][travis]
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=master)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=main)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=main)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl


### PR DESCRIPTION
Have found that the travis and coveralls badges in the README.md file are still pointing at the master branch. This PR updates this file to point at the main branch.