### PR TITLE
Fix the id we use for Bio::Seq

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -2154,7 +2154,7 @@ sub translate {
   if ( CORE::length($mrna) < 1 ) { return undef }
 
   my $display_id = $self->translation->display_id()
-    || scalar( $self->translation() );
+    || "" . $self->translation();
 
   my $peptide = Bio::Seq->new( -seq      => $mrna,
                                -moltype  => 'dna',


### PR DESCRIPTION
- We use an id to construct a Bio::Seq object. Before, we would pass in an actual object reference instead of a string. This could result in a segfault later. This occurs because BioPerl will clone the object. The Transcript object contains DBI handles, these will frequently result in segfaults when cloned. Force a string instead.
