### PR TITLE
TranscriptSelector optimisation for genes with only one transcript

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/TranscriptSelector.pm
+++ b/modules/Bio/EnsEMBL/Utils/TranscriptSelector.pm
@@ -108,6 +108,12 @@ sub select_canonical_transcript_for_Gene {
         return;
     }
     my @encoded; # array of encoded transcripts
+
+    # if we have a single transcript return it by default
+    if (scalar (@transcripts) == 1) {
+        print 'Choosing the only existing transcript: ' . $transcripts[0]->stable_id . "\n" if ($self->{'verbose'});
+        return $transcripts[0];
+    }
     
     foreach my $transcript (@transcripts) {
         my $encoded_transcript = $self->encode_transcript($transcript); 


### PR DESCRIPTION
## Description

TranscriptSelector optimisation for genes with only one transcript.

## Use case

Speed up of the `misc-scripts/canonical_transcripts/select_canonical_transcripts.pl`

## Benefits

Speed up  of the `misc-scripts/canonical_transcripts/select_canonical_transcripts.pl`

## Possible Drawbacks

None

## Testing

No specific tests were added.

@vsitnik tested by running `misc-scripts/canonical_transcripts/select_canonical_transcripts.pl`

Test suite could successfully ran locally.
