### PR TITLE
Add CDS version to ensembl flat

### DIFF
--- a/modules/Bio/EnsEMBL/CDS.pm
+++ b/modules/Bio/EnsEMBL/CDS.pm
@@ -266,6 +266,7 @@ sub summary_as_hash {
   $hash->{'source'} = $self->transcript->source() if $self->transcript();
   $hash->{'id'} = $self->translation_id() if $self->translation_id();
   $hash->{'protein_id'} = $self->translation_id() if $self->translation_id();
+  $hash->{'version'} = $self->translation()->version() if $self->translation();
   return $hash;
 }
 


### PR DESCRIPTION
## Description

The spec for the GFF files says there is a “version” tag on the CDS for the protein version, but it is not added to  GFF files.
(e.g. here is a line from GRCh38.111.gff3 with protein_id but no version:1 havana CDS 65565 65573 . + 0 ID=CDS:ENSP00000493376;Parent=transcript:ENST00000641515;protein_id=ENSP00000493376).
 On the browser, this protein ID is ENSP00000493376.2 in 111 (http://jan2024.archive.ensembl.org/Homo_sapiens/Transcript/ProteinSummary?db=core;g=ENSG00000186092;r=1:65419-71585;t=ENST00000641515) and 112 (https://may2024.archive.ensembl.org/Homo_sapiens/Transcript/ProteinSummary?db=core;g=ENSG00000186092;r=1:65419-71585;t=ENST00000641515)

The README file mentions version: (https://ftp.ensembl.org/pub/release-112/gff3/homo_sapiens/README)CDS

ID: Unique identifier, format “CDS:<protein_stable_id>”
Parent: Transcript identifier, format “transcript:<transcript_stable_id>”
protein_id: Ensembl protein stable ID
version: Ensembl protein version

## Benefits

- Having CDS version to gff3 and other formats 

## Possible Drawbacks

None

## Testing

No changes. Test suite could run successfully

