### PR TITLE
DBEntryAdaptor._type_by_external_id changes in wildcard default logic

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
@@ -2019,15 +2019,21 @@ SQL
     }
   }
 
+  my @external_db_ids;
   if ( defined($external_db_name) ) {
-    # Involve the 'external_db' table to limit the hits to a particular
-    # external database.
+    # Preserve the prefix match on db_name, but keep external_db out of the lookup
+    # so the xref indices remain usable
 
-    $from_sql .= 'external_db xdb, ';
-    $where_sql .=
-        'xdb.db_name LIKE '
-      . $self->dbc()->db_handle()->quote( $external_db_name . '%' )
-      . ' AND xdb.external_db_id = x.external_db_id AND';
+    @external_db_ids = @{
+        $self->dbc()->sql_helper()->execute_simple(
+            -SQL    => 'SELECT external_db_id FROM external_db WHERE db_name LIKE ?',
+            -PARAMS => [ [ $external_db_name . '%', SQL_VARCHAR ] ],
+        )
+    };
+    return unless @external_db_ids;
+
+    my $external_db_placeholders = join ', ', '?' x @external_db_ids;
+    $where_sql .= "x.external_db_id IN ($external_db_placeholders) AND ";
   }
 
   my @queries;
@@ -2088,7 +2094,12 @@ SQL
   my %result;
   my $h = $self->dbc()->sql_helper();
   my @params = ([$name, SQL_VARCHAR], [$ensType, SQL_VARCHAR]);
+  # The optional species_id must be the first parameter
   unshift(@params, [$self->species_id(), SQL_INTEGER] ) if $multispecies;
