### PR TITLE
reading sequences from indexed fasta instead of dna sql table POC

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/SequenceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/SequenceAdaptor.pm
@@ -49,7 +49,9 @@ package Bio::EnsEMBL::DBSQL::SequenceAdaptor;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Exception qw(throw);
+use Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor;
+use Bio::EnsEMBL::Utils::Exception qw(info throw);
+use Bio::EnsEMBL::Utils::IO::FileFaidx;
 use Bio::EnsEMBL::Utils::Sequence  qw(reverse_comp);
 use Bio::EnsEMBL::Utils::Scalar qw( assert_ref );
 use DBI qw/:sql_types/;
@@ -75,8 +77,70 @@ sub new {
   my $self = $class->SUPER::new($db);
   $self->_init_seq_instance($chunk_power, $cache_size);
   $self->_populate_seq_region_edits();
+  $self->{_use_faindex} = $self->try_to_use_index();
   return $self;
 }
+
+sub try_to_use_index {
+  my ($self) = @_;
+
+  # get metakey for the indexed fasta
+  my $meta_container = $self->db()->get_MetaContainer();
+  my ($fasta_file) = @{ $meta_container->list_value_by_key('sequence_level.fasta_file') };
+
+  return 0 if (!$fasta_file);
+
+  my $prefix = exists($ENV{ENSEMBL_SEQUENCE_FASTA_DIR}) ? $ENV{ENSEMBL_SEQUENCE_FASTA_DIR} : '';
+  $fasta_file = $prefix . '/' . $fasta_file if ($fasta_file !~ m,^/, && $prefix);
+
+  if (! -f $fasta_file) {
+    throw("No fasta file found at '${fasta_file}'");
+  }
+  info("using $fasta_file as dna sequences source");
+
+  my ($write, $persist_fh, $no_generation) = 0, 1, 1;
+  my $uppercase = 1; # see $self->_fetch_raw_seq
+  my $faindex = Bio::EnsEMBL::Utils::IO::FileFaidx->new(
+    $fasta_file, $write, $persist_fh, $no_generation, $uppercase
+  );
+
+  $self->{_fasta_sequence_adaptor} = Bio::EnsEMBL::DBSQL::FastaSequenceAdaptor->new($faindex);
+  $self->fill_index_id_name_map();
+
+  return 1;
+}
+
+sub _fetch_raw_seq_index {
+  my ($self, $id, $start, $length) = @_;
+  $id = $self->get_index_name_for_id($id);
+  my $seq_ref = $self->{_fasta_sequence_adaptor}->_fetch_raw_seq($id, $start, $length);
+  return $seq_ref;
+}
+
+sub fill_index_id_name_map {
+  my ($self) = @_;
+  $self->{_index_id_name_map} = {};
+
+  my $sth = $self->prepare(qq(
+    SELECT sr.seq_region_id, sr.name
+    FROM seq_region sr, coord_system cs
+    WHERE sr.coord_system_id = cs.coord_system_id
+      AND cs.attrib LIKE "%sequence_level%";
+  ));
+  $sth->execute();
+
+  while( (my $pair = $sth->fetchrow_arrayref()) ) {
+    $self->{_index_id_name_map}->{ $pair->[0] } = $pair->[1];
+  }
+
+}
+
+sub get_index_name_for_id {
+  my ($self, $id) = @_;
+  return $id if (!exists $self->{_index_id_name_map}->{$id});
+  return $self->{_index_id_name_map}->{$id};
+}
+
 
 =head2 fetch_by_Slice_start_end_strand
 
