### PR TITLE
Fixing Coveralls not working and some CI optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ services:
   - mysql
 
 perl:
-#  - '5.26'
-  - '5.30'
+  - '5.26'
+  - '5.40'
 
 env:
   matrix:
   - COVERALLS=true  DB=mysql
-#  - COVERALLS=false DB=mysql
-#  - COVERALLS=false DB=sqlite
+  - COVERALLS=false DB=mysql
+  - COVERALLS=false DB=sqlite
   global:
   - secure: Ju069PzB8QZG3302emIhyCEEQfVfVsiXy0nGcR6hue+vW9nE82NnOEZHbZIwUCXEjUaZRMVQ31Em70Ky22OrLK4D59bs2ClH21u8URDGD/cn7JNPGWFrgxuaXQKMQrw72doeB0+w1+ShURtqM41vITjinyU3y34RZ1NcbDwYSZI=
 
@@ -55,10 +55,10 @@ script:
 
 jobs:
   include:
-    - perl: '5.30'
+    - perl: '5.26'
       env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   exclude:
-    - perl: '5.26'
+    - perl: '5.40'
       env: COVERALLS=true DB=mysql
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ perl:
 
 env:
   matrix:
-  - COVERALLS=true  DB=mysql
+  - COVERALLS=true  DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   - COVERALLS=false DB=mysql
   - COVERALLS=false DB=sqlite
   global:
@@ -59,7 +59,7 @@ jobs:
       env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   exclude:
     - perl: '5.40'
-      env: COVERALLS=true DB=mysql
+      env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,9 @@ jobs:
   include:
     - perl: '5.30'
       env: COVERALLS=false DB=mysql
-      dist: focal
   exclude:
     - perl: '5.26'
-      env: COVERALLS=false DB=mysql
-    - perl: '5.30'
-      dist: trusty
+      env: COVERALLS=true DB=mysql
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: perl
 
 dist:
-  - trusty
+  - focal
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ services:
   - mysql
 
 perl:
-  - '5.26'
+#  - '5.26'
   - '5.30'
 
 env:
   matrix:
   - COVERALLS=true  DB=mysql
-  - COVERALLS=false DB=mysql
-  - COVERALLS=false DB=sqlite
+#  - COVERALLS=false DB=mysql
+#  - COVERALLS=false DB=sqlite
   global:
   - secure: Ju069PzB8QZG3302emIhyCEEQfVfVsiXy0nGcR6hue+vW9nE82NnOEZHbZIwUCXEjUaZRMVQ31Em70Ky22OrLK4D59bs2ClH21u8URDGD/cn7JNPGWFrgxuaXQKMQrw72doeB0+w1+ShURtqM41vITjinyU3y34RZ1NcbDwYSZI=
 
@@ -56,10 +56,10 @@ script:
 jobs:
   include:
     - perl: '5.30'
-      env: COVERALLS=false DB=mysql
+      env: COVERALLS=false DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   exclude:
     - perl: '5.26'
-      env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
+      env: COVERALLS=true DB=mysql
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
 jobs:
   include:
     - perl: '5.30'
-      env: COVERALLS=false DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
+      env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   exclude:
     - perl: '5.26'
       env: COVERALLS=true DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,11 @@ script:
   - "./travisci/harness.sh"
 
 jobs:
-  include:
-    - perl: '5.26'
-      env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
   exclude:
     - perl: '5.40'
       env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
+    - perl: '5.26'
+      env: COVERALLS=false DB=mysql
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ jobs:
     - perl: '5.26'
       env: COVERALLS=true DB=mysql
 
+
 notifications:
   email:
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       env: COVERALLS=false DB=mysql
   exclude:
     - perl: '5.26'
-      env: COVERALLS=true DB=mysql
+      env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
 
 
 notifications:


### PR DESCRIPTION
## Description

These changes were originally meant to troubleshoot Coveralls integration.
Decided eventually to increase the scope by including also
- Base image version update (focal)
- Perl version update 5.30 --> 5.40
- build matrix optimisation 

## Use case

Coveralls was not triggered properly anymore by the CI process. The issue was resolved by configuring the repo token.
Also
- the "modern" Perl version 5.30 to run the test suite with was outdated, and replaced by a true up-to-date 5.40.
- the base image version has been bumped up to `focal`
- build matrix cross product has been streamlined

## Benefits

- Coveralls reporting restored
- up-to-date base system configuration
- potentially faster builds / e2e test execution

## Possible Drawbacks

None

## Testing

The test suite is unaffected by these changes, as well as the repo's codebase.
Manual testing for Coveralls were carried out locally, and Travis-related tests were run by submitting changes to the online branch.