+  # The optional external_db IDS must go before $name but after species_id if present
+  if (@external_db_ids) {
+      splice @params, ($multispecies ? 1 : 0), 0, map { [$_, SQL_INTEGER] } @external_db_ids;
+  }
   foreach my $query (@queries) {
     $h->execute_no_return(-SQL => $query, -PARAMS => \@params, -CALLBACK => sub {
       my ($row) = @_;

--- a/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
@@ -1920,8 +1920,10 @@ sub list_rnaproduct_ids_by_extids {
                NOTE:  In a multi-species database, this method will
                return all the entries matching the search criteria, not
                just the ones associated with the current species.
-               SQL wildcards can be used in the external id, 
-               but overly generic queries (two characters) will be prevented.
+               External identifiers are matched exactly by default.
+               SQL wildcards matching is only enabled when override is true,
+               and only when the first wildcard appear after at least three
+               literal characters.
   Description: Gets
   Returntype : list of dbIDs (gene_id, transcript_id, etc.)
   Exceptions : none
@@ -1935,28 +1937,18 @@ sub list_rnaproduct_ids_by_extids {
 sub _type_by_external_id {
   my ( $self, $name, $ensType, $extraType, $external_db_name, $override ) = @_;
 
+  # External identifiers are exact matches unless override explicitly enables
+  # SQL wildcard matching for %, _ and [.
   # $name has SQL wildcard support
   # = or LIKE put into SQL statement, and open queries like % or A% are rejected.
-  my $comparison_operator;
-  if ($name =~ /[_%\[]/ ) {
-    $comparison_operator = "LIKE";
-    if ($name =~ /^.?%/ && !$override) {
+  my $comparison_operator = "=";
+  if ( $override && $name =~ /[_%\[]/ ) {
+    if ( $name =~ /^[^_%\[]{0,2}[_%\[]/ ) {
       warn "External $ensType name $name is too vague and will monopolise database resources. Please use a more specific $ensType name.\n";
       return;
     }
-    elsif ($name =~ /^\w\w_/ && !$override) {
-        # For entries such as NM_00000065, escape the _ so that SQL LIKE does not have to scan entire table
-        # Escape only the _ in the third character position
-        $name =~ s/(?<=\w\w)(?=_)/\\/;
-    }
+    $comparison_operator = "LIKE";
   }
-  else {
-    $comparison_operator = "=";
-  }
-  # SGiorgetti - 29 May 2026
-  # Hacking for alleviate the DB load and not to affect the 'official' API
-  $comparison_operator = "=";
-
 
   my $from_sql  = '';
   my $where_sql = '';

--- a/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
@@ -1953,6 +1953,9 @@ sub _type_by_external_id {
   else {
     $comparison_operator = "=";
   }
+  # SGiorgetti - 29 May 2026
+  # Hacking for alleviate the DB load and not to affect the 'official' API
+  $comparison_operator = "=";
 
 
   my $from_sql  = '';

--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -897,10 +897,10 @@ sub fetch_by_translation_stable_id {
                system they are stored in the database in.  If another
                coordinate system is required then the Gene::transfer or
                Gene::transform method can be used.
-               SQL wildcards % and _ are supported in the $external_name,
-               but their use is somewhat restricted for performance reasons.
-               Users that really do want % and _ in the first three characters
-               should use argument 3 to prevent optimisations
+               External identifiers are matched exactly by default.
+               SQL wildcard matching for % and _ is enabled only when
+               argument 3 is true and the first wildcard appears after at
+               least three literal characters.
   Returntype : listref of Bio::EnsEMBL::Gene
   Exceptions : none
   Caller     : goview, general

--- a/modules/Bio/EnsEMBL/DBSQL/RNAProductAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/RNAProductAdaptor.pm
@@ -119,10 +119,10 @@ sub fetch_all_by_Transcript {
                RNAProduct returned in the list reference, but not
                always. If no RNAProducts with the external identifier
                are found, a reference to an empty list is returned.
-               SQL wildcards % and _ are supported in the $external_name
-               but their use is somewhat restricted for performance reasons.
-               Users that really do want % and _ in the first three characters
-               should use argument 3 to prevent optimisations
+               External identifiers are matched exactly by default.
+               SQL wildcard matching for % and _ is enabled only when
+               argument 3 is true and the first wildcard appears after at
+               least three literal characters.
   Returntype : listref of Bio::EnsEMBL::RNAProduct
   Exceptions : none
   Caller     : general

--- a/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranscriptAdaptor.pm
@@ -680,10 +680,10 @@ sub fetch_all_by_Slice {
                Transcript::transform method can be used to convert them.
                If no transcripts with the external identifier are found,
                a reference to an empty list is returned.
-               SQL wildcards % and _ are supported in the $external_name
-               but their use is somewhat restricted for performance reasons.
-               Users that really do want % and _ in the first three characters
-               should use argument 3 to prevent optimisations
+               External identifiers are matched exactly by default.
+               SQL wildcard matching for % and _ is enabled only when
+               argument 3 is true and the first wildcard appears after at
+               least three literal characters.
   Returntype : listref of Bio::EnsEMBL::Transcript
   Exceptions : none
   Caller     : general

--- a/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/TranslationAdaptor.pm
@@ -300,10 +300,10 @@ sub fetch_by_Transcript {
                do not make much sense out of the context of
                their transcript.  It may be better to use the
                TranscriptAdaptor::fetch_all_by_external_name instead.
-               SQL wildcards % and _ are supported in the $external_name
-               but their use is somewhat restricted for performance reasons.
-               Users that really do want % and _ in the first three characters
-               should use argument 3 to prevent optimisations
+               External identifiers are matched exactly by default.
+               SQL wildcard matching for % and _ is enabled only when
+               argument 3 is true and the first wildcard appears after at
+               least three literal characters.
   Returntype : reference to a list of Translations
   Exceptions : none
   Caller     : general

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -531,6 +531,10 @@ ok(($genes[0]->stable_id() eq 'ENSG00000174873') || ($genes[1]->stable_id() eq '
 debug($gene->stable_id);
 ok($gene->stable_id() eq 'ENSG00000101367');
 
+@genes = @{$ga->fetch_all_by_external_name('MAE1_HUMAN','Uniprot/SWISS')};
+is(scalar(@genes), 1, "External name lookup supports external DB name prefix matching");
+is($genes[0]->stable_id(), "ENSG00000101367", "External DB name prefix lookup returns the expected gene");
+
 #
 # test GeneAdaptor::fetch_all_by_Slice
 #

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -605,46 +605,53 @@ ok(scalar(@$gene_list) == 1, "Get by description");
 ok($gene_list->[0]->stable_id eq "ENSG00000101367", "check we got the right one by description");
 
 #
-# test fetch_all_by_external_name with wildcard restrictions
+# test fetch_all_by_external_name with wildcard override behaviour
 #
 (@genes) = @{$ga->fetch_all_by_external_name('AF_%')};
-# Should = 0 because _ is auto-escaped.
+# Should be 0 because wildcard matching is disabled by default.
 debug('Genes found under external_name AF_%: ' . scalar(@genes));
 ok(scalar(@genes) == 0);
-(@genes) = @{$ga->fetch_all_by_external_name('AF_%', undef, 'override')};
-debug('Genes found under external_name AF_% with override on: ' . scalar(@genes));
-debug($genes[0]->stable_id());
-debug($genes[1]->stable_id());
-debug($genes[2]->stable_id());
-debug($genes[3]->stable_id());
-# Note that 9 AF_% xrefs correspond to 4 unique ensembl IDs.
-ok(scalar(@genes) == 4);
+{
+    my $warnings = q{};
+    local $SIG{'__WARN__'} = sub {
+        $warning .= $_[0];
+    };
+    (@genes) = @{$ga->fetch_all_by_external_name('AF_%', undef, 'override')};
+    debug('Genes found under external_name AF_% with override on: ' . scalar(@genes));
+    ok(scalar(@genes) == 0);
+    like($warnings,qr/is too vague and will monopolise database/, 'AF_% with override is rejected as too vague');
+}
 #
-# test fetch_all_by_external_name with wildcard matching
+# test fetch_all_by_external_name with explicit wildcard override
 #
 @genes = @{$ga->fetch_all_by_external_name('MAE__HUMAN')};
-debug("Wildcard test:" . $genes[0]->stable_id);
+ok(scalar(@genes) == 0);
+
+@genes = @{$ga->fetch_all_by_external_name('MAE__HUMAN', undef, 'override')};
+debug("Wildcard test with override:" . $genes[0]->stable_id) if @genes;
+ok(scalar(@genes) == 1);
 ok($genes[0]->stable_id() eq 'ENSG00000101367');
+
+@genes = @{$ga->fetch_all_by_external_name('M_%')};
+ok(scalar(@genes) == 0);
 
 SKIP: {
   skip 'Wildcard behaviour different for SQLite', 1 if $db->dbc->driver() eq 'SQLite';
-  @genes = @{$ga->fetch_all_by_external_name('M_%')};
-  debug("Wildcard test:" . $genes[0]->stable_id());
-  debug(scalar @genes . " genes found");
-  ok(scalar @genes == 2);
-}
-
-# Test performance protection (very vague queries return no hits)
-debug("Testing vague query protection");
-{
   my $warnings = q{};
   local $SIG{'__WARN__'} = sub {
 	$warnings .= $_[0];
   };
-  ok(scalar(@{$ga->fetch_all_by_external_name('M%')}) == 0);
-  ok(scalar(@{$ga->fetch_all_by_external_name('%')}) == 0);
-  like($warnings, qr/is too vague and will monopolise database/, 'Checking for warnings being emitted by the above methods');
+  @genes = @{$ga->fetch_all_by_external_name('M_%', undef, 'override')};
+  debug("Wildcard test with override:" . $genes[0]->stable_id()) if @genes;
+  debug(scalar @genes . " genes found");
+  ok(scalar @genes == 0);
+  like($warnings, qr/is too vague and will monopolise database/, 'M_% with override is rejected as too vague');
 }
+
+# Test exact matching when wildcard characters are present but override is off
+debug("Testing exact matching without wildcard override");
+ok(scalar(@{$ga->fetch_all_by_external_name('M%')}) == 0);
+ok(scalar(@{$ga->fetch_all_by_external_name('%')}) == 0);
 
 #
 # test GeneAdaptor::get_Interpro_by_geneid

--- a/modules/t/gene.t
+++ b/modules/t/gene.t
@@ -614,7 +614,7 @@ ok(scalar(@genes) == 0);
 {
     my $warnings = q{};
     local $SIG{'__WARN__'} = sub {
-        $warning .= $_[0];
+        $warnings .= $_[0];
     };
     (@genes) = @{$ga->fetch_all_by_external_name('AF_%', undef, 'override')};
     debug('Genes found under external_name AF_% with override on: ' . scalar(@genes));


### PR DESCRIPTION
## Description

This is for internal use only - at least I conceived it as such - for reducing the LIKE comparisons in queries triggered by `[_%]` in accessions.

The current behaviour is not to consider `[_%]` as wildcards by default, but standard characters.
Consequently the comparison operator is "=".
This behaviour can be overridden: in this case wildcards can be used, but their presence is allowed after the 3rd character in the accession string to prevent too broad queries. 

This change alters the contract and the impact is reflected in Gene, Transcript, and Translation adaptors.

Also when querying by external_db names, the filtering clause is built like `db_name LIKE "$external_name%"`.
This is making the query execution significantly slower.

The tests in `gene.t` required tuning, accordingly.

## Use case

DB overload due to abuse or misuse of wildcards in accessions or external db names.

## Benefits

The DB will breathe again.

## Possible Drawbacks

Some regression in edge cases/pages.

## Testing

`gene.t` logic needed updating because of the changes in the default logic, and wildcard behaviour.
Also added tests for ensuring results are unchanged when the db_name prefix matches one or multiple external_db rows.
Tests pass and no regression has been detected so far, but better testing would be desirable.