### PR TITLE
Copyright optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
 install:
   - cpanm -v --sudo --notest XML::LibXML # https://github.com/shlomif/perl-XML-LibXML/pull/87
-  - cpanm -v --sudo --installdeps --with-all-features .
+  - cpanm -v --sudo --installdeps --notest --with-all-features .
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - cp travisci/testdb.conf.travisci.mysql  testdb.conf.mysql

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-                                Apache License
+
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,8 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-   Copyright [2016-2024] EMBL-European Bioinformatics Institute
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,42 +200,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-ENSEMBL CORE PROJECT SUBCOMPONENTS
-
-The Ensembl Core Project includes a number of subcomponents with
-separate copyright notices and license terms. Your use of the source
-code for the these subcomponents is subject to the terms and
-conditions of the following licenses.
-
-COMPONENT: modules/Bio/EnsEMBL/Utils/Cache.pm
-
-Code has been renamed from Tie::Cache to 
-Bio::EnsEMBL::Utils::Cache and originally distributed on CPAN.
-
-Copyright (c) 1999-2002 Joshua Chamas, Chamas Enterprises Inc.  
-Sponsored by development on NodeWorks http://www.nodeworks.com
-
-All rights reserved. This program is free software; 
-you can redistribute it and/or modify it under the same 
-terms as Perl itself.
-
-COMPONENT: misc-scripts/doxygen_filter/EnsEMBL/Filter.pm and 
-           misc-scripts/doxygen_filter/EnsEMBL/PerlFilter.pm. 
-
-Both portions of code were based on the following agreement; 
-PerlFilter.pm has seen significant re-writing but derives from the 
-original source.
-
-Doxygen Pre-Processor for Perl
-Copyright (C) 2002  Bart Schuller
-Copyright (C) 2006  Phinex Informatik AG
-All Rights Reserved
-
-Doxygen Filter is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
-Larry Wall's 'Artistic License' for perl can be found in
-http://www.perl.com/pub/a/language/misc/Artistic.html
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Ensembl
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+This product includes software developed at:
+- EMBL-European Bioinformatics Institute
+- Wellcome Trust Sanger Institute

--- a/NOTICE
+++ b/NOTICE
@@ -5,3 +5,37 @@ Copyright [2016-2024] EMBL-European Bioinformatics Institute
 This product includes software developed at:
 - EMBL-European Bioinformatics Institute
 - Wellcome Trust Sanger Institute
+
+ENSEMBL CORE PROJECT SUBCOMPONENTS
+
+The Ensembl Core Project includes a number of subcomponents with
+separate copyright notices and license terms. Your use of the source
+code for the these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+COMPONENT: modules/Bio/EnsEMBL/Utils/Cache.pm
+
+Code has been renamed from Tie::Cache to 
+Bio::EnsEMBL::Utils::Cache and originally distributed on CPAN.
+
+Copyright (c) 1999-2002 Joshua Chamas, Chamas Enterprises Inc.  
+Sponsored by development on NodeWorks http://www.nodeworks.com
+
+All rights reserved. This program is free software; 
+you can redistribute it and/or modify it under the same 
+terms as Perl itself.
+
+COMPONENT: misc-scripts/doxygen_filter/EnsEMBL/Filter.pm and 
+           misc-scripts/doxygen_filter/EnsEMBL/PerlFilter.pm. 
+
+Both portions of code were based on the following agreement; 
+PerlFilter.pm has seen significant re-writing but derives from the 
+original source.
+
+Doxygen Pre-Processor for Perl
+Copyright (C) 2002  Bart Schuller
+Copyright (C) 2006  Phinex Informatik AG
+All Rights Reserved
+
+Doxygen Filter is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.

