### PR TITLE
[114] Update travis and coveralls badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ensembl Core API
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=main)][travis]
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=main)][coveralls]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl.svg?branch=release/114)][travis]
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl/badge.svg?branch=release/114)][coveralls]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl
 [coveralls]: https://coveralls.io/github/Ensembl/ensembl


### PR DESCRIPTION
Update travis and coveralls badge to release/114.

Apologies, I forgot to update the travis and coveralls badges to the new release branch before pushing the new branch.