### PR TITLE
Tidying up TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 
 install:
   - cpanm -v --sudo --installdeps --with-all-features .
+  - cpanm -v --sudo --notest XML::LibXML # https://github.com/shlomif/perl-XML-LibXML/pull/87
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - cp travisci/testdb.conf.travisci.mysql  testdb.conf.mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ env:
   global:
   - secure: Ju069PzB8QZG3302emIhyCEEQfVfVsiXy0nGcR6hue+vW9nE82NnOEZHbZIwUCXEjUaZRMVQ31Em70Ky22OrLK4D59bs2ClH21u8URDGD/cn7JNPGWFrgxuaXQKMQrw72doeB0+w1+ShURtqM41vITjinyU3y34RZ1NcbDwYSZI=
 
-addons:
-  apt:
-    packages:
-    - unzip
-
 before_install:
   - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
   - export PATH=$PWD/ensembl-git-tools/bin:$PATH
@@ -37,18 +32,13 @@ before_install:
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:
-  - cpanm -v --sudo --installdeps --notest . --with-all-features
-  - cpanm -n --sudo Devel::Cover Devel::Cover::Report::Coveralls Test::Exception Moose Devel::Cycle Test::Warnings
-  - cpanm -n --sudo DBD::SQLite JSON
+  - cpanm -v --sudo --installdeps --with-all-features .
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - cp travisci/testdb.conf.travisci.mysql  testdb.conf.mysql
   - cp travisci/testdb.conf.travisci.SQLite testdb.conf.SQLite
   - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
   - mysql -u root -h localhost -e 'SET GLOBAL local_infile=1'
-
-before_script:
-  - rm -f "$HOME/.ensemblapi_no_version_check"
 
 script:
   - "./travisci/harness.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 perl:
   - '5.26'
-  - '5.40'
+  - '5.32'
 
 env:
   matrix:
@@ -32,8 +32,8 @@ before_install:
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:
-  - cpanm -v --sudo --installdeps --with-all-features .
   - cpanm -v --sudo --notest XML::LibXML # https://github.com/shlomif/perl-XML-LibXML/pull/87
+  - cpanm -v --sudo --installdeps --with-all-features .
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - cp travisci/testdb.conf.travisci.mysql  testdb.conf.mysql
@@ -46,7 +46,7 @@ script:
 
 jobs:
   exclude:
-    - perl: '5.40'
+    - perl: '5.32'
       env: COVERALLS=true DB=mysql COVERALLS_REPO_TOKEN=${{secret.COVERALLS_REPO_TOKEN}}
     - perl: '5.26'
       env: COVERALLS=false DB=mysql

--- a/cpanfile
+++ b/cpanfile
@@ -1,11 +1,13 @@
 requires 'DBI';
 requires 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
+requires 'DBD::SQLite';
 requires 'HTTP::Tiny';
 requires 'IO::Compress::Gzip';
 requires 'URI::Escape';
 requires 'Config::IniFiles';
 requires 'Gzip::Faster';
 requires 'List::MoreUtils';
+requires 'JSON';
 
 test_requires 'Test::Warnings';
 test_requires 'Test::Differences';
@@ -15,6 +17,8 @@ test_requires 'Test::Deep';
 test_requires 'Test::More';
 test_requires 'Devel::Peek';
 test_requires 'Devel::Cycle';
+test_requires 'Devel::Cover';
+test_requires 'Devel::Cover::Report::Coveralls';
 test_requires 'Error';
 test_requires 'PadWalker';
 test_requires 'Test::Builder::Module';


### PR DESCRIPTION
## Description

- Moved Perl deps from `.travis.yml` to `cpanfile`
- Exception: XML::LibXML tests contain bugs - see https://github.com/shlomif/perl-XML-LibXML/pull/87
- removed un-necessary `before-script` stanza from `.travis.yml`
- fixed max supported Perl version by Travis `focal` ([build environment](https://docs.travis-ci.com/user/reference/focal/#perl-support))

## Use case

Minor optimisations

## Benefits

Better tracking and handling of Perl dependencies

## Possible Drawbacks

None

## Testing

No tests were updated or added.
Test suite could run successfully