--- a/misc-scripts/CreateFile4CopyDBoverServer.pl
+++ b/misc-scripts/CreateFile4CopyDBoverServer.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/alt_alleles/alt_alleles.pl
+++ b/misc-scripts/alt_alleles/alt_alleles.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/annual_copyright_updater.sh
+++ b/misc-scripts/annual_copyright_updater.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/AssemblyMapper/BlastzAligner.pm
+++ b/misc-scripts/assembly/AssemblyMapper/BlastzAligner.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/EXAMPLE.use_mapping.pl
+++ b/misc-scripts/assembly/EXAMPLE.use_mapping.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/align_by_clone_identity.pl
+++ b/misc-scripts/assembly/align_by_clone_identity.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/align_nonident_regions.pl
+++ b/misc-scripts/assembly/align_nonident_regions.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/align_nonident_regions_wrapper.pl
+++ b/misc-scripts/assembly/align_nonident_regions_wrapper.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/check_mapping.pl
+++ b/misc-scripts/assembly/check_mapping.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/cleanup_tmp_tables.sql
+++ b/misc-scripts/assembly/cleanup_tmp_tables.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/compare_assemblies.pl
+++ b/misc-scripts/assembly/compare_assemblies.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/conservation_statistics.pl
+++ b/misc-scripts/assembly/conservation_statistics.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/ensembl_assembly_to_chain.pl
+++ b/misc-scripts/assembly/ensembl_assembly_to_chain.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/exon_conservation_check.pl
+++ b/misc-scripts/assembly/exon_conservation_check.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/find_overlaps.pl
+++ b/misc-scripts/assembly/find_overlaps.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/fix_asm_overlaps.pl
+++ b/misc-scripts/assembly/fix_asm_overlaps.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/fix_cmp_overlaps.pl
+++ b/misc-scripts/assembly/fix_cmp_overlaps.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/fix_overlaps.pl
+++ b/misc-scripts/assembly/fix_overlaps.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/load_alternative_assembly.pl
+++ b/misc-scripts/assembly/load_alternative_assembly.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/load_feature_mappings.pl
+++ b/misc-scripts/assembly/load_feature_mappings.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/load_patch_fix_to_ref.pl
+++ b/misc-scripts/assembly/load_patch_fix_to_ref.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/mapping_stats.pl
+++ b/misc-scripts/assembly/mapping_stats.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/merge_cmp_gaps.pl
+++ b/misc-scripts/assembly/merge_cmp_gaps.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/assembly/test_assembly_mapping.pl
+++ b/misc-scripts/assembly/test_assembly_mapping.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/canonical_transcripts/emit_canonical_encodings.pl
+++ b/misc-scripts/canonical_transcripts/emit_canonical_encodings.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/canonical_transcripts/reason_changes.pl
+++ b/misc-scripts/canonical_transcripts/reason_changes.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [2020-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
+++ b/misc-scripts/canonical_transcripts/select_canonical_transcripts.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Cmd.pm
+++ b/misc-scripts/cloud/EnsCloud/Cmd.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Cmd/Command/SpeciesToVolumes.pm
+++ b/misc-scripts/cloud/EnsCloud/Cmd/Command/SpeciesToVolumes.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Cmd/Command/list.pm
+++ b/misc-scripts/cloud/EnsCloud/Cmd/Command/list.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Describer.pm
+++ b/misc-scripts/cloud/EnsCloud/Describer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Image.pm
+++ b/misc-scripts/cloud/EnsCloud/Image.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Image/VolumeBundle.pm
+++ b/misc-scripts/cloud/EnsCloud/Image/VolumeBundle.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Image/VolumeBundle/Volume.pm
+++ b/misc-scripts/cloud/EnsCloud/Image/VolumeBundle/Volume.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/EnsCloud/Image/VolumeBundle/Volume/DatabaseDetails.pm
+++ b/misc-scripts/cloud/EnsCloud/Image/VolumeBundle/Volume/DatabaseDetails.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/cloud/ecloud
+++ b/misc-scripts/cloud/ecloud
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/core_tutorial_test/test_code_from_html.pl
+++ b/misc-scripts/core_tutorial_test/test_code_from_html.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/cleanup_tmp_tables.pl
+++ b/misc-scripts/db/cleanup_tmp_tables.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/convert_tables_MyISAM_InnoDB.pl
+++ b/misc-scripts/db/convert_tables_MyISAM_InnoDB.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/cp_mysqldb
+++ b/misc-scripts/db/cp_mysqldb
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/db-space.pl
+++ b/misc-scripts/db/db-space.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/dump_mysql.pl
+++ b/misc-scripts/db/dump_mysql.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/fingerprint_db.pl
+++ b/misc-scripts/db/fingerprint_db.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/kill_process_by_db.pl
+++ b/misc-scripts/db/kill_process_by_db.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/multidb_sql.pl
+++ b/misc-scripts/db/multidb_sql.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/mv_mysqldb
+++ b/misc-scripts/db/mv_mysqldb
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/remove_mysqldb.pl
+++ b/misc-scripts/db/remove_mysqldb.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/db/search_dbs.pl
+++ b/misc-scripts/db/search_dbs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/doxygen_filter/EnsEMBL/Filter.pm
+++ b/misc-scripts/doxygen_filter/EnsEMBL/Filter.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/doxygen_filter/EnsEMBL/PerlFilter.pm
+++ b/misc-scripts/doxygen_filter/EnsEMBL/PerlFilter.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/doxygen_filter/ensembldoxygenfilter.pl
+++ b/misc-scripts/doxygen_filter/ensembldoxygenfilter.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/email_blatter.sh
+++ b/misc-scripts/email_blatter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/frameshift_transcript_attribs.pl
+++ b/misc-scripts/frameshift_transcript_attribs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/generate_stable_ids.pl
+++ b/misc-scripts/generate_stable_ids.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/gifts_import/populate_protein_feature.pl
+++ b/misc-scripts/gifts_import/populate_protein_feature.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/dump_by_seq_region.pl
+++ b/misc-scripts/id_mapping/dump_by_seq_region.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/dump_cache.pl
+++ b/misc-scripts/id_mapping/dump_cache.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/fake_stable_id_mapping.pl
+++ b/misc-scripts/id_mapping/fake_stable_id_mapping.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/id_mapping.pl
+++ b/misc-scripts/id_mapping/id_mapping.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/myRun.ksh
+++ b/misc-scripts/id_mapping/myRun.ksh
@@ -1,6 +1,6 @@
 #!/bin/ksh
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/run.pl
+++ b/misc-scripts/id_mapping/run.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/synteny_rescore.pl
+++ b/misc-scripts/id_mapping/synteny_rescore.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/batch_id_history.pl
+++ b/misc-scripts/id_mapping/utils/batch_id_history.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/compare_results.pl
+++ b/misc-scripts/id_mapping/utils/compare_results.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/compare_scores.pl
+++ b/misc-scripts/id_mapping/utils/compare_scores.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/dump_scores.pl
+++ b/misc-scripts/id_mapping/utils/dump_scores.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/id_mapping_clean.sql
+++ b/misc-scripts/id_mapping/utils/id_mapping_clean.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/manage_id_mapping_tables.pl
+++ b/misc-scripts/id_mapping/utils/manage_id_mapping_tables.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/id_mapping/utils/myManager.ksh
+++ b/misc-scripts/id_mapping/utils/myManager.ksh
@@ -1,6 +1,6 @@
 #!/bin/ksh
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/import/import_bed_simple_feature.pl
+++ b/misc-scripts/import/import_bed_simple_feature.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/import/import_recombinant_hotspots.pl
+++ b/misc-scripts/import/import_recombinant_hotspots.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/import/karyotype_rank_assigner.pl
+++ b/misc-scripts/import/karyotype_rank_assigner.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/import/sort_feature_table.pl
+++ b/misc-scripts/import/sort_feature_table.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/load_databases/load_database_from_ftp_site.pl
+++ b/misc-scripts/load_databases/load_database_from_ftp_site.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/load_databases/load_multiple_databases.pl
+++ b/misc-scripts/load_databases/load_multiple_databases.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/meta_coord/update_meta_coord.pl
+++ b/misc-scripts/meta_coord/update_meta_coord.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/meta_levels.pl
+++ b/misc-scripts/meta_levels.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 #
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/mouse_knockouts/IKMC_get_data.pl
+++ b/misc-scripts/mouse_knockouts/IKMC_get_data.pl
@@ -1,6 +1,6 @@
 #!/ebi/extserv/bin/perl/bin/perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/mouse_knockouts/add_ikmc_as_simple_features.pl
+++ b/misc-scripts/mouse_knockouts/add_ikmc_as_simple_features.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/ping_ensembl.pl
+++ b/misc-scripts/ping_ensembl.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/repeats/repeat-libraries.pl
+++ b/misc-scripts/repeats/repeat-libraries.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/repeats/repeat-types.pl
+++ b/misc-scripts/repeats/repeat-types.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/repeats/shrink_trfs.pl
+++ b/misc-scripts/repeats/shrink_trfs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/repeats/vega_repeat_libraries.pl
+++ b/misc-scripts/repeats/vega_repeat_libraries.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/schema_patcher.pl
+++ b/misc-scripts/schema_patcher.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/stable_id_lookup/populate_stable_id_lookup.pl
+++ b/misc-scripts/stable_id_lookup/populate_stable_id_lookup.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/stable_id_lookup/sql/tables.sql
+++ b/misc-scripts/stable_id_lookup/sql/tables.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SchemaConverter.pm
+++ b/misc-scripts/surgery/SchemaConverter.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/AnophelesGambiae.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/AnophelesGambiae.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/ApisMellifera.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/ApisMellifera.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/BasicConverter.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/BasicConverter.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/CaenorhabditisBriggsae.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/CaenorhabditisBriggsae.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/CaenorhabditisElegans.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/CaenorhabditisElegans.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/CanisFamiliaris.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/CanisFamiliaris.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/DanioRerio.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/DanioRerio.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/DrosophilaMelanogaster.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/DrosophilaMelanogaster.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/FuguRubripes.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/FuguRubripes.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/GallusGallus.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/GallusGallus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/HomoSapiens.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/HomoSapiens.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/MusMusculus.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/MusMusculus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/PanTroglodytes.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/PanTroglodytes.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/RattusNorvegicus.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/RattusNorvegicus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/vega/CanisFamiliaris.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/vega/CanisFamiliaris.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/vega/DanioRerio.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/vega/DanioRerio.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/vega/HomoSapiens.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/vega/HomoSapiens.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/vega/MusMusculus.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/vega/MusMusculus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/SeqStoreConverter/vega/VBasicConverter.pm
+++ b/misc-scripts/surgery/SeqStoreConverter/vega/VBasicConverter.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/convert_seqstore.pl
+++ b/misc-scripts/surgery/convert_seqstore.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/create_fixsql.pl
+++ b/misc-scripts/surgery/create_fixsql.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/fuller_test_genome_9_chr20.pl
+++ b/misc-scripts/surgery/fuller_test_genome_9_chr20.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/push_align_features.pl
+++ b/misc-scripts/surgery/push_align_features.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/set_nonredundant_attribs.pl
+++ b/misc-scripts/surgery/set_nonredundant_attribs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/surgery/shortintrons2frameshifts.pl
+++ b/misc-scripts/surgery/shortintrons2frameshifts.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/transfer_karyotype.pl
+++ b/misc-scripts/transfer_karyotype.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 #
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/update_mapping_set.pl
+++ b/misc-scripts/update_mapping_set.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 #
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/web_stats.sh
+++ b/misc-scripts/web_stats.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/DB.pm
+++ b/misc-scripts/xref_mapping/Xref/DB.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/AltAllele.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/AltAllele.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/ChecksumXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/ChecksumXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/CoordinateXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/CoordinateXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/DependentSource.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/DependentSource.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/DependentXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/DependentXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/DisplayXrefPriority.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/DisplayXrefPriority.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/GeneDescPriority.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/GeneDescPriority.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/GeneDirectXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/GeneDirectXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/GeneStableId.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/GeneStableId.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/GeneTranscriptTranslation.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/GeneTranscriptTranslation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/IdentityXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/IdentityXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Mapping.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Mapping.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/MappingJob.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/MappingJob.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Meta.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Meta.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/ObjectXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/ObjectXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Pair.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Pair.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/PrimaryXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/PrimaryXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/ProcessStatus.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/ProcessStatus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Source.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Source.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/SourceMappingMethod.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/SourceMappingMethod.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/SourceUrl.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/SourceUrl.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Species.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Species.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Synonym.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Synonym.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/TranscriptDirectXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/TranscriptDirectXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/TranscriptStableId.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/TranscriptStableId.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/TranslationDirectXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/TranslationDirectXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/TranslationStableId.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/TranslationStableId.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/Result/Xref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/Result/Xref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/ResultSet/DependentXref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/ResultSet/DependentXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/ResultSet/Synonym.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/ResultSet/Synonym.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Schema/ResultSet/Xref.pm
+++ b/misc-scripts/xref_mapping/Xref/Schema/ResultSet/Xref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/Xref/Test/TestDB.pm
+++ b/misc-scripts/xref_mapping/Xref/Test/TestDB.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/BasicMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/BasicMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/ChecksumMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/ChecksumMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/CoordinateMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/CoreInfo.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/CoreInfo.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/DirectXrefs.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/DirectXrefs.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/DisplayXrefs.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/LoadMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/LoadMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ChecksumBasic.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ChecksumBasic.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBasic.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBasic.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBest1.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateBest1.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest1.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest1.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest1_55_perc_id.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest1_55_perc_id.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest5.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest5.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest5_55_perc_id.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest5_55_perc_id.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest5_subtran.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest5_subtran.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest_100_perc_id.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest_100_perc_id.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest_90_perc_id.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateGappedBest_90_perc_id.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateUngappedBest1.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/ExonerateUngappedBest1.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/LocalExonerateGappedBest1.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/LocalExonerateGappedBest1.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/MySQLChecksum.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/MySQLChecksum.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/Methods/PBSExonerateGappedBest1.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/Methods/PBSExonerateGappedBest1.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/OfficialNaming.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/ProcessMappings.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/ProcessMappings.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/ProcessPaired.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/ProcessPaired.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/ProcessPrioritys.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/ProcessPrioritys.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/RNACentralMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/RNACentralMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/SubmitMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/TestMappings.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/TestMappings.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/UniParcMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/UniParcMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/VBCoordinateMapper.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/VBCoordinateMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/XrefLoader.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/XrefLoader.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/aedes_aegypti.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/aedes_aegypti.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/anopheles_gambiae.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/anopheles_gambiae.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/culex_quinquefasciatus.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/culex_quinquefasciatus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/danio_rerio.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/danio_rerio.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/db.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/db.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/drosophila.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/drosophila.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/eukaryota.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/eukaryota.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/homo_sapiens.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/homo_sapiens.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/ixodes_scapularis.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/ixodes_scapularis.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/mus_musculus.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/mus_musculus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/neurospora_crassa.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/neurospora_crassa.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/parasite.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/parasite.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/rattus_norvegicus.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/rattus_norvegicus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/saccharomyces_cerevisiae.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/saccharomyces_cerevisiae.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/sars_cov_2.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/sars_cov_2.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/schizosaccharomyces_pombe.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/schizosaccharomyces_pombe.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/sus_scrofa.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/sus_scrofa.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefMapper/wormbase.pm
+++ b/misc-scripts/xref_mapping/XrefMapper/wormbase.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/ArrayExpressParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ArrayExpressParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/BaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/CCDSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/CCDSParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ChecksumParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/CodelinkParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/CodelinkParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/CoordinateParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/CoordinateParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/CoreXrefParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/CoreXrefParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DBASSParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/Database.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Database.pm
@@ -1,8 +1,8 @@
 
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/DirectParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/DirectParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/EG_DBParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/EG_DBParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/EntrezGeneParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/FetchFiles.pm
+++ b/misc-scripts/xref_mapping/XrefParser/FetchFiles.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/FlybaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/FlybaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/GramenePathwayParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/GramenePathwayParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HGNCParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/HPAParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/HPAParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/JGI_ProteinParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/JGI_ProteinParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/MGIParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGIParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/MGI_CCDS_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_CCDS_Parser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MGI_Desc_Parser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/MIMParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/Mim2GeneParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/PGSCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/PGSCParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/PHIbaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/PHIbaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/PhytozomeGmaxParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/PhytozomeGmaxParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/PomBaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/PomBaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RFAMParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RGDParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ReactomeParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqCoordinateParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqDatabaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqGPFFParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqGPFFParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/RefSeqParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/RefSeqParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/SGDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/SGDParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/TAIRIDParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/TAIRIDParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/TAIROntologyParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/TAIROntologyParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UCSCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSCParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UCSC_human_parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSC_human_parser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_parser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UCSC_mouse_parser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtDatabaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtDatabaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/UniProtVarSplicParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/UniProtVarSplicParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/VGNCParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/WilsonAffyParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WilsonAffyParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/WormBaseCuratedSynonymsParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WormBaseCuratedSynonymsParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansBase.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansBase.pm
@@ -1,6 +1,7 @@
 =head1 LICENSE
 
-Copyright [2018-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansRefSeqGPFFParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansRefSeqGPFFParser.pm
@@ -1,6 +1,7 @@
 =head1 LICENSE
 
-Copyright [2018-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansUniProtParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WormbaseCElegansUniProtParser.pm
@@ -1,6 +1,7 @@
 =head1 LICENSE
 
-Copyright [2018-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/WormbaseDirectParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/WormbaseDirectParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/XenopusJamboreeParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINDescParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/ZFINParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/ZFINParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/XrefParser/miRBaseParser.pm
+++ b/misc-scripts/xref_mapping/XrefParser/miRBaseParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/sql/table.sql
+++ b/misc-scripts/xref_mapping/sql/table.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/store_ccds_xrefs.pl
+++ b/misc-scripts/xref_mapping/store_ccds_xrefs.pl
@@ -7,7 +7,8 @@
 
 =head1 LICENSE
 
-Copyright [2020-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/dbass.t
+++ b/misc-scripts/xref_mapping/t/dbass.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/entrezgene.t
+++ b/misc-scripts/xref_mapping/t/entrezgene.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/hgnc.t
+++ b/misc-scripts/xref_mapping/t/hgnc.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/hpa.t
+++ b/misc-scripts/xref_mapping/t/hpa.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/jgi_proteinparser.t
+++ b/misc-scripts/xref_mapping/t/jgi_proteinparser.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/mgi.t
+++ b/misc-scripts/xref_mapping/t/mgi.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/mgi_desc.t
+++ b/misc-scripts/xref_mapping/t/mgi_desc.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/mim2gene.t
+++ b/misc-scripts/xref_mapping/t/mim2gene.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/omim.t
+++ b/misc-scripts/xref_mapping/t/omim.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/rgd.t
+++ b/misc-scripts/xref_mapping/t/rgd.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/testdb.t
+++ b/misc-scripts/xref_mapping/t/testdb.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/ucsc.t
+++ b/misc-scripts/xref_mapping/t/ucsc.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/vgnc.t
+++ b/misc-scripts/xref_mapping/t/vgnc.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/xenopus.t
+++ b/misc-scripts/xref_mapping/t/xenopus.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/t/zfin_desc.t
+++ b/misc-scripts/xref_mapping/t/zfin_desc.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/xref_config2sql.pl
+++ b/misc-scripts/xref_mapping/xref_config2sql.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/xref_mindmap/generate_xref_mindmap.pl
+++ b/misc-scripts/xref_mapping/xref_mindmap/generate_xref_mindmap.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/xref_mindmap/sql/tables.sql
+++ b/misc-scripts/xref_mapping/xref_mindmap/sql/tables.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/xref_mindmap/sql/update.sql
+++ b/misc-scripts/xref_mapping/xref_mindmap/sql/update.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/misc-scripts/xref_mapping/xref_parser.pl
+++ b/misc-scripts/xref_mapping/xref_parser.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/AltAlleleGroup.pm
+++ b/modules/Bio/EnsEMBL/AltAlleleGroup.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Analysis.pm
+++ b/modules/Bio/EnsEMBL/Analysis.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Analysis/PairAlign.pm
+++ b/modules/Bio/EnsEMBL/Analysis/PairAlign.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Analysis/Programs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Programs.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/ApiVersion.pm
+++ b/modules/Bio/EnsEMBL/ApiVersion.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/ArchiveStableId.pm
+++ b/modules/Bio/EnsEMBL/ArchiveStableId.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/AssemblyExceptionFeature.pm
+++ b/modules/Bio/EnsEMBL/AssemblyExceptionFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/AssemblyMapper.pm
+++ b/modules/Bio/EnsEMBL/AssemblyMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Attribute.pm
+++ b/modules/Bio/EnsEMBL/Attribute.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/BaseAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/BaseAlignFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Biotype.pm
+++ b/modules/Bio/EnsEMBL/Biotype.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/CDS.pm
+++ b/modules/Bio/EnsEMBL/CDS.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/ChainedAssemblyMapper.pm
+++ b/modules/Bio/EnsEMBL/ChainedAssemblyMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/CircularSlice.pm
+++ b/modules/Bio/EnsEMBL/CircularSlice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/CoordSystem.pm
+++ b/modules/Bio/EnsEMBL/CoordSystem.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DB/ExternalFeatureFactoryI.pm
+++ b/modules/Bio/EnsEMBL/DB/ExternalFeatureFactoryI.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBEntry.pm
+++ b/modules/Bio/EnsEMBL/DBEntry.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBLoader.pm
+++ b/modules/Bio/EnsEMBL/DBLoader.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/AltAlleleGroupAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AltAlleleGroupAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AnalysisAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ArchiveStableIdAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/AssemblyExceptionFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AssemblyExceptionFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/AssemblyMapperAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AssemblyMapperAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/AssemblySliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AssemblySliceAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/AttributeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/AttributeAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/BaseAlignFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseAlignFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/BaseMetaContainer.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseMetaContainer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/BaseSequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BaseSequenceAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/BiotypeAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/CoordSystemAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/CoordSystemAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBConnection.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DataFileAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DataFileAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DensityFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DensityFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DensityTypeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DensityTypeAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/DnaAlignFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DnaAlignFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/Oracle.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/Oracle.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/Pg.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/Pg.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/SQLite.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/SQLite.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/Sybase.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/Sybase.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/TestDummy.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/TestDummy.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/mysql.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/mysql.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Driver/odbc.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Driver/odbc.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/ExonAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ExonAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/FastaSequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/FastaSequenceAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/GenomeContainer.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GenomeContainer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/IntronSupportingEvidenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/IntronSupportingEvidenceAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/KaryotypeBandAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/KaryotypeBandAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/MergedAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/MergedAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/MetaContainer.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/MetaContainer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/MetaCoordContainer.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/MetaCoordContainer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/MiscFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/MiscFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/MiscSetAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/MiscSetAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/OntologyDBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/OntologyDBAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/OntologyTermAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/OntologyTermAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/OperonAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/OperonAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/OperonTranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/OperonTranscriptAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/PredictionExonAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/PredictionExonAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/PredictionTranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/PredictionTranscriptAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/ProteinAlignFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ProteinAlignFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/ProteinFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ProteinFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/ProxyDBConnection.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/ProxyDBConnection.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/RNAProductAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/RNAProductAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/RepeatConsensusAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/RepeatConsensusAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/RepeatFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/RepeatFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/SeqRegionSynonymAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SeqRegionSynonymAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/SequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SequenceAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/SimpleFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SimpleFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SliceAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/StatementHandle.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Support/BaseCache.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Support/BaseCache.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Support/FullIdCache.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Support/FullIdCache.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/Support/LruIdCache.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/Support/LruIdCache.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/SupportingFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SupportingFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptSupportingFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptSupportingFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DBSQL/UnmappedObjectAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/UnmappedObjectAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DataFile.pm
+++ b/modules/Bio/EnsEMBL/DataFile.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DensityFeature.pm
+++ b/modules/Bio/EnsEMBL/DensityFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DensityFeatureSet.pm
+++ b/modules/Bio/EnsEMBL/DensityFeatureSet.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DensityPlot/BinValue.pm
+++ b/modules/Bio/EnsEMBL/DensityPlot/BinValue.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DensityPlot/BinValueSet.pm
+++ b/modules/Bio/EnsEMBL/DensityPlot/BinValueSet.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DensityType.pm
+++ b/modules/Bio/EnsEMBL/DensityType.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaDnaAlignFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/DnaPepAlignFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Exon.pm
+++ b/modules/Bio/EnsEMBL/Exon.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/ExonTranscript.pm
+++ b/modules/Bio/EnsEMBL/ExonTranscript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/External/ExternalFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/External/ExternalFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Feature.pm
+++ b/modules/Bio/EnsEMBL/Feature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/FeaturePair.pm
+++ b/modules/Bio/EnsEMBL/FeaturePair.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Gene.pm
+++ b/modules/Bio/EnsEMBL/Gene.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Genome.pm
+++ b/modules/Bio/EnsEMBL/Genome.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/Archiver.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/Archiver.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/BaseObject.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/BaseObject.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/Cache.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/Cache.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/Entry.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/Entry.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ExonScoreBuilder.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/GeneScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/GeneScoreBuilder.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/BaseMapper.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/BaseMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/EnsemblExonGeneric.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/EnsemblExonGeneric.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/EnsemblGeneGeneric.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/EnsemblGeneGeneric.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/EnsemblTranscriptGeneric.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/InternalIdMapper/EnsemblTranscriptGeneric.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/MappingList.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/MappingList.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/ResultAnalyser.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ResultAnalyser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/ScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ScoreBuilder.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/ScoredMappingMatrix.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/ScoredMappingMatrix.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/Serialisable.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/Serialisable.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/AedesAegypti.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/AedesAegypti.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/AnophelesGambiae.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/AnophelesGambiae.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/EnsemblGeneric.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/EnsemblGeneric.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/PristionchusPacificus.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/StableIdGenerator/PristionchusPacificus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/StableIdMapper.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/StableIdMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/SyntenyFramework.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/SyntenyFramework.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/SyntenyRegion.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/SyntenyRegion.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/TinyExon.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/TinyExon.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/TinyFeature.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/TinyFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/TinyGene.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/TinyGene.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/TinyTranscript.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/TinyTranscript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/TinyTranslation.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/TinyTranslation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdMapping/TranscriptScoreBuilder.pm
+++ b/modules/Bio/EnsEMBL/IdMapping/TranscriptScoreBuilder.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IdentityXref.pm
+++ b/modules/Bio/EnsEMBL/IdentityXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Intron.pm
+++ b/modules/Bio/EnsEMBL/Intron.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/IntronSupportingEvidence.pm
+++ b/modules/Bio/EnsEMBL/IntronSupportingEvidence.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/KaryotypeBand.pm
+++ b/modules/Bio/EnsEMBL/KaryotypeBand.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/LRGSlice.pm
+++ b/modules/Bio/EnsEMBL/LRGSlice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MANE.pm
+++ b/modules/Bio/EnsEMBL/MANE.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/DBSQL/DitagAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Map/DBSQL/DitagAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/DBSQL/DitagFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Map/DBSQL/DitagFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/DBSQL/MarkerAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Map/DBSQL/MarkerAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/DBSQL/MarkerFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Map/DBSQL/MarkerFeatureAdaptor.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/Ditag.pm
+++ b/modules/Bio/EnsEMBL/Map/Ditag.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/DitagFeature.pm
+++ b/modules/Bio/EnsEMBL/Map/DitagFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/MapLocation.pm
+++ b/modules/Bio/EnsEMBL/Map/MapLocation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/Marker.pm
+++ b/modules/Bio/EnsEMBL/Map/Marker.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/MarkerFeature.pm
+++ b/modules/Bio/EnsEMBL/Map/MarkerFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Map/MarkerSynonym.pm
+++ b/modules/Bio/EnsEMBL/Map/MarkerSynonym.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MappedSlice.pm
+++ b/modules/Bio/EnsEMBL/MappedSlice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MappedSliceContainer.pm
+++ b/modules/Bio/EnsEMBL/MappedSliceContainer.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper.pm
+++ b/modules/Bio/EnsEMBL/Mapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/Coordinate.pm
+++ b/modules/Bio/EnsEMBL/Mapper/Coordinate.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/Gap.pm
+++ b/modules/Bio/EnsEMBL/Mapper/Gap.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/IndelCoordinate.pm
+++ b/modules/Bio/EnsEMBL/Mapper/IndelCoordinate.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/IndelPair.pm
+++ b/modules/Bio/EnsEMBL/Mapper/IndelPair.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/Pair.pm
+++ b/modules/Bio/EnsEMBL/Mapper/Pair.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/RangeRegistry.pm
+++ b/modules/Bio/EnsEMBL/Mapper/RangeRegistry.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Mapper/Unit.pm
+++ b/modules/Bio/EnsEMBL/Mapper/Unit.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MicroRNA.pm
+++ b/modules/Bio/EnsEMBL/MicroRNA.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MiscFeature.pm
+++ b/modules/Bio/EnsEMBL/MiscFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/MiscSet.pm
+++ b/modules/Bio/EnsEMBL/MiscSet.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/OntologyTerm.pm
+++ b/modules/Bio/EnsEMBL/OntologyTerm.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/OntologyXref.pm
+++ b/modules/Bio/EnsEMBL/OntologyXref.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Operon.pm
+++ b/modules/Bio/EnsEMBL/Operon.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/OperonTranscript.pm
+++ b/modules/Bio/EnsEMBL/OperonTranscript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/PaddedSlice.pm
+++ b/modules/Bio/EnsEMBL/PaddedSlice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/PepDnaAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/PepDnaAlignFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/PredictionExon.pm
+++ b/modules/Bio/EnsEMBL/PredictionExon.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/PredictionTranscript.pm
+++ b/modules/Bio/EnsEMBL/PredictionTranscript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/ProjectionSegment.pm
+++ b/modules/Bio/EnsEMBL/ProjectionSegment.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/ProteinFeature.pm
+++ b/modules/Bio/EnsEMBL/ProteinFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/RNAProduct.pm
+++ b/modules/Bio/EnsEMBL/RNAProduct.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Registry.pm
+++ b/modules/Bio/EnsEMBL/Registry.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/RepeatConsensus.pm
+++ b/modules/Bio/EnsEMBL/RepeatConsensus.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/RepeatFeature.pm
+++ b/modules/Bio/EnsEMBL/RepeatFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/RepeatMaskedSlice.pm
+++ b/modules/Bio/EnsEMBL/RepeatMaskedSlice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/SeqEdit.pm
+++ b/modules/Bio/EnsEMBL/SeqEdit.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/SeqFeature.pm
+++ b/modules/Bio/EnsEMBL/SeqFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/SeqRegionSynonym.pm
+++ b/modules/Bio/EnsEMBL/SeqRegionSynonym.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/SimpleFeature.pm
+++ b/modules/Bio/EnsEMBL/SimpleFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Slice.pm
+++ b/modules/Bio/EnsEMBL/Slice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/StableIdEvent.pm
+++ b/modules/Bio/EnsEMBL/StableIdEvent.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/StableIdHistoryTree.pm
+++ b/modules/Bio/EnsEMBL/StableIdHistoryTree.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/StopCodonReadthroughEdit.pm
+++ b/modules/Bio/EnsEMBL/StopCodonReadthroughEdit.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Storable.pm
+++ b/modules/Bio/EnsEMBL/Storable.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/SubSlicedFeature.pm
+++ b/modules/Bio/EnsEMBL/SubSlicedFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/TopLevelAssemblyMapper.pm
+++ b/modules/Bio/EnsEMBL/TopLevelAssemblyMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/TranscriptFactory.pm
+++ b/modules/Bio/EnsEMBL/TranscriptFactory.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/TranscriptMapper.pm
+++ b/modules/Bio/EnsEMBL/TranscriptMapper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Translation.pm
+++ b/modules/Bio/EnsEMBL/Translation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/UTR.pm
+++ b/modules/Bio/EnsEMBL/UTR.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/UnmappedObject.pm
+++ b/modules/Bio/EnsEMBL/UnmappedObject.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Upstream.pm
+++ b/modules/Bio/EnsEMBL/Upstream.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Argument.pm
+++ b/modules/Bio/EnsEMBL/Utils/Argument.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/AssemblyProjector.pm
+++ b/modules/Bio/EnsEMBL/Utils/AssemblyProjector.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/BitString.pm
+++ b/modules/Bio/EnsEMBL/Utils/BitString.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Cache.pm
+++ b/modules/Bio/EnsEMBL/Utils/Cache.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/CigarString.pm
+++ b/modules/Bio/EnsEMBL/Utils/CigarString.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/CliHelper.pm
+++ b/modules/Bio/EnsEMBL/Utils/CliHelper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/ConfParser.pm
+++ b/modules/Bio/EnsEMBL/Utils/ConfParser.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/ConfigRegistry.pm
+++ b/modules/Bio/EnsEMBL/Utils/ConfigRegistry.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/ConversionSupport.pm
+++ b/modules/Bio/EnsEMBL/Utils/ConversionSupport.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_analysis.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_analysis.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_exon.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_exon.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_featurePair.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_featurePair.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_gene.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_gene.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_hit.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_hit.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_hsp.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_hsp.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_predictionExon.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_predictionExon.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_predictionGene.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_predictionGene.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_seqFeature.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_seqFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_transcript.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/bio_ens_transcript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/ens_bio.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/ens_bio.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/ens_bio_featurePair.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/ens_bio_featurePair.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Converter/ens_bio_seqFeature.pm
+++ b/modules/Bio/EnsEMBL/Utils/Converter/ens_bio_seqFeature.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/EasyArgv.pm
+++ b/modules/Bio/EnsEMBL/Utils/EasyArgv.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Eprof.pm
+++ b/modules/Bio/EnsEMBL/Utils/Eprof.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/EprofStack.pm
+++ b/modules/Bio/EnsEMBL/Utils/EprofStack.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Exception.pm
+++ b/modules/Bio/EnsEMBL/Utils/Exception.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/IO.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Interval.pm
+++ b/modules/Bio/EnsEMBL/Utils/Interval.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Iterator.pm
+++ b/modules/Bio/EnsEMBL/Utils/Iterator.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Logger.pm
+++ b/modules/Bio/EnsEMBL/Utils/Logger.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Net.pm
+++ b/modules/Bio/EnsEMBL/Utils/Net.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/PolyA.pm
+++ b/modules/Bio/EnsEMBL/Utils/PolyA.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Proxy.pm
+++ b/modules/Bio/EnsEMBL/Utils/Proxy.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/RNAProductTypeMapper.pm
+++ b/modules/Bio/EnsEMBL/Utils/RNAProductTypeMapper.pm
@@ -1,8 +1,8 @@
 
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Scalar.pm
+++ b/modules/Bio/EnsEMBL/Utils/Scalar.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/SchemaConversion.pm
+++ b/modules/Bio/EnsEMBL/Utils/SchemaConversion.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/ScriptUtils.pm
+++ b/modules/Bio/EnsEMBL/Utils/ScriptUtils.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/SeqRegionCache.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqRegionCache.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Utils/Sequence.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Slice.pm
+++ b/modules/Bio/EnsEMBL/Utils/Slice.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/SqlHelper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SqlHelper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/TranscriptSelector.pm
+++ b/modules/Bio/EnsEMBL/Utils/TranscriptSelector.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Immutable.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Immutable.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Immutable/Node.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Immutable/Node.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable/Node.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable/Node.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable/PP.pm
+++ b/modules/Bio/EnsEMBL/Utils/Tree/Interval/Mutable/PP.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/URI.pm
+++ b/modules/Bio/EnsEMBL/Utils/URI.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/VegaCuration/Gene.pm
+++ b/modules/Bio/EnsEMBL/Utils/VegaCuration/Gene.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/VegaCuration/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Utils/VegaCuration/Transcript.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Utils/VegaCuration/Translation.pm
+++ b/modules/Bio/EnsEMBL/Utils/VegaCuration/Translation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/t/.cvsignore
+++ b/modules/t/.cvsignore
@@ -1,3 +1,0 @@
-MultiTestDB.conf
-CLEAN.t
-*.MultiTestDB.frozen.conf

--- a/modules/t/MultiTestDB.t
+++ b/modules/t/MultiTestDB.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/altAlleleGroup.t
+++ b/modules/t/altAlleleGroup.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/analysis.t
+++ b/modules/t/analysis.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/archiveStableId.t
+++ b/modules/t/archiveStableId.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/argument.t
+++ b/modules/t/argument.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/assemblyException.t
+++ b/modules/t/assemblyException.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/assemblyExceptionFeature.t
+++ b/modules/t/assemblyExceptionFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/assemblyMapper.t
+++ b/modules/t/assemblyMapper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/associated_xref.t
+++ b/modules/t/associated_xref.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/attribute.t
+++ b/modules/t/attribute.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/attributeAdaptor.t
+++ b/modules/t/attributeAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/baseAdaptor.t
+++ b/modules/t/baseAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/baseAlignFeature.t
+++ b/modules/t/baseAlignFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/biotype.t
+++ b/modules/t/biotype.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/canonicalDBAdaptor.t
+++ b/modules/t/canonicalDBAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/cds.t
+++ b/modules/t/cds.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/chainedAssemblyMapper.t
+++ b/modules/t/chainedAssemblyMapper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/circularSlice.t
+++ b/modules/t/circularSlice.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/cliHelper.t
+++ b/modules/t/cliHelper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/compara.t
+++ b/modules/t/compara.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/coordSystem.t
+++ b/modules/t/coordSystem.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/coordSystemAdaptor.t
+++ b/modules/t/coordSystemAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dataFile.t
+++ b/modules/t/dataFile.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dbConnection.t
+++ b/modules/t/dbConnection.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dbEntries.t
+++ b/modules/t/dbEntries.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/densityFeature.t
+++ b/modules/t/densityFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/densityFeatureAdaptor.t
+++ b/modules/t/densityFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/densityType.t
+++ b/modules/t/densityType.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/densityTypeAdaptor.t
+++ b/modules/t/densityTypeAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dependencies.t
+++ b/modules/t/dependencies.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/ditag.t
+++ b/modules/t/ditag.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/ditagAdaptor.t
+++ b/modules/t/ditagAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/ditagFeature.t
+++ b/modules/t/ditagFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/ditagFeatureAdaptor.t
+++ b/modules/t/ditagFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dnaAlignFeatureAdaptor.t
+++ b/modules/t/dnaAlignFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dnaDnaAlignFeature.t
+++ b/modules/t/dnaDnaAlignFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/dnaPepAlignFeature.t
+++ b/modules/t/dnaPepAlignFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/easyargv.t
+++ b/modules/t/easyargv.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/exception.t
+++ b/modules/t/exception.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/exon.t
+++ b/modules/t/exon.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/exonTranscript.pm
+++ b/modules/t/exonTranscript.pm
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/externalFeatureAdaptor.t
+++ b/modules/t/externalFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/fastaSequenceAdaptor.t
+++ b/modules/t/fastaSequenceAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/feature.t
+++ b/modules/t/feature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/featurePair.t
+++ b/modules/t/featurePair.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/fullIdCaching.t
+++ b/modules/t/fullIdCaching.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/geneview.t
+++ b/modules/t/geneview.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/genomeContainer.t
+++ b/modules/t/genomeContainer.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/getNearestFeature.t
+++ b/modules/t/getNearestFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/housekeeping_apache2.t
+++ b/modules/t/housekeeping_apache2.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/housekeeping_apache2.t
+++ b/modules/t/housekeeping_apache2.t
@@ -39,6 +39,13 @@ my $cur_dir = cwd();
 chdir($original_dir);
 my $root = File::Spec->catdir($cur_dir, File::Spec->updir(),File::Spec->updir());
 
+my $notice_file = File::Spec->catfile($root, "NOTICE");
+my $skip_copyright = undef;
+if (-e $notice_file) {
+    is_notice_file_good($notice_file);
+    $skip_copyright = 1;
+}
+
 my @source_files = map {all_source_code(File::Spec->catfile($root, $_))} qw(modules scripts sql docs);
 #Find all files & run
 foreach my $f (@source_files) {
@@ -49,7 +56,7 @@ foreach my $f (@source_files) {
     next if $f =~ /\.conf\b/;
     next if $f =~ /\/CLEAN\b/;
     next if $f =~ /\.(tmpl|hash|nw|ctl|txt|html|textile)$/;
-    has_apache2_licence($f);
+    has_apache2_licence($f, $skip_copyright);
 }
 
 done_testing();

--- a/modules/t/housekeeping_perlCritic.t
+++ b/modules/t/housekeeping_perlCritic.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/interval_tree_immutable.t
+++ b/modules/t/interval_tree_immutable.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/interval_tree_mutable.t
+++ b/modules/t/interval_tree_mutable.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/intron.t
+++ b/modules/t/intron.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/intronSupportingEvidence.t
+++ b/modules/t/intronSupportingEvidence.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/iterator.t
+++ b/modules/t/iterator.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/karyotypeBand.t
+++ b/modules/t/karyotypeBand.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/karyotypeBandAdaptor.t
+++ b/modules/t/karyotypeBandAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/lruIdCaching.t
+++ b/modules/t/lruIdCaching.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/mane.t
+++ b/modules/t/mane.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/mapLocation.t
+++ b/modules/t/mapLocation.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/mappedSliceContainer.t
+++ b/modules/t/mappedSliceContainer.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/mapper.t
+++ b/modules/t/mapper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/marker.t
+++ b/modules/t/marker.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/markerAdaptor.t
+++ b/modules/t/markerAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/markerFeature.t
+++ b/modules/t/markerFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/markerFeatureAdaptor.t
+++ b/modules/t/markerFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/markerSynonym.t
+++ b/modules/t/markerSynonym.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/metaContainer.t
+++ b/modules/t/metaContainer.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/metaCoordContainer.t
+++ b/modules/t/metaCoordContainer.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/miscFeature.t
+++ b/modules/t/miscFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/miscFeatureAdaptor.t
+++ b/modules/t/miscFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/miscSet.t
+++ b/modules/t/miscSet.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/miscSetAdaptor.t
+++ b/modules/t/miscSetAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/objectLoad.t
+++ b/modules/t/objectLoad.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/ontologyTerm.t
+++ b/modules/t/ontologyTerm.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/operon.t
+++ b/modules/t/operon.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/operon_fetch.t
+++ b/modules/t/operon_fetch.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/operon_transcript.t
+++ b/modules/t/operon_transcript.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/paddedSlice.t
+++ b/modules/t/paddedSlice.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/predictionTranscript.t
+++ b/modules/t/predictionTranscript.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/proteinAlignFeatureAdaptor.t
+++ b/modules/t/proteinAlignFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/proteinFeature.t
+++ b/modules/t/proteinFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/proteinFeatureAdaptor.t
+++ b/modules/t/proteinFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/rangeRegistry.t
+++ b/modules/t/rangeRegistry.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/registry.t
+++ b/modules/t/registry.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/registry_public_cores.t
+++ b/modules/t/registry_public_cores.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/regression_baseFeatureAdaptorMultiQuery.t
+++ b/modules/t/regression_baseFeatureAdaptorMultiQuery.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/regression_featureAdaptorCache.t
+++ b/modules/t/regression_featureAdaptorCache.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/regression_multiMappingContig.t
+++ b/modules/t/regression_multiMappingContig.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/regression_transcriptProjectionAttributeDuplication.t
+++ b/modules/t/regression_transcriptProjectionAttributeDuplication.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/repeatConsensus.t
+++ b/modules/t/repeatConsensus.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/repeatConsensusAdaptor.t
+++ b/modules/t/repeatConsensusAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/repeatFeature.t
+++ b/modules/t/repeatFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/repeatFeatureAdaptor.t
+++ b/modules/t/repeatFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/repeatMaskedSlice.t
+++ b/modules/t/repeatMaskedSlice.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/rnaProduct.t
+++ b/modules/t/rnaProduct.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/schema.t
+++ b/modules/t/schema.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/schemaPatches.t
+++ b/modules/t/schemaPatches.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/seqDumper.t
+++ b/modules/t/seqDumper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/seqEdit.t
+++ b/modules/t/seqEdit.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/sequenceAdaptor.t
+++ b/modules/t/sequenceAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/simpleFeature.t
+++ b/modules/t/simpleFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/slice.t
+++ b/modules/t/slice.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/sliceAdaptor.t
+++ b/modules/t/sliceAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/sliceVariation.t
+++ b/modules/t/sliceVariation.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/sqlHelper.t
+++ b/modules/t/sqlHelper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/strainSlice.t
+++ b/modules/t/strainSlice.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/subSliceFeature.t
+++ b/modules/t/subSliceFeature.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/switchableAdaptors.t
+++ b/modules/t/switchableAdaptors.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/topLevelAssemblyMapper.t
+++ b/modules/t/topLevelAssemblyMapper.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/transcriptSelector.t
+++ b/modules/t/transcriptSelector.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/transcriptSupportingFeatureAdaptor.t
+++ b/modules/t/transcriptSupportingFeatureAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/translation.t
+++ b/modules/t/translation.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/unmappedObject.t
+++ b/modules/t/unmappedObject.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/unmappedObjectAdaptor.t
+++ b/modules/t/unmappedObjectAdaptor.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/utilsIo.t
+++ b/modules/t/utilsIo.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/utilsNet.t
+++ b/modules/t/utilsNet.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/utilsScalar.t
+++ b/modules/t/utilsScalar.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/utilsUri.t
+++ b/modules/t/utilsUri.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/utr.t
+++ b/modules/t/utr.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/t/xref_parser.t
+++ b/modules/t/xref_parser.t
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/t/xrefs.t
+++ b/modules/t/xrefs.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sql/foreign_keys.sql
+++ b/sql/foreign_keys.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_100_101_a.sql
+++ b/sql/patch_100_101_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_101_102_a.sql
+++ b/sql/patch_101_102_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_102_103_a.sql
+++ b/sql/patch_102_103_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_103_104_a.sql
+++ b/sql/patch_103_104_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_104_105_a.sql
+++ b/sql/patch_104_105_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_105_106_a.sql
+++ b/sql/patch_105_106_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_106_107_a.sql
+++ b/sql/patch_106_107_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_106_107_b.sql
+++ b/sql/patch_106_107_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_107_108_a.sql
+++ b/sql/patch_107_108_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_108_109_a.sql
+++ b/sql/patch_108_109_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_108_109_b.sql
+++ b/sql/patch_108_109_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_109_110_a.sql
+++ b/sql/patch_109_110_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_109_110_b.sql
+++ b/sql/patch_109_110_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_109_110_c.sql
+++ b/sql/patch_109_110_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_110_111_a.sql
+++ b/sql/patch_110_111_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_111_112_a.sql
+++ b/sql/patch_111_112_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_111_112_b.sql
+++ b/sql/patch_111_112_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_111_112_c.sql
+++ b/sql/patch_111_112_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_112_113_a.sql
+++ b/sql/patch_112_113_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_112_113_b.sql
+++ b/sql/patch_112_113_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_113_114_a.sql
+++ b/sql/patch_113_114_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_21_22.sql
+++ b/sql/patch_21_22.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_23_24.sql
+++ b/sql/patch_23_24.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_24_25.sql
+++ b/sql/patch_24_25.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_25_26.sql
+++ b/sql/patch_25_26.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_26_27.sql
+++ b/sql/patch_26_27.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_27_28.sql
+++ b/sql/patch_27_28.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_28_29.sql
+++ b/sql/patch_28_29.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_29_30.sql
+++ b/sql/patch_29_30.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_30_31.sql
+++ b/sql/patch_30_31.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_31_32.sql
+++ b/sql/patch_31_32.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_32_33.sql
+++ b/sql/patch_32_33.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_33_34.sql
+++ b/sql/patch_33_34.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_34_35.sql
+++ b/sql/patch_34_35.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_35_36.sql
+++ b/sql/patch_35_36.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_36_37.sql
+++ b/sql/patch_36_37.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_37_38.sql
+++ b/sql/patch_37_38.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_38_39_a.sql
+++ b/sql/patch_38_39_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_38_39_b.sql
+++ b/sql/patch_38_39_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_38_39_c.sql
+++ b/sql/patch_38_39_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_38_39_d.sql
+++ b/sql/patch_38_39_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_38_39_e.sql
+++ b/sql/patch_38_39_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_a.sql
+++ b/sql/patch_39_40_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_b.sql
+++ b/sql/patch_39_40_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_c.sql
+++ b/sql/patch_39_40_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_d.sql
+++ b/sql/patch_39_40_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_e.sql
+++ b/sql/patch_39_40_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_f.sql
+++ b/sql/patch_39_40_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_g.sql
+++ b/sql/patch_39_40_g.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_h.sql
+++ b/sql/patch_39_40_h.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_i.sql
+++ b/sql/patch_39_40_i.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_39_40_j.sql
+++ b/sql/patch_39_40_j.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_40_41_a.sql
+++ b/sql/patch_40_41_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_40_41_b.sql
+++ b/sql/patch_40_41_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_40_41_c.sql
+++ b/sql/patch_40_41_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_40_41_d.sql
+++ b/sql/patch_40_41_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_40_41_e.sql
+++ b/sql/patch_40_41_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_40_41_f.sql
+++ b/sql/patch_40_41_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_a.sql
+++ b/sql/patch_41_42_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_b.sql
+++ b/sql/patch_41_42_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_c.sql
+++ b/sql/patch_41_42_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_d.sql
+++ b/sql/patch_41_42_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_e.sql
+++ b/sql/patch_41_42_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_f.sql
+++ b/sql/patch_41_42_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_41_42_g.sql
+++ b/sql/patch_41_42_g.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_42_43_a.sql
+++ b/sql/patch_42_43_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_42_43_b.sql
+++ b/sql/patch_42_43_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_42_43_c.sql
+++ b/sql/patch_42_43_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_42_43_d.sql
+++ b/sql/patch_42_43_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_42_43_e.sql
+++ b/sql/patch_42_43_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_42_43_f.sql
+++ b/sql/patch_42_43_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_43_44_a.sql
+++ b/sql/patch_43_44_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_43_44_b.sql
+++ b/sql/patch_43_44_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_43_44_c.sql
+++ b/sql/patch_43_44_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_43_44_d.sql
+++ b/sql/patch_43_44_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_43_44_e.sql
+++ b/sql/patch_43_44_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_43_44_f.sql
+++ b/sql/patch_43_44_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_44_45_a.sql
+++ b/sql/patch_44_45_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_44_45_b.sql
+++ b/sql/patch_44_45_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_44_45_c.sql
+++ b/sql/patch_44_45_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_a.sql
+++ b/sql/patch_45_46_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_b.sql
+++ b/sql/patch_45_46_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_c.sql
+++ b/sql/patch_45_46_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_d.sql
+++ b/sql/patch_45_46_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_e.sql
+++ b/sql/patch_45_46_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_f.sql
+++ b/sql/patch_45_46_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_45_46_g.sql
+++ b/sql/patch_45_46_g.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_46_47_a.sql
+++ b/sql/patch_46_47_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_46_47_b.sql
+++ b/sql/patch_46_47_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_46_47_c.sql
+++ b/sql/patch_46_47_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_47_48_a.sql
+++ b/sql/patch_47_48_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_48_49_a.sql
+++ b/sql/patch_48_49_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_48_49_b.sql
+++ b/sql/patch_48_49_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_48_49_c.sql
+++ b/sql/patch_48_49_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_48_49_d.sql
+++ b/sql/patch_48_49_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_48_49_e.sql
+++ b/sql/patch_48_49_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_49_50_a.sql
+++ b/sql/patch_49_50_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_49_50_b.sql
+++ b/sql/patch_49_50_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_49_50_c.sql
+++ b/sql/patch_49_50_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_49_50_d.sql
+++ b/sql/patch_49_50_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_49_50_e.sql
+++ b/sql/patch_49_50_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_a.sql
+++ b/sql/patch_50_51_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_b.sql
+++ b/sql/patch_50_51_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_c.sql
+++ b/sql/patch_50_51_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_d.sql
+++ b/sql/patch_50_51_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_e.sql
+++ b/sql/patch_50_51_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_f.sql
+++ b/sql/patch_50_51_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_g.sql
+++ b/sql/patch_50_51_g.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_h.sql
+++ b/sql/patch_50_51_h.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_50_51_i.sql
+++ b/sql/patch_50_51_i.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_51_52_a.sql
+++ b/sql/patch_51_52_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_51_52_b.sql
+++ b/sql/patch_51_52_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_51_52_c.sql
+++ b/sql/patch_51_52_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_51_52_d.sql
+++ b/sql/patch_51_52_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_52_53_a.sql
+++ b/sql/patch_52_53_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_52_53_b.sql
+++ b/sql/patch_52_53_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_52_53_c.sql
+++ b/sql/patch_52_53_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_52_53_d.sql
+++ b/sql/patch_52_53_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_53_54_a.sql
+++ b/sql/patch_53_54_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_53_54_b.sql
+++ b/sql/patch_53_54_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_53_54_c.sql
+++ b/sql/patch_53_54_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_a.sql
+++ b/sql/patch_54_55_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_b.sql
+++ b/sql/patch_54_55_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_c.sql
+++ b/sql/patch_54_55_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_d.sql
+++ b/sql/patch_54_55_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_e.sql
+++ b/sql/patch_54_55_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_f.sql
+++ b/sql/patch_54_55_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_g.sql
+++ b/sql/patch_54_55_g.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_54_55_h.sql
+++ b/sql/patch_54_55_h.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_55_56_a.sql
+++ b/sql/patch_55_56_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_55_56_b.sql
+++ b/sql/patch_55_56_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_55_56_c.sql
+++ b/sql/patch_55_56_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_55_56_d.sql
+++ b/sql/patch_55_56_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_56_57_a.sql
+++ b/sql/patch_56_57_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_56_57_b.sql
+++ b/sql/patch_56_57_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_56_57_c.sql
+++ b/sql/patch_56_57_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_56_57_d.sql
+++ b/sql/patch_56_57_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_56_57_e.sql
+++ b/sql/patch_56_57_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_56_57_f.sql
+++ b/sql/patch_56_57_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_57_58_a.sql
+++ b/sql/patch_57_58_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_58_59_a.sql
+++ b/sql/patch_58_59_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_58_59_b.sql
+++ b/sql/patch_58_59_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_58_59_c.sql
+++ b/sql/patch_58_59_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_58_59_d.sql
+++ b/sql/patch_58_59_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_58_59_e.sql
+++ b/sql/patch_58_59_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_59_60_a.sql
+++ b/sql/patch_59_60_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_59_60_b.sql
+++ b/sql/patch_59_60_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_59_60_c.sql
+++ b/sql/patch_59_60_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_60_61_a.sql
+++ b/sql/patch_60_61_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_60_61_b.sql
+++ b/sql/patch_60_61_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_60_61_c.sql
+++ b/sql/patch_60_61_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_61_62_a.sql
+++ b/sql/patch_61_62_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_61_62_b.sql
+++ b/sql/patch_61_62_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_61_62_c.sql
+++ b/sql/patch_61_62_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_61_62_d.sql
+++ b/sql/patch_61_62_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_61_62_e.sql
+++ b/sql/patch_61_62_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_62_63_a.sql
+++ b/sql/patch_62_63_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_62_63_b.sql
+++ b/sql/patch_62_63_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_62_63_c.sql
+++ b/sql/patch_62_63_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_63_64_a.sql
+++ b/sql/patch_63_64_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_63_64_b.sql
+++ b/sql/patch_63_64_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_63_64_c.sql
+++ b/sql/patch_63_64_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_63_64_d.sql
+++ b/sql/patch_63_64_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_64_65_a.sql
+++ b/sql/patch_64_65_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_64_65_b.sql
+++ b/sql/patch_64_65_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_64_65_c.sql
+++ b/sql/patch_64_65_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_64_65_d.sql
+++ b/sql/patch_64_65_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_65_66_a.sql
+++ b/sql/patch_65_66_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_65_66_b.sql
+++ b/sql/patch_65_66_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_65_66_c.sql
+++ b/sql/patch_65_66_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_65_66_d.sql
+++ b/sql/patch_65_66_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_65_66_e.sql
+++ b/sql/patch_65_66_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_65_66_f.sql
+++ b/sql/patch_65_66_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_66_67_a.sql
+++ b/sql/patch_66_67_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_66_67_b.sql
+++ b/sql/patch_66_67_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_66_67_c.sql
+++ b/sql/patch_66_67_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_66_67_d.sql
+++ b/sql/patch_66_67_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_66_67_e.sql
+++ b/sql/patch_66_67_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_67_68_a.sql
+++ b/sql/patch_67_68_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_67_68_b.sql
+++ b/sql/patch_67_68_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_67_68_c.sql
+++ b/sql/patch_67_68_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_67_68_d.sql
+++ b/sql/patch_67_68_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_67_68_e.sql
+++ b/sql/patch_67_68_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_68_69_a.sql
+++ b/sql/patch_68_69_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_69_70_a.sql
+++ b/sql/patch_69_70_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_69_70_b.sql
+++ b/sql/patch_69_70_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_69_70_c.sql
+++ b/sql/patch_69_70_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_69_70_d.sql
+++ b/sql/patch_69_70_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_69_70_e.sql
+++ b/sql/patch_69_70_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_70_71_a.sql
+++ b/sql/patch_70_71_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_70_71_b.sql
+++ b/sql/patch_70_71_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_71_72_a.sql
+++ b/sql/patch_71_72_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_71_72_b.sql
+++ b/sql/patch_71_72_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_72_73_a.sql
+++ b/sql/patch_72_73_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_72_73_b.sql
+++ b/sql/patch_72_73_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_72_73_c.sql
+++ b/sql/patch_72_73_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_a.sql
+++ b/sql/patch_73_74_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_b.sql
+++ b/sql/patch_73_74_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_c.sql
+++ b/sql/patch_73_74_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_d.sql
+++ b/sql/patch_73_74_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_e.sql
+++ b/sql/patch_73_74_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_f.sql
+++ b/sql/patch_73_74_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_g.sql
+++ b/sql/patch_73_74_g.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_73_74_h.sql
+++ b/sql/patch_73_74_h.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_74_75_a.sql
+++ b/sql/patch_74_75_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_74_75_b.sql
+++ b/sql/patch_74_75_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_74_75_c.sql
+++ b/sql/patch_74_75_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_74_75_d.sql
+++ b/sql/patch_74_75_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_74_75_e.sql
+++ b/sql/patch_74_75_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_74_75_f.sql
+++ b/sql/patch_74_75_f.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_75_76_a.sql
+++ b/sql/patch_75_76_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_75_76_b.sql
+++ b/sql/patch_75_76_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_75_76_c.sql
+++ b/sql/patch_75_76_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_76_77_a.sql
+++ b/sql/patch_76_77_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_77_78_a.sql
+++ b/sql/patch_77_78_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_77_78_b.sql
+++ b/sql/patch_77_78_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_77_78_c.sql
+++ b/sql/patch_77_78_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_78_79_a.sql
+++ b/sql/patch_78_79_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_78_79_b.sql
+++ b/sql/patch_78_79_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_79_80_a.sql
+++ b/sql/patch_79_80_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_79_80_b.sql
+++ b/sql/patch_79_80_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_79_80_c.sql
+++ b/sql/patch_79_80_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_79_80_d.sql
+++ b/sql/patch_79_80_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_80_81_a.sql
+++ b/sql/patch_80_81_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_80_81_b.sql
+++ b/sql/patch_80_81_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_81_82_a.sql
+++ b/sql/patch_81_82_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_81_82_b.sql
+++ b/sql/patch_81_82_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_81_82_c.sql
+++ b/sql/patch_81_82_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_82_83_a.sql
+++ b/sql/patch_82_83_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_83_84_a.sql
+++ b/sql/patch_83_84_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_83_84_b.sql
+++ b/sql/patch_83_84_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_83_84_c.sql
+++ b/sql/patch_83_84_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_83_84_d.sql
+++ b/sql/patch_83_84_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_83_84_e.sql
+++ b/sql/patch_83_84_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_84_85_a.sql
+++ b/sql/patch_84_85_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_84_85_b.sql
+++ b/sql/patch_84_85_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_85_86_a.sql
+++ b/sql/patch_85_86_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_85_86_b.sql
+++ b/sql/patch_85_86_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_85_86_c.sql
+++ b/sql/patch_85_86_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_86_87_a.sql
+++ b/sql/patch_86_87_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_86_87_b.sql
+++ b/sql/patch_86_87_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_86_87_c.sql
+++ b/sql/patch_86_87_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_87_88_a.sql
+++ b/sql/patch_87_88_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_87_88_b.sql
+++ b/sql/patch_87_88_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_87_88_c.sql
+++ b/sql/patch_87_88_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_88_89_a.sql
+++ b/sql/patch_88_89_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_89_90_a.sql
+++ b/sql/patch_89_90_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_89_90_b.sql
+++ b/sql/patch_89_90_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_89_90_c.sql
+++ b/sql/patch_89_90_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_90_91_a.sql
+++ b/sql/patch_90_91_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_90_91_b.sql
+++ b/sql/patch_90_91_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_90_91_c.sql
+++ b/sql/patch_90_91_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_90_91_d.sql
+++ b/sql/patch_90_91_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_91_92_a.sql
+++ b/sql/patch_91_92_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_91_92_b.sql
+++ b/sql/patch_91_92_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_92_93_a.sql
+++ b/sql/patch_92_93_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_92_93_b.sql
+++ b/sql/patch_92_93_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_92_93_c.sql
+++ b/sql/patch_92_93_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_93_94_a.sql
+++ b/sql/patch_93_94_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_93_94_b.sql
+++ b/sql/patch_93_94_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_93_94_c.sql
+++ b/sql/patch_93_94_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_94_95_a.sql
+++ b/sql/patch_94_95_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_94_95_b.sql
+++ b/sql/patch_94_95_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_95_96_a.sql
+++ b/sql/patch_95_96_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_96_97_a.sql
+++ b/sql/patch_96_97_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_96_97_b.sql
+++ b/sql/patch_96_97_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_96_97_c.sql
+++ b/sql/patch_96_97_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_96_97_d.sql
+++ b/sql/patch_96_97_d.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_96_97_e.sql
+++ b/sql/patch_96_97_e.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_97_98_a.sql
+++ b/sql/patch_97_98_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_98_99_a.sql
+++ b/sql/patch_98_99_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_99_100_a.sql
+++ b/sql/patch_99_100_a.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_99_100_b.sql
+++ b/sql/patch_99_100_b.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/patch_99_100_c.sql
+++ b/sql/patch_99_100_c.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/sql/populate_meta_coord.pl
+++ b/sql/populate_meta_coord.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1,5 +1,5 @@
--- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
--- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Centralising the copyright string with the year into the NOTICE file, and fixing the existing LICENSE file, to avoid massive update of the year across the repo.

## Use case

Every year the copyright must be updated. Because the copyright info - for historical reason - is contained in many files, the procedure is risky and annoying.
By centralising the year bit into a single NOTICE file, the entire updating procedure becomes trivial.

## Benefits

Centralising the copyright string with the year into the NOTICE file, and fixing the existing LICENSE file, to avoid massive update of the year across the repo.
The copyright update will be easier to do and check.

## Possible Drawbacks

None

## Testing

Tests modified to check for the new copyright header.
Test suite runs fine.

