### PR TITLE
Handle carriage returns

### DIFF
--- a/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
@@ -86,10 +86,13 @@ sub run {
   my $input_file = Text::CSV->new({
     sep_char       => "\t",
     empty_is_undef => 1,
+    binary => 1,
+    verbatim => 1
   }) || confess "Cannot use file $file: " . Text::CSV->error_diag();
 
   my $count = 0;
   while ( my $data = $input_file->getline($file_io) ) {
+    tr/\r\n//d for @$data;
 
     my ( $accession, $label, $desc, $stable_id ) = @{$data};
 


### PR DESCRIPTION
## Description

Fix in Xenbase parser.

## Use case

After changing the file downloaded for the Xenbase source, the parser is now failing due to a difference in the file. There exist some lines that end in a carriage return rather than a new line. This change fixes that by reading the lines verbatim and then replacing the carriage return.

## Benefits

Xenbase parser succeeds.

## Possible Drawbacks

None

## Testing

Parser was run with this change and the xrefs were correctly added into the intermediate DB.