@@ -452,6 +516,11 @@ sub _rna_edit {
 
 sub _fetch_raw_seq {
   my ($self, $id, $start, $length) = @_;
+
+  if ($self->{_use_faindex}) {
+    return $self->_fetch_raw_seq_index($id, $start, $length);
+  }
+
   my $sql = <<'SQL';
 SELECT UPPER(SUBSTR(d.sequence, ?, ?))
 FROM dna d
@@ -484,6 +553,8 @@ SQL
 
 sub store {
   my ($self, $seq_region_id, $sequence) = @_;
+
+  throw("Unsupported operation. Cannot store sequence in a fasta file") if ($self->{_use_faindex});
 
   if(!$seq_region_id) {
     throw('seq_region_id is required');
@@ -518,6 +589,8 @@ sub store {
    
 sub remove {   
   my ($self, $seq_region_id) = @_;   
+
+  throw("Unsupported operation. Cannot store sequence in a fasta file") if ($self->{_use_faindex});
    
   if(!$seq_region_id) {    
     throw('seq_region_id is required');    


### PR DESCRIPTION
A POC to test if it's possible to read data from locally stored indexed fasta instead of the core_db "dna" table.
~3x speed up.

Tested on `premz_drosophila_suzukii_gcf043229965v1rs_core_63_115_1`:
0)
```
CMD=...
DB=premz_drosophila_suzukii_gcf043229965v1rs_core_63_115_1
```
1) get translations to compare to  (on unmodified code)
```
mkdir -p faa
time perl ../ensembl.prod.115/ensembl-production-imported/scripts/misc_scripts/get_trans.pl \
  $($CMD details script) -dbname $DB -type translation > faa/$DB.tr_orig.fa
# real    9m43.910s user    1m34.322s sys     0m4.856s  
```
2) get sequence data from core (initial fasta should be used instead)
```
time ${CMD} --max_allowed_packet=2048M -D $DB -Ne '
  select sr.name, sr.seq_region_id, dna.sequence
    from coord_system cs, seq_region sr, dna
   where cs.attrib like "%sequence_level%"
     and sr.seq_region_id = dna.seq_region_id
     and sr.coord_system_id = cs.coord_system_id
  ' > $DB.dna
```
3) generate fasta and index it
```
mkdir -p fasta
cat $DB.dna | awk -F "\t" '{print ">"$1; print $3}' > ./fasta/$DB.fa
samtools faidx ./fasta/$DB.fa
```
4) Add metakeys with the fasta path, ideally, we should have checksum stored (and checked) as well.
If not starts with `/` (like in this case), file path is prepended with the value of the `ENSEMBL_SEQUENCE_FASTA_DIR` env variable
```
${CMD}-w -D $DB -e 'delete from meta where meta_key = "sequence_level.fasta_file";'
${CMD}-w -D $DB -e '
  insert into meta (species_id, meta_key, meta_value)
  values ("1", "sequence_level.fasta_file", "'$DB'.fa");
  '
 ${CMD} -D $DB  -e 'select * from meta' | grep fasta
```
5) dump `dna` and truncate
```
mkdir -p bup
${CMD}  mysqldump --max_allowed_packet=2048M  $DB dna | gzip - > bup/$DB.dna.gz
${CMD}-w -D $DB  -e 'truncate dna'
${CMD}-w -D $DB  -e 'select count(*) from dna'
```
6) run
```
time \
  ENSEMBL_SEQUENCE_FASTA_DIR=$(pwd)/fasta \
  perl ../ensembl.prod.115/ensembl-production-imported/scripts/misc_scripts/get_trans.pl \
    $($CMD details script)  -dbname $DB  -type translation > $DB.tr_from_index.fa
```
stderr:
```
#-------------------- WARNING ----------------------
MSG: using ..../tr/fasta/premz_drosophila_suzukii_gcf043229965v1rs_core_63_115_1.fa as dna sequences source
FILE: EnsEMBL/DBSQL/SequenceAdaptor.pm LINE: 99
CALLED BY: EnsEMBL/DBSQL/SequenceAdaptor.pm  LINE: 80
Date (localtime)    = Thu Mar  5 21:45:42 2026
Ensembl API version = 115
---------------------------------------------------
```
time:
```
real    2m30.502s user    1m22.203s sys     0m4.248s
```
```
# on shm
mkdir -p /dev/shm/fasta
cp fasta/* /dev/shm/fasta
time \
  ENSEMBL_SEQUENCE_FASTA_DIR=/dev/shm/fasta \
  perl ../ensembl.prod.115/ensembl-production-imported/scripts/misc_scripts/get_trans.pl \
    $($CMD details script)  -dbname $DB  -type translation > /dev/shm/$DB.tr_from_index.fa
# ... MSG: using /dev/shm/fasta/premz_drosophila_suzukii_gcf043229965v1rs_core_63_115_1.fa as dna sequences source ...
# real    1m58.626s user    1m21.975s sys     0m3.851s

```
7) compare:
```
diff faa/$DB.tr_orig.fa $DB.tr_from_index.fa | wc -l 
0
diff faa/$DB.tr_orig.fa /dev/shm/$DB.tr_from_index.fa | wc -l
0
```

TODO:
I assume we don't need to load sequences at all. This would allow to disable chunking.
For multilevel we'll need to have contig sequences ("sequence_level" cs) in fasta files.
We need to keep track of integrity (I assume, we should have at least sha256 as another metakey).
Perhaps, we can use another type of ideces.
Putting on `/dev/shm` speeds up a bit as well.