### PR TITLE
Xref ZFIN Parser Fix

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/ZFINParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINParser.pm
@@ -45,7 +45,7 @@ sub run {
   my $file = @{$files}[0];
   my $dir = dirname($file);
 
-  my (%swiss) = %{$self->get_valid_codes("uniprot/swissprot",$species_id, $dbi)};
+  my (%swiss) = %{$self->get_valid_codes("uniprot/",$species_id, $dbi)};
   my (%refseq) = %{$self->get_valid_codes("refseq",$species_id, $dbi)};
 
   my $swissprot_io =


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Changing ZFIN gene name mapping from only considering SWISSPROT to all Uniprot.

## Use case

A decrease has been noticed in the Zebrafish core DB for gene names assigned by ZFIN. It turns out that the ZFIN xref parser only adds ZFIN xrefs when they are associated with SWISSPROT data. A change was added to consider all Unirpot data (including trEMBL) in an effort to get back some of those lost gene names.

## Benefits

More ZFIN gene names.

## Possible Drawbacks

The trEMBL data can be considered less reliable than the SWISSPROT one, but because we are getting the mapping from ZFIN then we depend on them to verify that the mappings are accurate.

## Testing

The xref processing pipeline was run with this change and the number of ZFIN gene names increased by close to 4500.

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

