### PR TITLE
Fix/gene object equality

### DIFF
--- a/modules/Bio/EnsEMBL/Gene.pm
+++ b/modules/Bio/EnsEMBL/Gene.pm
@@ -371,7 +371,7 @@ sub equals {
     return 0;
   }
 
-  if ( $self->get_Biotype->name ne $self->get_Biotype->name ) {
+  if ( $self->get_Biotype->name ne $gene->get_Biotype->name ) {
     return 0;
   }
 

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -1131,4 +1131,38 @@ SKIP: {
   is($_->display_xref()->dbname(), 'HUGO', $_->stable_id().' has a display HUGO') for @{$genes};
 }
 
+# Testing gene object equality - stable ids
+{
+  my $gene1 = $ga->fetch_by_stable_id('ENSG00000171456.1');
+  my $gene2 = $ga->fetch_by_stable_id('ENSG00000171456.1');
+  ok($gene1->equals($gene2), 'Gene objects with same stable id are equal');
+  
+  my $gene3 = $ga->fetch_by_stable_id('ENSG00000171455');
+  ok(!$gene1->equals($gene3), 'Gene objects with different stable ids are not equal');
+}
+
+# Testing gene object equality - biotype
+{
+  my $gene1 = Bio::EnsEMBL::Gene->new(
+    -START  => 100,
+    -END    => 200,
+    -STRAND => 1,
+    -SLICE  => $slice,
+    -STABLE_ID => 'TEST_GENE',
+    -BIOTYPE => 'protein_coding'
+  );
+  
+  my $gene2 = Bio::EnsEMBL::Gene->new(
+    -START  => 100,
+    -END    => 200,
+    -STRAND => 1,
+    -SLICE  => $slice,
+    -STABLE_ID => 'TEST_GENE',
+    -BIOTYPE => 'lncRNA'
+  );
+
+  ok(!$gene1->equals($gene2), 'Gene objects with different biotypes are not equal');
+  $gene2->biotype('protein_coding');
+  ok($gene1->equals($gene2), 'Gene objects with same biotype are equal');
+}
 done_testing();


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
This PR fixes the `equals` subroutine in the `Gene` module. Previously the biotype check evaluated the biotype of `$self` vs `$self` meaning this check always passed even if the biotype of `$self` and the target gene (`$gene`) differed. This PR alters one line of the module and adds tests to confirm the correct behaviour. 

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

## Benefits

_If applicable, describe the advantages the changes will have._
Accurate evaluation of Gene object equality. 

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
None

## Testing

_Have you added/modified unit tests to test the changes?_
Yes
_If so, do the tests pass/fail?_
Tests now pass 

_Have you run the entire test suite and no regression was detected?_
I have only run the `gene.t` tests. 
