### PR TITLE
Xref Changes and Fixes

### DIFF
--- a/misc-scripts/xref_mapping/XrefMapper/ProcessPrioritys.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/ProcessPrioritys.pm
@@ -318,7 +318,12 @@ sub process_dependents{
       foreach my $ensembl_id (@{ $ensembl_ids{$object_type} }) {
         # Add new object_xref for each best_ensembl_id. 
         $insert_dep_ox_sth->execute($new_master_xref_id, $object_type, $ensembl_id, $dep_xref_id);
-        ## If there is a linkage_annotation, it is a go xref
+
+        $dep_ox_sth->execute($new_master_xref_id, $object_type, $ensembl_id, $dep_xref_id);
+        $dep_ox_sth->bind_columns(\$new_object_xref_id);
+        while ($dep_ox_sth->fetch()) {
+          $insert_ix_sth->execute($new_object_xref_id);
+        }
       }
       unless ($dep_xref_id == $xref_id) {
         push @master_xrefs, $dep_xref_id; # remember chained dependent xrefs

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
@@ -211,7 +211,11 @@ sub run_script {
 ## Add link to EntrezGene IDs where available
   my (%entrez_ids) = %{ $self->get_valid_codes("EntrezGene", $species_id, $dbi) };
   my $entrez_source_id = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
-  my $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)");
+  my $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?,?)");
+
+  ## Add link to WikiGene IDs where available
+  my (%wiki_ids) = %{ $self->get_valid_codes('WikiGene', $species_id, $dbi) };
+  my $wiki_source_id = $self->get_source_id_for_source_name('WikiGene', undef, $dbi);
 
   my $sa = $core_dba->get_SliceAdaptor();
   my $sa_of = $otherf_dba->get_SliceAdaptor();
@@ -401,7 +405,10 @@ sub run_script {
 # Add link between Ensembl gene and EntrezGene
           if (defined $entrez_ids{$entrez_id} ) {
             foreach my $dependent_xref_id (@{$entrez_ids{$entrez_id}}) {
-              $add_dependent_xref_sth->execute($xref_id, $dependent_xref_id);
+              $add_dependent_xref_sth->execute($xref_id, $dependent_xref_id, $entrez_source_id);
+            }
+            foreach my $dependent_xref_id (@{$wiki_ids{$entrez_id}}) {
+              $add_dependent_xref_sth->execute($xref_id, $dependent_xref_id, $wiki_source_id);
             }
           }
 

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqGPFFParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqGPFFParser.pm
@@ -259,6 +259,8 @@ sub xref_from_record {
       print $entry if (length($description) == 0);
       $description =~ s/\nACCESSION.*//s;
       $description =~ s/\n//g;
+      $description =~ s/{.*}-like//g;
+      $description =~ s/{.*}//g;
       $description =~ s/\s+/ /g;
       $description = substr($description, 0, 255) if (length($description) > 255);
 

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -582,7 +582,7 @@ sub get_name {
 }
 
 sub get_hgnc_descriptions {
-  my ($hgnc_file) = @_;
+  my ($self, $hgnc_file) = @_;
   my %descriptions;
 
   my $hgnc_fh = $self->get_filehandle($hgnc_file);
@@ -603,7 +603,7 @@ sub get_hgnc_descriptions {
 
   $input_file->column_names( @{ $input_file->getline( $hgnc_io ) } );
 
-  while ( my $data = $input_file->getline_hr( $fh ) ) {
+  while ( my $data = $input_file->getline_hr( $hgnc_io ) ) {
     my $gene_name   = $data->{'Approved symbol'};
     my $description = $data->{'Approved name'};
 

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -33,6 +33,7 @@ use warnings;
 use Carp;
 use POSIX qw(strftime);
 use File::Basename;
+use Text::CSV;
 
 use base qw( XrefParser::BaseParser );
 
@@ -49,6 +50,8 @@ sub run {
   my $verbose      = $ref_arg->{verbose};
   my $dbi          = $ref_arg->{dbi};
   $dbi = $self->dbi unless defined $dbi;
+
+  my $hgnc_file = $ref_arg->{hgnc_file} || undef;
 
   if((!defined $source_id) or (!defined $species_id) or (!defined $files)){
     croak "Need to pass source_id, species_id, files and rel_file as pairs";
@@ -79,7 +82,7 @@ sub run {
   print "SpTREMBL direct source id for $file: $sptr_direct_source_id\n" if ($verbose);
  
   $self->create_xrefs( $sp_source_id, $sptr_source_id, $sptr_non_display_source_id, $species_id,
-      $file, $verbose, $sp_direct_source_id, $sptr_direct_source_id, $isoform_source_id, $dbi );
+      $file, $verbose, $sp_direct_source_id, $sptr_direct_source_id, $isoform_source_id, $hgnc_file, $dbi );
 
     if ( defined $release_file ) {
         # Parse Swiss-Prot and SpTrEMBL release info from
@@ -113,7 +116,7 @@ sub run {
 # Parse file into array of xref objects
 
 sub create_xrefs {
-  my ($self, $sp_source_id, $sptr_source_id, $sptr_non_display_source_id, $species_id, $file, $verbose, $sp_direct_source_id, $sptr_direct_source_id, $isoform_source_id, $dbi ) = @_;
+  my ($self, $sp_source_id, $sptr_source_id, $sptr_non_display_source_id, $species_id, $file, $verbose, $sp_direct_source_id, $sptr_direct_source_id, $isoform_source_id, $hgnc_file, $dbi ) = @_;
 
   my $num_sp = 0;
   my $num_sptr = 0;
@@ -125,13 +128,16 @@ sub create_xrefs {
 
   my %dependent_sources = $self->get_xref_sources($dbi);
 
-    my (%genemap) =
-      %{ $self->get_valid_codes( "mim_gene", $species_id, $dbi ) };
-    my (%morbidmap) =
-      %{ $self->get_valid_codes( "mim_morbid", $species_id, $dbi ) };
+  my (%genemap) =
+    %{ $self->get_valid_codes( "mim_gene", $species_id, $dbi ) };
+  my (%morbidmap) =
+    %{ $self->get_valid_codes( "mim_morbid", $species_id, $dbi ) };
 
-    my $uniprot_io = $self->get_filehandle($file);
-    if ( !defined $uniprot_io ) { return }
+  # Extract descriptions from hgnc
+  my %hgnc_descriptions = $self->get_hgnc_descriptions($hgnc_file);
+
+  my $uniprot_io = $self->get_filehandle($file);
+  if ( !defined $uniprot_io ) { return }
 
   my @xrefs;
 
@@ -336,7 +342,17 @@ sub create_xrefs {
     
     my ($gns) = $_ =~ /(GN\s+.+)/s;
     my @gn_lines = ();
-    if ( defined $gns ) { @gn_lines = split /;/, $gns }
+    if (defined $gns) {
+      foreach my $gn_line (split("\n", $gns)) {
+        if ($gn_line !~ /^GN/) {last;}
+
+        $gn_line =~ s/^GN\s+//g;
+        push(@gn_lines, $gn_line);
+      }
+
+      $gns = join('', @gn_lines);
+      @gn_lines = split /;/, $gns;
+    }
   
     # Do not allow the addition of UniProt Gene Name dependent Xrefs
     # if the protein was imported from Ensembl. Otherwise we will
@@ -344,11 +360,9 @@ sub create_xrefs {
     if(! $ensembl_derived_protein) {
       my %depe;
       foreach my $gn (@gn_lines){
-# Make sure these are still lines with Name or Synonyms
-        if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
         my $gene_name = undef;
 
-        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s:]+)/s) { #/s for multi-line entries ; is the delimiter
+        if ($gn =~ /Name=([A-Za-z0-9_\-\.\s:]+)/s) { #/s for multi-line entries ; is the delimiter
 # Example line 
 # GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
           my $name = $1;
@@ -360,6 +374,7 @@ sub create_xrefs {
           $depe{SOURCE_NAME} = "Uniprot_gn";
           $depe{SOURCE_ID} = $dependent_sources{"Uniprot_gn"};
           $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+          $depe{DESCRIPTION} = $hgnc_descriptions{$name};
           push @{$xref->{DEPENDENT_XREFS}}, \%depe;
           $dependent_xrefs{"Uniprot_gn"}++;
         }
@@ -565,4 +580,39 @@ sub get_name {
 
   return $acc;
 }
+
+sub get_hgnc_descriptions {
+  my ($hgnc_file) = @_;
+  my %descriptions;
+
+  my $hgnc_fh = $self->get_filehandle($hgnc_file);
+  if ( !defined $hgnc_fh ) {confess "Can't open HGNC file '$hgnc_file'\n";}
+  $hgnc_file = do { local $/; <$hgnc_fh> };
+
+  my $input_file = Text::CSV->new({
+    sep_char       => "\t",
+    empty_is_undef => 1,
+    binary         => 1,
+    auto_diag      => 1
+  }) or croak "Cannot use file $hgnc_file: ".Text::CSV->error_diag ();
+
+  $hgnc_file = Encode::encode("UTF-8", $hgnc_file);
+  $hgnc_file =~ s/"//xg;
+
+  open my $hgnc_io, '<', \$hgnc_file or confess "Can't open HGNC file: $!\n";
+
+  $input_file->column_names( @{ $input_file->getline( $hgnc_io ) } );
+
+  while ( my $data = $input_file->getline_hr( $fh ) ) {
+    my $gene_name   = $data->{'Approved symbol'};
+    my $description = $data->{'Approved name'};
+
+    $descriptions{$gene_name} = $description;
+  }
+
+  close $hgnc_io;
+
+  return %descriptions;
+}
+
 1;

--- a/misc-scripts/xref_mapping/XrefParser/ZFINParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -237,4 +237,3 @@ sub run {
 }
 
 1;
-

--- a/misc-scripts/xref_mapping/xref_config.ini
+++ b/misc-scripts/xref_mapping/xref_config.ini
@@ -946,6 +946,13 @@ order           = 20
 priority        = 1
 parser          = UniProtParser
 
+[source UniProt::STRING]
+# Special source used in UniProtParser.  No species uses this source.
+name            = STRING
+order           = 20
+priority        = 1
+parser          = UniProtParser
+
 [source UniParc::MULTI]
 name        = UniParc
 order       = 20
@@ -1661,6 +1668,7 @@ source      = EntrezGene::MULTI
 source      = Reactome::MULTI
 source      = RNACentral::MULTI
 source      = RefSeq_dna::MULTI-Plants
+source      = RefSeq_peptide::MULTI-Plants
 source      = RefSeq_import::otherfeatures
 source      = Uniprot/SPTREMBL::MULTI
 source      = Uniprot/SWISSPROT::MULTI


### PR DESCRIPTION
## Description

During the 113 xref run, several issues were flagged and these changes attempt to fix them.

## Use case

These changes consist of some bug fixes along with improvements to xrefs. These include:
- Making the ZFIN xrefs DIRECT ones (read from the ensembl_1_to_1 file downloaded from ZFIN), in addition to the DEPENDENT xrefs added based on UniProt and RefSeq
- Adding WikiGene xrefs along with EntrezGene ones when a mapping is found in the otherfeatures db
- Uniprot_gn xrefs were missing identity_xref rows when dependency is moved from the SEQUENCE_MATCH Uniprot to the DIRECT one, which was leading to loss in gene names
- Adding HGNC descriptions to Uniprot_gn xrefs, as they are used as display xrefs but have no descriptions since they are dependents
- Adding the STRING source to all species as it was missing in some Plants DBs (as a Uniprot DEPENDENT source)
- Adding the parsing of RefSeq_peptide to Plants species
- Fixing the handling of RefSeq descriptions as it was leaving in the "{ECO}" text, leading to a critical DC failure
- Fixing the handling of multiline gene names in the Uniprot file, which was leading to having a newline in the name

## Benefits

Bug fixes and improvements.

## Possible Drawbacks

The majority of gene names in most species will now come from Uniprot_gn instead of an HGNC projection. While this shouldn't be an issue, as the actual names are the same and descriptions still come from HGNC, it's still a noticeable change.

## Testing

Waiting for Codon to be back to complete testing.

