### PR TITLE
Fix the id we use for Bio::Seq

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -2138,7 +2138,7 @@ sub translate {
   my $last_mrna_codon  = substr( $mrna, -3, 3 );
 
   my $display_id = $self->translation->display_id()
-    || scalar( $self->translation() );
+    || "" . $self->translation();
 
   # From BioPerl perspective, we'll treat our CDS as incomplete:
   # thus, BioPerl will not 


### PR DESCRIPTION
We use an id to construct a Bio::Seq object. Before, we would pass in an actual object reference instead of a string. This could result in a segfault later. This occurs because BioPerl will clone the object. The Transcript object contains DBI handles, these will frequently result in segfaults when cloned. Force a string instead.
