### PR TITLE
[116] Add support for HAVANA readthrough transcript attribute

### DIFF
--- a/modules/Bio/EnsEMBL/Transcript.pm
+++ b/modules/Bio/EnsEMBL/Transcript.pm
@@ -3151,6 +3151,7 @@ sub summary_as_hash {
   push @tags, 'Ensembl_canonical' if $self->is_canonical();
   push @tags, $self->get_all_Attributes('gencode_primary')->[0]->code if $self->gencode_primary();
   push @tags, $self->get_all_Attributes('ens_canon_extended')->[0]->code if $self->ens_canon_extended();
+  push @tags, $self->get_all_Attributes('readthrough_tra')->[0]->code if $self->readthrough_transcript();
 
   my $mane = $self->mane_transcript();
   if ($mane) {
@@ -3210,6 +3211,21 @@ sub ens_canon_extended {
   my $canon_extended = 0;
   $canon_extended = 1 if scalar(@attributes) > 0;
   return $canon_extended;
+}
+
+=head2 readthrough_transcript
+
+  Example       : $readthrough_transcript = $transcript->readthrough_transcript();
+  Description   : Returns true if readthrough_transcript is set
+  Returns       : boolean
+=cut
+
+sub readthrough_transcript {
+  my $self = shift;
+  my @attributes = @{ $self->get_all_Attributes('readthrough_tra') };
+  my $readthrough_tra = 0;
+  $readthrough_tra = 1 if scalar(@attributes) > 0;
+  return $readthrough_tra;
 }
 
 =head2 tsl

--- a/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
@@ -24,6 +24,7 @@
 24	appris	APPRIS	\N
 124	mRNA_start_NF	mRNA start not found	\N
 126	cds_start_NF	CDS start not found	\N
+218 readthrough_tra readthrough transcript  Havana readthrough transcripts \N
 417	gencode_basic	GENCODE basic annotation	GENCODE Basic is a view provided by UCSC for users. It includes a subset of the GENCODE transcripts. In general, for protein coding genes it will show only the full length models (unless a protein coding gene has no full-length models, in which case other rules apply). For noncoding genes, it will also only show the full-length (mRNA start and end found) models (unless there are no full-length models, in which case other rules apply).
 428	TSL	Transcript Support Level	\N
 535	MANE_Select	MANE Select v0.92	MANE Select (v0.92) is the preliminary release (phase 7) of the MANE Select data set. The Matched Annotation from NCBI and EMBL-EBI project (MANE) is a collaboration between Ensembl-GENCODE and RefSeq to select a default transcript per human protein coding locus that is representative of biology, well-supported, expressed and conserved. This transcript set matches GRCh38 and is 100% identical between RefSeq and Ensembl-GENCODE for 5' UTR, CDS, splicing and 3' UTR.

--- a/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/attrib_type.txt
@@ -24,7 +24,7 @@
 24	appris	APPRIS	\N
 124	mRNA_start_NF	mRNA start not found	\N
 126	cds_start_NF	CDS start not found	\N
-218 readthrough_tra readthrough transcript  Havana readthrough transcripts \N
+218	readthrough_tra	readthrough transcript	Havana readthrough transcripts
 417	gencode_basic	GENCODE basic annotation	GENCODE Basic is a view provided by UCSC for users. It includes a subset of the GENCODE transcripts. In general, for protein coding genes it will show only the full length models (unless a protein coding gene has no full-length models, in which case other rules apply). For noncoding genes, it will also only show the full-length (mRNA start and end found) models (unless there are no full-length models, in which case other rules apply).
 428	TSL	Transcript Support Level	\N
 535	MANE_Select	MANE Select v0.92	MANE Select (v0.92) is the preliminary release (phase 7) of the MANE Select data set. The Matched Annotation from NCBI and EMBL-EBI project (MANE) is a collaboration between Ensembl-GENCODE and RefSeq to select a default transcript per human protein coding locus that is representative of biology, well-supported, expressed and conserved. This transcript set matches GRCh38 and is 100% identical between RefSeq and Ensembl-GENCODE for 5' UTR, CDS, splicing and 3' UTR.

--- a/modules/t/test-genome-DBs/homo_sapiens/core/transcript_attrib.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/transcript_attrib.txt
@@ -4,6 +4,7 @@
 21726	417	GENCODE basic
 21726	576	GENCODE primary
 21726	584	Ensembl Canonical Extended
+21726   218 readthrough transcript
 548627	1	AC002531.1-005
 548627	124	1
 548627	126	1

--- a/modules/t/test-genome-DBs/homo_sapiens/core/transcript_attrib.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/transcript_attrib.txt
@@ -4,7 +4,7 @@
 21726	417	GENCODE basic
 21726	576	GENCODE primary
 21726	584	Ensembl Canonical Extended
-21726   218 readthrough transcript
+21726	218	readthrough transcript
 548627	1	AC002531.1-005
 548627	124	1
 548627	126	1

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -338,6 +338,10 @@ is($ens_canon_ext, '1', 'Presence of the Ensembl canonical extended transcript a
 my $gencode_basic = $tr->gencode_basic();
 is($gencode_basic, '1', 'Presence of the GENCODE Basic transcript attribute is correctly set to true');
 
+# test that transcript has the HAVANA readthrough transcript attribute
+my $readthrough_transcript = $tr->readthrough_transcript();
+is($readthrough_transcript, '1', 'Presence of the HAVANA readthrough transcript attribute is correctly set to true')
+
 my $interpro = $ta->get_Interpro_by_transid("ENST00000252021");
 foreach my $i (@$interpro) {
   note($i);

--- a/modules/t/transcript.t
+++ b/modules/t/transcript.t
@@ -340,7 +340,7 @@ is($gencode_basic, '1', 'Presence of the GENCODE Basic transcript attribute is c
 
 # test that transcript has the HAVANA readthrough transcript attribute
 my $readthrough_transcript = $tr->readthrough_transcript();
-is($readthrough_transcript, '1', 'Presence of the HAVANA readthrough transcript attribute is correctly set to true')
+is($readthrough_transcript, '1', 'Presence of the HAVANA readthrough transcript attribute is correctly set to true');
 
 my $interpro = $ta->get_Interpro_by_transid("ENST00000252021");
 foreach my $i (@$interpro) {


### PR DESCRIPTION
## Description

Add support for HAVANA readthrough transcript attribute. Associated tests included. Follows same method as used for `GENCODE Primary` and `Ensembl canonical extended` transcript attributes.

Requested for pre-release file dumps (GTF + GFF3), which Automation will be working on soon.

Jira ticket: [ENSPROD-11603](https://embl.atlassian.net/browse/ENSPROD-11603)

I'll create a duplicate PR against `main` branch once all finalised in this PR.

## Use case

Variation have requested this transcript attribute be included in file dumps.

## Benefits

Additional information available to users.

## Possible Drawbacks

n/a

## Testing

_Have you added/modified unit tests to test the changes?_

Yes.

_If so, do the tests pass/fail?_

Test suite is passing.

_Have you run the entire test suite and no regression was detected?_

All passes.
