### PR TITLE
Query speed optimisations

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -528,12 +528,14 @@ sub fetch_all_by_domain {
 
   throw("domain argument is required") unless ($domain);
 
+  my $index_hint = $self->dbc->driver eq 'mysql' ? ' FORCE INDEX (seq_region_current_start_idx)' : '';
+
   my $sth = $self->prepare(
   qq(
-  SELECT    tr.gene_id
+  SELECT    DISTINCT tr.gene_id
   FROM      interpro i,
             protein_feature pf,
-            transcript tr,
+            transcript tr$index_hint,
             translation tl,
             seq_region sr,
             coord_system cs
@@ -545,7 +547,7 @@ sub fetch_all_by_domain {
     AND     tl.translation_id = pf.translation_id
     AND     pf.hit_name = i.id
     AND     i.interpro_ac = ?
-  GROUP BY  tr.gene_id));
+  ));
 
   $sth->bind_param(1, $self->species_id(), SQL_VARCHAR);
   $sth->bind_param(2, $domain,             SQL_VARCHAR);

--- a/modules/t/test-genome-DBs/circ/core/meta.txt
+++ b/modules/t/test-genome-DBs/circ/core/meta.txt
@@ -159,3 +159,4 @@
 159	\N	patch	patch_113_114_a.sql|schema_version
 160	\N	patch	patch_114_115_a.sql|schema_version
 161	\N	patch	patch_115_116_a.sql|schema_version
+162	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/circ/core/table.sql
+++ b/modules/t/test-genome-DBs/circ/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=391 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=162 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=24117 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=14 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=9 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6690 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -142,3 +142,4 @@
 216	\N	patch	patch_113_114_a.sql|schema_version
 217	\N	patch	patch_114_115_a.sql|schema_version
 218	\N	patch	patch_115_116_a.sql|schema_version
+219	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=25 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=8415 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=585 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM AUTO_INCREMENT=88 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=13 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=625 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3278361 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4828765 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=29797248 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1756927 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=140609 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=9 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=101 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=103 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1063 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=219 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=220 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM AUTO_INCREMENT=12 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=13 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1000011 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=196 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=18086 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=11554509 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=242849 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1022 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=922517 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1069295 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=10 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=95700 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=548628 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1185323 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM AUTO_INCREMENT=9 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -138,3 +138,4 @@
 187	\N	patch	patch_113_114_a.sql|schema_version
 188	\N	patch	patch_114_115_a.sql|schema_version
 189	\N	patch	patch_115_116_a.sql|schema_version
+190	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1504 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=555 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=8 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6903 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6887 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=190 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=191 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=24117 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=965907 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=65 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6889 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6690 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/meta.txt
@@ -143,3 +143,4 @@
 2150	\N	patch	patch_113_114_a.sql|schema_version
 2151	\N	patch	patch_114_115_a.sql|schema_version
 2152	\N	patch	patch_115_116_a.sql|schema_version
+2153	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/patch/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=5213 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=8453 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM AUTO_INCREMENT=157 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=410 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1004 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=16758826 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM AUTO_INCREMENT=110 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1366612 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1221449 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=29387404 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=7296966 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=633706 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=71 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM AUTO_INCREMENT=852 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=13 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=394 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=27 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=27 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=716771 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2153 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=2154 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM AUTO_INCREMENT=93001 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=19 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=17375428 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM AUTO_INCREMENT=250655 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=394607 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=54799 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=19573639 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=7821872 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM AUTO_INCREMENT=595635 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=31576665 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1001161224 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=177 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=968567 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=2047756 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1044748 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM AUTO_INCREMENT=12401901 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=139 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/mapping/core/meta.txt
+++ b/modules/t/test-genome-DBs/mapping/core/meta.txt
@@ -99,3 +99,4 @@
 192	\N	patch	patch_113_114_a.sql|schema_version
 193	\N	patch	patch_114_115_a.sql|schema_version
 194	\N	patch	patch_115_116_a.sql|schema_version
+195	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/mapping/core/table.sql
+++ b/modules/t/test-genome-DBs/mapping/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=391 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=195 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=196 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=24117 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=14 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6690 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
+++ b/modules/t/test-genome-DBs/mus_musculus/core/meta.txt
@@ -216,3 +216,4 @@
 1728	\N	patch	patch_113_114_a.sql|schema_version
 1729	\N	patch	patch_114_115_a.sql|schema_version
 1730	\N	patch	patch_115_116_a.sql|schema_version
+1731	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/mus_musculus/core/table.sql
+++ b/modules/t/test-genome-DBs/mus_musculus/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=40 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=508 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=112 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=18257 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1731 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=1732 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=24117 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=13705556 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6690 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=139 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/nameless/core/meta.txt
+++ b/modules/t/test-genome-DBs/nameless/core/meta.txt
@@ -137,3 +137,4 @@
 191	\N	patch	patch_113_114_a.sql|schema_version
 192	\N	patch	patch_114_115_a.sql|schema_version
 193	\N	patch	patch_115_116_a.sql|schema_version
+194	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/nameless/core/table.sql
+++ b/modules/t/test-genome-DBs/nameless/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=391 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,17 +241,17 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -259,51 +260,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -315,14 +316,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -330,9 +331,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -340,44 +341,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -388,36 +389,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -425,74 +426,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=194 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=195 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -500,39 +501,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -540,24 +541,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -567,16 +568,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -586,28 +587,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -616,35 +617,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -654,21 +655,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -677,11 +678,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=24117 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -690,15 +691,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -707,15 +708,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -724,8 +725,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -734,7 +735,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -743,19 +744,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=14 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -763,31 +764,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -796,12 +797,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -809,29 +810,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -840,13 +841,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -854,31 +856,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -887,9 +889,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6690 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -897,17 +899,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -916,21 +918,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/parus_major1/core/meta.txt
+++ b/modules/t/test-genome-DBs/parus_major1/core/meta.txt
@@ -110,3 +110,4 @@
 151	\N	patch	patch_113_114_a.sql|schema_version
 152	\N	patch	patch_114_115_a.sql|schema_version
 153	\N	patch	patch_115_116_a.sql|schema_version
+154	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/parus_major1/core/table.sql
+++ b/modules/t/test-genome-DBs/parus_major1/core/table.sql
@@ -1,25 +1,25 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
   `logic_name` varchar(128) NOT NULL,
   `db` varchar(120) DEFAULT NULL,
@@ -38,7 +38,7 @@ CREATE TABLE `analysis` (
 ) ENGINE=MyISAM AUTO_INCREMENT=222 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `description` text,
   `display_label` varchar(255) NOT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
@@ -47,47 +47,48 @@ CREATE TABLE `analysis_description` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL,
-  `cmp_seq_region_id` int(10) unsigned NOT NULL,
-  `asm_start` int(10) NOT NULL,
-  `asm_end` int(10) NOT NULL,
-  `cmp_start` int(10) NOT NULL,
-  `cmp_end` int(10) NOT NULL,
-  `ori` tinyint(4) NOT NULL,
+  `asm_seq_region_id` int unsigned NOT NULL,
+  `cmp_seq_region_id` int unsigned NOT NULL,
+  `asm_start` int NOT NULL,
+  `asm_end` int NOT NULL,
+  `cmp_start` int NOT NULL,
+  `cmp_end` int NOT NULL,
+  `ori` tinyint NOT NULL,
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_idx` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_idx` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_idx` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `exc_type` enum('HAP','PAR','PATCH_FIX','PATCH_NOVEL') NOT NULL,
-  `exc_seq_region_id` int(10) unsigned NOT NULL,
-  `exc_seq_region_start` int(10) unsigned NOT NULL,
-  `exc_seq_region_end` int(10) unsigned NOT NULL,
-  `ori` int(11) NOT NULL,
+  `exc_seq_region_id` int unsigned NOT NULL,
+  `exc_seq_region_start` int unsigned NOT NULL,
+  `exc_seq_region_end` int unsigned NOT NULL,
+  `ori` int NOT NULL,
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,7 +98,7 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -106,11 +107,11 @@ CREATE TABLE `attrib_type` (
 ) ENGINE=MyISAM AUTO_INCREMENT=550 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM AUTO_INCREMENT=232 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(10) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `density_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `density_type_id` int unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `density_value` float NOT NULL,
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=16033 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `block_size` int(11) NOT NULL,
-  `region_features` int(11) NOT NULL,
+  `density_type_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `block_size` int NOT NULL,
+  `region_features` int NOT NULL,
   `value_type` enum('sum','ratio') NOT NULL,
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_idx` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(30) NOT NULL,
   `type` varchar(30) NOT NULL,
-  `tag_count` smallint(6) unsigned NOT NULL DEFAULT '1',
+  `tag_count` smallint unsigned NOT NULL DEFAULT '1',
   `sequence` tinytext NOT NULL,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` smallint unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` tinytext NOT NULL,
   `ditag_side` enum('F','L','R') NOT NULL,
@@ -208,27 +209,27 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `seq_region_strand` tinyint(1) NOT NULL,
-  `hit_start` int(11) NOT NULL,
-  `hit_end` int(11) NOT NULL,
+  `hit_start` int NOT NULL,
+  `hit_end` int NOT NULL,
   `hit_strand` tinyint(1) NOT NULL,
   `hit_name` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
   `cigar_line` text,
-  `external_db_id` int(10) unsigned DEFAULT NULL,
+  `external_db_id` int unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
   `align_type` enum('ensembl','cigar','vulgar','mdtag') DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=529 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,20 +270,20 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=198287 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `rank` int(10) NOT NULL,
+  `exon_id` int unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `rank` int NOT NULL,
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int unsigned NOT NULL AUTO_INCREMENT,
   `db_name` varchar(100) NOT NULL,
   `db_release` varchar(255) DEFAULT NULL,
   `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') NOT NULL,
-  `priority` int(11) NOT NULL,
+  `priority` int NOT NULL,
   `db_display_name` varchar(255) DEFAULT NULL,
   `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') NOT NULL,
   `secondary_db_name` varchar(255) DEFAULT NULL,
@@ -293,27 +294,27 @@ CREATE TABLE `external_db` (
 ) ENGINE=MyISAM AUTO_INCREMENT=50870 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL,
+  `xref_id` int unsigned NOT NULL,
   `synonym` varchar(100) NOT NULL,
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -326,13 +327,13 @@ CREATE TABLE `gene` (
 
 CREATE TABLE `gene_archive` (
   `gene_stable_id` varchar(128) NOT NULL,
-  `gene_version` smallint(6) NOT NULL DEFAULT '1',
+  `gene_version` smallint NOT NULL DEFAULT '1',
   `transcript_stable_id` varchar(128) NOT NULL,
-  `transcript_version` smallint(6) NOT NULL DEFAULT '1',
+  `transcript_version` smallint NOT NULL DEFAULT '1',
   `translation_stable_id` varchar(128) DEFAULT NULL,
-  `translation_version` smallint(6) NOT NULL DEFAULT '1',
-  `peptide_archive_id` int(10) unsigned DEFAULT NULL,
-  `mapping_session_id` int(10) unsigned NOT NULL,
+  `translation_version` smallint NOT NULL DEFAULT '1',
+  `peptide_archive_id` int unsigned DEFAULT NULL,
+  `mapping_session_id` int unsigned NOT NULL,
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,8 +341,8 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -350,24 +351,24 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=12 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
   `cigar_line` text,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
@@ -382,12 +383,12 @@ CREATE TABLE `interpro` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,10 +399,10 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM AUTO_INCREMENT=126974 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `band` varchar(40) DEFAULT NULL,
   `stain` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
@@ -409,13 +410,13 @@ CREATE TABLE `karyotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
   `map_name` varchar(30) NOT NULL,
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `mapping_session_id` int unsigned NOT NULL AUTO_INCREMENT,
   `old_db_name` varchar(80) NOT NULL DEFAULT '',
   `new_db_name` varchar(80) NOT NULL DEFAULT '',
   `old_release` varchar(5) NOT NULL DEFAULT '',
@@ -427,7 +428,7 @@ CREATE TABLE `mapping_session` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,13 +436,13 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
   `left_primer` varchar(100) NOT NULL,
   `right_primer` varchar(100) NOT NULL,
-  `min_primer_dist` int(10) unsigned NOT NULL,
-  `max_primer_dist` int(10) unsigned NOT NULL,
-  `priority` int(11) DEFAULT NULL,
+  `min_primer_dist` int unsigned NOT NULL,
+  `max_primer_dist` int unsigned NOT NULL,
+  `priority` int DEFAULT NULL,
   `type` enum('est','microsatellite') DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
@@ -449,23 +450,23 @@ CREATE TABLE `marker` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL,
-  `map_id` int(10) unsigned NOT NULL,
+  `marker_id` int unsigned NOT NULL,
+  `map_id` int unsigned NOT NULL,
   `chromosome_name` varchar(15) NOT NULL,
-  `marker_synonym_id` int(10) unsigned NOT NULL,
+  `marker_synonym_id` int unsigned NOT NULL,
   `position` varchar(15) NOT NULL,
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
@@ -473,8 +474,8 @@ CREATE TABLE `marker_map_location` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL,
   `source` varchar(20) DEFAULT NULL,
   `name` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
@@ -483,25 +484,25 @@ CREATE TABLE `marker_synonym` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=154 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=155 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `max_length` int(11) DEFAULT NULL,
+  `coord_system_id` int unsigned NOT NULL,
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(25) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
-  `max_length` int(10) unsigned NOT NULL,
+  `max_length` int unsigned NOT NULL,
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=91 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL,
   `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
+  `xref_id` int unsigned NOT NULL,
   `linkage_annotation` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`,`analysis_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,8 +551,8 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=2562286 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `linkage_type` varchar(3) DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `source_idx` (`source_xref_id`),
@@ -559,15 +560,15 @@ CREATE TABLE `ontology_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,13 +597,13 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `peptide_archive_id` int unsigned NOT NULL AUTO_INCREMENT,
   `md5_checksum` varchar(32) DEFAULT NULL,
   `peptide_seq` mediumtext NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
@@ -610,14 +611,14 @@ CREATE TABLE `peptide_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL,
-  `exon_rank` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(4) NOT NULL,
-  `start_phase` tinyint(4) NOT NULL,
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL,
+  `exon_rank` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `start_phase` tinyint NOT NULL,
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,12 +627,12 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=272065 DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(4) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -639,20 +640,20 @@ CREATE TABLE `prediction_transcript` (
 ) ENGINE=MyISAM AUTO_INCREMENT=34643 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL,
-  `hit_end` int(10) NOT NULL,
+  `hit_start` int NOT NULL,
+  `hit_end` int NOT NULL,
   `hit_name` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
   `cigar_line` text,
-  `external_db_id` int(10) unsigned DEFAULT NULL,
+  `external_db_id` int unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
   `align_type` enum('ensembl','cigar','vulgar','mdtag') DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
@@ -664,14 +665,14 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=272385 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `hit_start` int(10) NOT NULL,
-  `hit_end` int(10) NOT NULL,
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `seq_end` int NOT NULL,
+  `hit_start` int NOT NULL,
+  `hit_end` int NOT NULL,
   `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
@@ -687,7 +688,7 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4456776 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
   `repeat_name` varchar(255) NOT NULL,
   `repeat_class` varchar(100) NOT NULL,
   `repeat_type` varchar(40) NOT NULL,
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM AUTO_INCREMENT=227243 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL,
-  `repeat_end` int(10) NOT NULL,
-  `repeat_consensus_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `repeat_start` int NOT NULL,
+  `repeat_end` int NOT NULL,
+  `repeat_consensus_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=2165456 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,18 +754,18 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `length` int(10) unsigned NOT NULL,
+  `coord_system_id` int unsigned NOT NULL,
+  `length` int unsigned NOT NULL,
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1676 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` int(10) unsigned DEFAULT NULL,
+  `external_db_id` int unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3349 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
   `seq_region_strand` tinyint(1) NOT NULL,
   `display_label` varchar(255) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -807,10 +808,10 @@ CREATE TABLE `simple_feature` (
 
 CREATE TABLE `stable_id_event` (
   `old_stable_id` varchar(128) DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
   `new_stable_id` varchar(128) DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int unsigned NOT NULL DEFAULT '0',
   `type` enum('gene','transcript','translation','rnaproduct') NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`new_stable_id`,`type`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
   `feature_type` enum('dna_align_feature','protein_align_feature') DEFAULT NULL,
-  `feature_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `feature_id` int unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,12 +851,13 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=35315 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
   `feature_type` enum('dna_align_feature','protein_align_feature') DEFAULT NULL,
-  `feature_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `feature_id` int unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,8 +899,8 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=27489 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -907,15 +909,15 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
   `type` enum('xref','cDNA','Marker') NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `external_db_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `external_db_id` int unsigned DEFAULT NULL,
   `identifier` varchar(255) NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
+  `ensembl_id` int unsigned DEFAULT '0',
   `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') DEFAULT 'RawContig',
   `parent` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
@@ -926,15 +928,15 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM AUTO_INCREMENT=269409 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
   `summary_description` varchar(255) DEFAULT NULL,
   `full_description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=139 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(10) unsigned NOT NULL,
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int unsigned NOT NULL,
   `dbprimary_acc` varchar(512) NOT NULL,
   `display_label` varchar(512) NOT NULL,
   `version` varchar(10) DEFAULT NULL,

--- a/modules/t/test-genome-DBs/polyploidy/core/meta.txt
+++ b/modules/t/test-genome-DBs/polyploidy/core/meta.txt
@@ -192,3 +192,4 @@
 272	\N	patch	patch_113_114_a.sql|schema_version
 273	\N	patch	patch_114_115_a.sql|schema_version
 274	\N	patch	patch_115_116_a.sql|schema_version
+275	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/polyploidy/core/table.sql
+++ b/modules/t/test-genome-DBs/polyploidy/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=201 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=437 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM AUTO_INCREMENT=23 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,8 +241,8 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature_attrib` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL,
-  `attrib_type_id` smallint(5) unsigned NOT NULL,
+  `dna_align_feature_id` int unsigned NOT NULL,
+  `attrib_type_id` smallint unsigned NOT NULL,
   `value` text NOT NULL,
   UNIQUE KEY `dna_align_feature_attribx` (`dna_align_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
@@ -250,17 +251,17 @@ CREATE TABLE `dna_align_feature_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -269,51 +270,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=382467 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -325,14 +326,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=40234 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -340,9 +341,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -350,44 +351,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=45 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -398,36 +399,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -435,74 +436,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=275 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=276 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -510,39 +511,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=24 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -550,24 +551,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -577,16 +578,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -596,28 +597,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -626,35 +627,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -664,21 +665,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -687,11 +688,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=3502933 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -700,15 +701,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1163919 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -717,15 +718,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=10446798 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -734,8 +735,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -744,7 +745,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -753,19 +754,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=3495795 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -773,31 +774,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -806,12 +807,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -819,29 +820,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -850,13 +851,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=124988 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -864,31 +866,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -897,9 +899,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=124988 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -907,17 +909,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -926,21 +928,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=139 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/modules/t/test-genome-DBs/test_collection/core/meta.txt
+++ b/modules/t/test-genome-DBs/test_collection/core/meta.txt
@@ -212,3 +212,4 @@
 254	\N	patch	patch_113_114_a.sql|schema_version
 255	\N	patch	patch_114_115_a.sql|schema_version
 256	\N	patch	patch_115_116_a.sql|schema_version
+257	\N	patch	patch_115_116_b.sql|Added indices to transcript and assembly

--- a/modules/t/test-genome-DBs/test_collection/core/table.sql
+++ b/modules/t/test-genome-DBs/test_collection/core/table.sql
@@ -1,93 +1,94 @@
 CREATE TABLE `alt_allele` (
-  `alt_allele_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `alt_allele_group_id` int(10) unsigned NOT NULL,
-  `gene_id` int(10) unsigned NOT NULL,
+  `alt_allele_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL,
+  `gene_id` int unsigned NOT NULL,
   PRIMARY KEY (`alt_allele_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`),
   KEY `gene_idx` (`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_attrib` (
-  `alt_allele_id` int(10) unsigned DEFAULT NULL,
+  `alt_allele_id` int unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED','IS_PAR') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `alt_allele_group` (
-  `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `alt_allele_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `analysis` (
-  `analysis_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` int unsigned NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,
-  `logic_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `db_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `db_file` varchar(120) COLLATE latin1_bin DEFAULT NULL,
-  `program` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `program_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `program_file` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `parameters` text COLLATE latin1_bin,
-  `module` varchar(80) COLLATE latin1_bin DEFAULT NULL,
-  `module_version` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_source` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `gff_feature` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `logic_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `db_file` varchar(120) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `program_file` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `parameters` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `module` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `module_version` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_source` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `gff_feature` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=39 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `analysis_description` (
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `description` text COLLATE latin1_bin,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
-  `web_data` text COLLATE latin1_bin,
+  `web_data` text CHARACTER SET latin1 COLLATE latin1_bin,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `assembly` (
-  `asm_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `cmp_seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `asm_start` int(10) NOT NULL DEFAULT '0',
-  `asm_end` int(10) NOT NULL DEFAULT '0',
-  `cmp_start` int(10) NOT NULL DEFAULT '0',
-  `cmp_end` int(10) NOT NULL DEFAULT '0',
-  `ori` tinyint(4) NOT NULL DEFAULT '0',
+  `asm_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `cmp_seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `asm_start` int NOT NULL DEFAULT '0',
+  `asm_end` int NOT NULL DEFAULT '0',
+  `cmp_start` int NOT NULL DEFAULT '0',
+  `cmp_end` int NOT NULL DEFAULT '0',
+  `ori` tinyint NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_id` (`cmp_seq_region_id`),
-  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`)
+  KEY `asm_seq_region_id` (`asm_seq_region_id`,`asm_start`),
+  KEY `asm_overlap_end_idx` (`asm_seq_region_id`,`asm_end`,`asm_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `assembly_exception` (
-  `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
-  `exc_seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `exc_seq_region_end` int(11) NOT NULL DEFAULT '0',
-  `ori` int(11) NOT NULL DEFAULT '0',
+  `assembly_exception_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `exc_type` enum('HAP','PAR','PATCH_NOVEL','PATCH_FIX') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'HAP',
+  `exc_seq_region_id` int NOT NULL DEFAULT '0',
+  `exc_seq_region_start` int NOT NULL DEFAULT '0',
+  `exc_seq_region_end` int NOT NULL DEFAULT '0',
+  `ori` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `associated_group` (
-  `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `associated_group_id` int unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `associated_xref` (
-  `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `associated_xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `source_xref_id` int unsigned DEFAULT NULL,
   `condition_type` varchar(128) DEFAULT NULL,
-  `associated_group_id` int(10) unsigned DEFAULT NULL,
-  `rank` int(10) unsigned DEFAULT '0',
+  `associated_group_id` int unsigned DEFAULT NULL,
+  `rank` int unsigned DEFAULT '0',
   PRIMARY KEY (`associated_xref_id`),
   UNIQUE KEY `object_associated_source_type_idx` (`object_xref_id`,`xref_id`,`source_xref_id`,`condition_type`,`associated_group_id`),
   KEY `associated_source_idx` (`source_xref_id`),
@@ -97,20 +98,20 @@ CREATE TABLE `associated_xref` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type` (
-  `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(20) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin,
+  `attrib_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=391 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `biotype` (
-  `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `biotype_id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
   `object_type` enum('gene','transcript') NOT NULL DEFAULT 'gene',
   `db_type` set('cdna','core','coreexpressionatlas','coreexpressionest','coreexpressiongnf','funcgen','otherfeatures','rnaseq','variation','vega','presite','sangervega') NOT NULL DEFAULT 'core',
-  `attrib_type_id` int(11) DEFAULT NULL,
+  `attrib_type_id` int DEFAULT NULL,
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
@@ -120,11 +121,11 @@ CREATE TABLE `biotype` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `coord_system` (
-  `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned NOT NULL DEFAULT '1',
+  `coord_system_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned NOT NULL DEFAULT '1',
   `name` varchar(40) NOT NULL,
   `version` varchar(255) DEFAULT NULL,
-  `rank` int(11) NOT NULL,
+  `rank` int NOT NULL,
   `attrib` set('default_version','sequence_level') DEFAULT NULL,
   PRIMARY KEY (`coord_system_id`),
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
@@ -133,9 +134,9 @@ CREATE TABLE `coord_system` (
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `coord_system_id` int(10) unsigned NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `data_file_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `coord_system_id` int unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `name` varchar(100) NOT NULL,
   `version_lock` tinyint(1) NOT NULL DEFAULT '0',
   `absolute` tinyint(1) NOT NULL DEFAULT '0',
@@ -148,11 +149,11 @@ CREATE TABLE `data_file` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `density_feature` (
-  `density_feature_id` int(11) NOT NULL AUTO_INCREMENT,
-  `density_type_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_id` int(11) NOT NULL DEFAULT '0',
-  `seq_region_start` int(11) NOT NULL DEFAULT '0',
-  `seq_region_end` int(11) NOT NULL DEFAULT '0',
+  `density_feature_id` int NOT NULL AUTO_INCREMENT,
+  `density_type_id` int NOT NULL DEFAULT '0',
+  `seq_region_id` int NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
   `density_value` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
@@ -160,44 +161,44 @@ CREATE TABLE `density_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `density_type` (
-  `density_type_id` int(11) NOT NULL AUTO_INCREMENT,
-  `analysis_id` int(11) NOT NULL DEFAULT '0',
-  `block_size` int(11) NOT NULL DEFAULT '0',
-  `region_features` int(11) NOT NULL DEFAULT '0',
-  `value_type` enum('sum','ratio') COLLATE latin1_bin NOT NULL DEFAULT 'sum',
+  `density_type_id` int NOT NULL AUTO_INCREMENT,
+  `analysis_id` int NOT NULL DEFAULT '0',
+  `block_size` int NOT NULL DEFAULT '0',
+  `region_features` int NOT NULL DEFAULT '0',
+  `value_type` enum('sum','ratio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'sum',
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`block_size`,`region_features`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `dependent_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL,
-  `master_xref_id` int(10) unsigned NOT NULL,
-  `dependent_xref_id` int(10) unsigned NOT NULL,
+  `object_xref_id` int unsigned NOT NULL,
+  `master_xref_id` int unsigned NOT NULL,
+  `dependent_xref_id` int unsigned NOT NULL,
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `ditag` (
-  `ditag_id` int(10) NOT NULL AUTO_INCREMENT,
+  `ditag_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(30) DEFAULT NULL,
   `type` varchar(30) DEFAULT NULL,
-  `tag_count` smallint(6) DEFAULT '1',
+  `tag_count` smallint DEFAULT '1',
   `sequence` text,
   PRIMARY KEY (`ditag_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ditag_feature` (
-  `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `ditag_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ditag_pair_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `ditag_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `ditag_id` int unsigned NOT NULL DEFAULT '0',
+  `ditag_pair_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `hit_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `hit_start` int unsigned NOT NULL DEFAULT '0',
+  `hit_end` int unsigned NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
   `cigar_line` text,
   `ditag_side` char(1) DEFAULT '',
@@ -208,29 +209,29 @@ CREATE TABLE `ditag_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `sequence` mediumtext COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `sequence` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=750000 AVG_ROW_LENGTH=19000 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `dna_align_feature` (
-  `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `dna_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_start` int(11) NOT NULL DEFAULT '0',
-  `hit_end` int(11) NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
   `hit_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`dna_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -240,17 +241,17 @@ CREATE TABLE `dna_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon` (
-  `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `phase` tinyint(2) NOT NULL,
-  `end_phase` tinyint(2) NOT NULL,
+  `exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `phase` tinyint NOT NULL,
+  `end_phase` tinyint NOT NULL,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
   `is_constitutive` tinyint(1) NOT NULL DEFAULT '0',
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`exon_id`),
@@ -259,51 +260,51 @@ CREATE TABLE `exon` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `exon_transcript` (
-  `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `rank` int(10) NOT NULL DEFAULT '0',
+  `exon_id` int unsigned NOT NULL DEFAULT '0',
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `external_db` (
-  `external_db_id` int(11) NOT NULL DEFAULT '0',
-  `db_name` varchar(27) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `db_release` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `db_display_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') COLLATE latin1_bin NOT NULL,
-  `secondary_db_name` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `secondary_db_table` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
+  `external_db_id` int NOT NULL DEFAULT '0',
+  `db_name` varchar(27) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `db_release` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `status` enum('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'KNOWNXREF',
+  `priority` int NOT NULL DEFAULT '0',
+  `db_display_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `type` enum('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `secondary_db_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `secondary_db_table` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `external_synonym` (
-  `xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `synonym` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL DEFAULT '0',
+  `synonym` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene` (
-  `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned NOT NULL AUTO_INCREMENT,
   `biotype` varchar(40) NOT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_transcript_id` int(10) unsigned NOT NULL,
+  `canonical_transcript_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`gene_id`),
@@ -315,14 +316,14 @@ CREATE TABLE `gene` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_archive` (
-  `gene_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `gene_version` smallint(6) NOT NULL DEFAULT '0',
-  `transcript_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `transcript_version` smallint(6) NOT NULL DEFAULT '0',
-  `translation_stable_id` varchar(128) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `translation_version` smallint(6) NOT NULL DEFAULT '0',
-  `peptide_archive_id` int(11) NOT NULL DEFAULT '0',
-  `mapping_session_id` int(11) NOT NULL DEFAULT '0',
+  `gene_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `gene_version` smallint NOT NULL DEFAULT '0',
+  `transcript_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `transcript_version` smallint NOT NULL DEFAULT '0',
+  `translation_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `translation_version` smallint NOT NULL DEFAULT '0',
+  `peptide_archive_id` int NOT NULL DEFAULT '0',
+  `mapping_session_id` int NOT NULL DEFAULT '0',
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`),
@@ -330,9 +331,9 @@ CREATE TABLE `gene_archive` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `gene_attrib` (
-  `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `gene_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `gene_attribx` (`gene_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -340,44 +341,44 @@ CREATE TABLE `gene_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `genome_statistics` (
-  `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `genome_statistics_id` int unsigned NOT NULL AUTO_INCREMENT,
   `statistic` varchar(128) NOT NULL,
-  `value` bigint(11) unsigned NOT NULL DEFAULT '0',
-  `species_id` int(10) unsigned DEFAULT '1',
-  `attrib_type_id` int(10) unsigned DEFAULT NULL,
+  `value` bigint unsigned NOT NULL DEFAULT '0',
+  `species_id` int unsigned DEFAULT '1',
+  `attrib_type_id` int unsigned DEFAULT NULL,
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `identity_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `xref_identity` int(5) DEFAULT NULL,
-  `ensembl_identity` int(5) DEFAULT NULL,
-  `xref_start` int(11) DEFAULT NULL,
-  `xref_end` int(11) DEFAULT NULL,
-  `ensembl_start` int(11) DEFAULT NULL,
-  `ensembl_end` int(11) DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
+  `xref_identity` int DEFAULT NULL,
+  `ensembl_identity` int DEFAULT NULL,
+  `xref_start` int DEFAULT NULL,
+  `xref_end` int DEFAULT NULL,
+  `ensembl_start` int DEFAULT NULL,
+  `ensembl_end` int DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `interpro` (
-  `interpro_ac` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `id` varchar(40) COLLATE latin1_bin NOT NULL,
+  `interpro_ac` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `id` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `intron_supporting_evidence` (
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `hit_name` varchar(100) NOT NULL,
   `score` decimal(10,3) DEFAULT NULL,
   `score_type` enum('NONE','DEPTH') DEFAULT 'NONE',
@@ -388,36 +389,36 @@ CREATE TABLE `intron_supporting_evidence` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `karyotype` (
-  `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) NOT NULL DEFAULT '0',
-  `band` varchar(40) COLLATE latin1_bin DEFAULT NULL,
-  `stain` varchar(40) COLLATE latin1_bin DEFAULT NULL,
+  `karyotype_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int NOT NULL DEFAULT '0',
+  `seq_region_end` int NOT NULL DEFAULT '0',
+  `band` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `stain` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `map` (
-  `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `map_name` varchar(30) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `map_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `map_name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`map_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_session` (
-  `mapping_session_id` int(11) NOT NULL AUTO_INCREMENT,
-  `old_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_db_name` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_release` varchar(5) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `old_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `new_assembly` varchar(80) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `mapping_session_id` int NOT NULL AUTO_INCREMENT,
+  `old_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_db_name` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_release` varchar(5) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `old_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `new_assembly` varchar(80) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`mapping_session_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `mapping_set` (
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   `internal_schema_build` varchar(20) NOT NULL,
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
@@ -425,74 +426,74 @@ CREATE TABLE `mapping_set` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker` (
-  `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `display_marker_synonym_id` int(10) unsigned DEFAULT NULL,
-  `left_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `right_primer` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `min_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `max_primer_dist` int(10) unsigned NOT NULL DEFAULT '0',
-  `priority` int(11) DEFAULT NULL,
-  `type` enum('est','microsatellite') COLLATE latin1_bin DEFAULT NULL,
+  `marker_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `display_marker_synonym_id` int unsigned DEFAULT NULL,
+  `left_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `right_primer` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `min_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `max_primer_dist` int unsigned NOT NULL DEFAULT '0',
+  `priority` int DEFAULT NULL,
+  `type` enum('est','microsatellite') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_feature` (
-  `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_weight` int(10) unsigned DEFAULT NULL,
+  `marker_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
+  `map_weight` int unsigned DEFAULT NULL,
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `marker_map_location` (
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `map_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `chromosome_name` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `marker_synonym_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `position` varchar(15) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `map_id` int unsigned NOT NULL DEFAULT '0',
+  `chromosome_name` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `marker_synonym_id` int unsigned NOT NULL DEFAULT '0',
+  `position` varchar(15) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `marker_synonym` (
-  `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `marker_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `source` varchar(20) COLLATE latin1_bin DEFAULT NULL,
-  `name` varchar(30) COLLATE latin1_bin DEFAULT NULL,
+  `marker_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `marker_id` int unsigned NOT NULL DEFAULT '0',
+  `source` varchar(20) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `name` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta` (
-  `meta_id` int(11) NOT NULL AUTO_INCREMENT,
-  `species_id` int(10) unsigned DEFAULT '1',
+  `meta_id` int NOT NULL AUTO_INCREMENT,
+  `species_id` int unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=257 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
+) ENGINE=MyISAM AUTO_INCREMENT=258 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `meta_coord` (
-  `table_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `coord_system_id` int(11) NOT NULL DEFAULT '0',
-  `max_length` int(11) DEFAULT NULL,
+  `table_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `max_length` int DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_attrib` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `misc_attribx` (`misc_feature_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -500,39 +501,39 @@ CREATE TABLE `misc_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `misc_feature` (
-  `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_feature_misc_set` (
-  `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc_feature_id` int unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `misc_set` (
-  `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-  `code` varchar(25) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `description` text COLLATE latin1_bin NOT NULL,
-  `max_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `misc_set_id` smallint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(25) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `max_length` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `object_xref` (
-  `object_xref_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ensembl_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') COLLATE latin1_bin NOT NULL,
-  `xref_id` int(10) unsigned NOT NULL,
-  `linkage_annotation` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned DEFAULT NULL,
+  `object_xref_id` int NOT NULL AUTO_INCREMENT,
+  `ensembl_id` int unsigned NOT NULL DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation','Operon','OperonTranscript','Marker','RNAProduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `xref_id` int unsigned NOT NULL,
+  `linkage_annotation` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `analysis_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`),
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`),
@@ -540,24 +541,24 @@ CREATE TABLE `object_xref` (
 ) ENGINE=MyISAM AUTO_INCREMENT=81424 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ontology_xref` (
-  `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `object_xref_id` int unsigned NOT NULL DEFAULT '0',
   `linkage_type` varchar(3) DEFAULT NULL,
-  `source_xref_id` int(10) unsigned DEFAULT NULL,
+  `source_xref_id` int unsigned DEFAULT NULL,
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`),
   KEY `object_idx` (`object_xref_id`),
   KEY `source_idx` (`source_xref_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon` (
-  `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
+  `operon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_id`),
@@ -567,16 +568,16 @@ CREATE TABLE `operon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript` (
-  `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `operon_id` int(10) unsigned NOT NULL,
+  `operon_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `operon_id` int unsigned NOT NULL,
   `display_label` varchar(255) DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`operon_transcript_id`),
@@ -586,28 +587,28 @@ CREATE TABLE `operon_transcript` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `operon_transcript_gene` (
-  `operon_transcript_id` int(10) unsigned DEFAULT NULL,
-  `gene_id` int(10) unsigned DEFAULT NULL,
+  `operon_transcript_id` int unsigned DEFAULT NULL,
+  `gene_id` int unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `peptide_archive` (
-  `peptide_archive_id` int(11) NOT NULL AUTO_INCREMENT,
-  `md5_checksum` varchar(32) COLLATE latin1_bin DEFAULT NULL,
-  `peptide_seq` mediumtext COLLATE latin1_bin NOT NULL,
+  `peptide_archive_id` int NOT NULL AUTO_INCREMENT,
+  `md5_checksum` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `peptide_seq` mediumtext CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `prediction_exon` (
-  `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `prediction_transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `exon_rank` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `start_phase` tinyint(4) NOT NULL DEFAULT '0',
+  `prediction_exon_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `prediction_transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `exon_rank` smallint unsigned NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `start_phase` tinyint NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `p_value` double DEFAULT NULL,
   PRIMARY KEY (`prediction_exon_id`),
@@ -616,35 +617,35 @@ CREATE TABLE `prediction_exon` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=FIXED;
 
 CREATE TABLE `prediction_transcript` (
-  `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
-  `analysis_id` int(11) DEFAULT NULL,
-  `display_label` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `prediction_transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_strand` tinyint NOT NULL DEFAULT '0',
+  `analysis_id` int DEFAULT NULL,
+  `display_label` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_align_feature` (
-  `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_align_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `cigar_line` text COLLATE latin1_bin,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   `hcoverage` double DEFAULT NULL,
-  `align_type` enum('ensembl','cigar','vulgar','mdtag') COLLATE latin1_bin DEFAULT 'ensembl',
+  `align_type` enum('ensembl','cigar','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'ensembl',
   PRIMARY KEY (`protein_align_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`analysis_id`,`seq_region_start`,`score`),
   KEY `seq_region_idx_2` (`seq_region_id`,`seq_region_start`),
@@ -654,21 +655,21 @@ CREATE TABLE `protein_align_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `protein_feature` (
-  `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `translation_id` int(11) NOT NULL DEFAULT '0',
-  `seq_start` int(10) NOT NULL DEFAULT '0',
-  `seq_end` int(10) NOT NULL DEFAULT '0',
-  `hit_start` int(10) NOT NULL DEFAULT '0',
-  `hit_end` int(10) NOT NULL DEFAULT '0',
-  `hit_name` varchar(40) COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `protein_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `translation_id` int NOT NULL DEFAULT '0',
+  `seq_start` int NOT NULL DEFAULT '0',
+  `seq_end` int NOT NULL DEFAULT '0',
+  `hit_start` int NOT NULL DEFAULT '0',
+  `hit_end` int NOT NULL DEFAULT '0',
+  `hit_name` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double NOT NULL DEFAULT '0',
   `evalue` double DEFAULT NULL,
   `perc_ident` float DEFAULT NULL,
-  `external_data` text COLLATE latin1_bin,
-  `hit_description` text COLLATE latin1_bin,
-  `cigar_line` text COLLATE latin1_bin,
-  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') COLLATE latin1_bin DEFAULT NULL,
+  `external_data` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `hit_description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `cigar_line` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `align_type` enum('ensembl','cigar','cigarplus','vulgar','mdtag') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`protein_feature_id`),
   UNIQUE KEY `aln_idx` (`translation_id`,`hit_name`,`seq_start`,`seq_end`,`hit_start`,`hit_end`,`analysis_id`),
   KEY `translation_idx` (`translation_id`),
@@ -677,11 +678,11 @@ CREATE TABLE `protein_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=24117 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_consensus` (
-  `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `repeat_name` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_class` varchar(100) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_type` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `repeat_consensus` text COLLATE latin1_bin,
+  `repeat_consensus_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `repeat_name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_class` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_type` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `repeat_consensus` text CHARACTER SET latin1 COLLATE latin1_bin,
   PRIMARY KEY (`repeat_consensus_id`),
   KEY `name` (`repeat_name`),
   KEY `class` (`repeat_class`),
@@ -690,15 +691,15 @@ CREATE TABLE `repeat_consensus` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repeat_feature` (
-  `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '1',
-  `repeat_start` int(10) NOT NULL DEFAULT '0',
-  `repeat_end` int(10) NOT NULL DEFAULT '0',
-  `repeat_consensus_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `repeat_start` int NOT NULL DEFAULT '0',
+  `repeat_end` int NOT NULL DEFAULT '0',
+  `repeat_consensus_id` int unsigned NOT NULL DEFAULT '0',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`repeat_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -707,15 +708,15 @@ CREATE TABLE `repeat_feature` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `rnaproduct` (
-  `rnaproduct_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned DEFAULT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned DEFAULT NULL,
+  `rnaproduct_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned DEFAULT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`rnaproduct_id`),
@@ -724,8 +725,8 @@ CREATE TABLE `rnaproduct` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_attrib` (
-  `rnaproduct_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `rnaproduct_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
   `value` text NOT NULL,
   UNIQUE KEY `rnaproduct_attribx` (`rnaproduct_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
@@ -734,7 +735,7 @@ CREATE TABLE `rnaproduct_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `rnaproduct_type` (
-  `rnaproduct_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `rnaproduct_type_id` smallint unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   `description` text,
@@ -743,19 +744,19 @@ CREATE TABLE `rnaproduct_type` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region` (
-  `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE latin1_bin NOT NULL,
-  `coord_system_id` int(10) NOT NULL DEFAULT '0',
-  `length` int(10) NOT NULL DEFAULT '0',
+  `seq_region_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `coord_system_id` int NOT NULL DEFAULT '0',
+  `length` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=14 DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_attrib` (
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `region_attribx` (`seq_region_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -763,31 +764,31 @@ CREATE TABLE `seq_region_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `seq_region_mapping` (
-  `external_seq_region_id` int(10) unsigned NOT NULL,
-  `internal_seq_region_id` int(10) unsigned NOT NULL,
-  `mapping_set_id` int(10) unsigned NOT NULL,
+  `external_seq_region_id` int unsigned NOT NULL,
+  `internal_seq_region_id` int unsigned NOT NULL,
+  `mapping_set_id` int unsigned NOT NULL,
   UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `seq_region_synonym` (
-  `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL,
+  `seq_region_synonym_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL,
   `synonym` varchar(250) NOT NULL,
-  `external_db_id` smallint(5) unsigned DEFAULT NULL,
+  `external_db_id` smallint unsigned DEFAULT NULL,
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `simple_feature` (
-  `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `seq_region_end` int(10) unsigned NOT NULL DEFAULT '0',
+  `simple_feature_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `seq_region_id` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_start` int unsigned NOT NULL DEFAULT '0',
+  `seq_region_end` int unsigned NOT NULL DEFAULT '0',
   `seq_region_strand` tinyint(1) NOT NULL DEFAULT '0',
-  `display_label` varchar(40) COLLATE latin1_bin NOT NULL DEFAULT '',
-  `analysis_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_label` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `analysis_id` int unsigned NOT NULL DEFAULT '0',
   `score` double DEFAULT NULL,
   PRIMARY KEY (`simple_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
@@ -796,12 +797,12 @@ CREATE TABLE `simple_feature` (
 ) ENGINE=MyISAM AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `stable_id_event` (
-  `old_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `old_version` smallint(6) DEFAULT NULL,
-  `new_stable_id` varchar(128) COLLATE latin1_bin DEFAULT NULL,
-  `new_version` smallint(6) DEFAULT NULL,
-  `mapping_session_id` int(10) NOT NULL DEFAULT '0',
-  `type` enum('gene','transcript','translation','rnaproduct') COLLATE latin1_bin NOT NULL,
+  `old_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `old_version` smallint DEFAULT NULL,
+  `new_stable_id` varchar(128) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `new_version` smallint DEFAULT NULL,
+  `mapping_session_id` int NOT NULL DEFAULT '0',
+  `type` enum('gene','transcript','translation','rnaproduct') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`old_version`,`new_stable_id`,`new_version`,`type`),
   KEY `new_idx` (`new_stable_id`),
@@ -809,29 +810,29 @@ CREATE TABLE `stable_id_event` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `supporting_feature` (
-  `exon_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `exon_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript` (
-  `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `gene_id` int(10) unsigned DEFAULT NULL,
-  `analysis_id` smallint(5) unsigned NOT NULL,
-  `seq_region_id` int(10) unsigned NOT NULL,
-  `seq_region_start` int(10) unsigned NOT NULL,
-  `seq_region_end` int(10) unsigned NOT NULL,
-  `seq_region_strand` tinyint(2) NOT NULL,
-  `display_xref_id` int(10) unsigned DEFAULT NULL,
+  `transcript_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `gene_id` int unsigned DEFAULT NULL,
+  `analysis_id` smallint unsigned NOT NULL,
+  `seq_region_id` int unsigned NOT NULL,
+  `seq_region_start` int unsigned NOT NULL,
+  `seq_region_end` int unsigned NOT NULL,
+  `seq_region_strand` tinyint NOT NULL,
+  `display_xref_id` int unsigned DEFAULT NULL,
   `source` varchar(40) NOT NULL DEFAULT 'ensembl',
   `biotype` varchar(40) NOT NULL,
   `description` text,
   `is_current` tinyint(1) NOT NULL DEFAULT '1',
-  `canonical_translation_id` int(10) unsigned DEFAULT NULL,
+  `canonical_translation_id` int unsigned DEFAULT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`transcript_id`),
@@ -840,13 +841,14 @@ CREATE TABLE `transcript` (
   KEY `gene_index` (`gene_id`),
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
-  KEY `stable_id_idx` (`stable_id`,`version`)
+  KEY `stable_id_idx` (`stable_id`,`version`),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=6885 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_attrib` (
-  `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `transcript_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `transcript_attribx` (`transcript_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -854,31 +856,31 @@ CREATE TABLE `transcript_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
-  `transcript_id` int(10) unsigned NOT NULL,
-  `intron_supporting_evidence_id` int(10) unsigned NOT NULL,
-  `previous_exon_id` int(10) unsigned NOT NULL,
-  `next_exon_id` int(10) unsigned NOT NULL,
+  `transcript_id` int unsigned NOT NULL,
+  `intron_supporting_evidence_id` int unsigned NOT NULL,
+  `previous_exon_id` int unsigned NOT NULL,
+  `next_exon_id` int unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 ROW_FORMAT=FIXED;
 
 CREATE TABLE `transcript_supporting_feature` (
-  `transcript_id` int(11) NOT NULL DEFAULT '0',
-  `feature_type` enum('dna_align_feature','protein_align_feature') COLLATE latin1_bin DEFAULT NULL,
-  `feature_id` int(11) NOT NULL DEFAULT '0',
+  `transcript_id` int NOT NULL DEFAULT '0',
+  `feature_type` enum('dna_align_feature','protein_align_feature') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `feature_id` int NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin MAX_ROWS=100000000 AVG_ROW_LENGTH=80 ROW_FORMAT=FIXED;
 
 CREATE TABLE `translation` (
-  `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `transcript_id` int(10) unsigned NOT NULL,
-  `seq_start` int(10) NOT NULL,
-  `start_exon_id` int(10) unsigned NOT NULL,
-  `seq_end` int(10) NOT NULL,
-  `end_exon_id` int(10) unsigned NOT NULL,
+  `translation_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `transcript_id` int unsigned NOT NULL,
+  `seq_start` int NOT NULL,
+  `start_exon_id` int unsigned NOT NULL,
+  `seq_end` int NOT NULL,
+  `end_exon_id` int unsigned NOT NULL,
   `stable_id` varchar(128) DEFAULT NULL,
-  `version` smallint(5) unsigned DEFAULT NULL,
+  `version` smallint unsigned DEFAULT NULL,
   `created_date` datetime DEFAULT NULL,
   `modified_date` datetime DEFAULT NULL,
   PRIMARY KEY (`translation_id`),
@@ -887,9 +889,9 @@ CREATE TABLE `translation` (
 ) ENGINE=MyISAM AUTO_INCREMENT=6690 DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `translation_attrib` (
-  `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `attrib_type_id` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `value` text COLLATE latin1_bin NOT NULL,
+  `translation_id` int unsigned NOT NULL DEFAULT '0',
+  `attrib_type_id` smallint unsigned NOT NULL DEFAULT '0',
+  `value` text CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
   UNIQUE KEY `translation_attribx` (`translation_id`,`attrib_type_id`,`value`(500)),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
@@ -897,17 +899,17 @@ CREATE TABLE `translation_attrib` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_object` (
-  `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `type` enum('xref','cDNA','Marker') COLLATE latin1_bin NOT NULL,
-  `analysis_id` int(10) unsigned NOT NULL,
-  `external_db_id` int(11) DEFAULT NULL,
-  `identifier` varchar(255) COLLATE latin1_bin NOT NULL,
-  `unmapped_reason_id` int(10) unsigned NOT NULL,
+  `unmapped_object_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('xref','cDNA','Marker') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `analysis_id` int unsigned NOT NULL,
+  `external_db_id` int DEFAULT NULL,
+  `identifier` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL,
   `query_score` double DEFAULT NULL,
   `target_score` double DEFAULT NULL,
-  `ensembl_id` int(10) unsigned DEFAULT '0',
-  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') COLLATE latin1_bin DEFAULT 'RawContig',
-  `parent` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `ensembl_id` int unsigned DEFAULT '0',
+  `ensembl_object_type` enum('RawContig','Transcript','Gene','Translation') CHARACTER SET latin1 COLLATE latin1_bin DEFAULT 'RawContig',
+  `parent` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_object_id`),
   UNIQUE KEY `unique_unmapped_obj_idx` (`ensembl_id`,`ensembl_object_type`,`identifier`,`unmapped_reason_id`,`parent`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
@@ -916,21 +918,21 @@ CREATE TABLE `unmapped_object` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `unmapped_reason` (
-  `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `summary_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
-  `full_description` varchar(255) COLLATE latin1_bin DEFAULT NULL,
+  `unmapped_reason_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `summary_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `full_description` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `xref` (
-  `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `external_db_id` int(11) NOT NULL,
-  `dbprimary_acc` varchar(512) COLLATE latin1_bin NOT NULL,
-  `display_label` varchar(512) COLLATE latin1_bin NOT NULL,
-  `version` varchar(10) COLLATE latin1_bin DEFAULT NULL,
-  `description` text COLLATE latin1_bin,
-  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
-  `info_text` varchar(255) COLLATE latin1_bin NOT NULL DEFAULT '',
+  `xref_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_db_id` int NOT NULL,
+  `dbprimary_acc` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `display_label` varchar(512) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  `version` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_bin,
+  `info_type` enum('NONE','PROJECTION','MISC','DEPENDENT','DIRECT','SEQUENCE_MATCH','INFERRED_PAIR','PROBE','UNMAPPED','CHECKSUM') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'NONE',
+  `info_text` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   PRIMARY KEY (`xref_id`),
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),

--- a/sql/patch_115_116_b.sql
+++ b/sql/patch_115_116_b.sql
@@ -1,0 +1,27 @@
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_115_116_b.sql
+#
+# Title: Added indices to transcript and assembly
+#
+# Description:
+#   Ensure meta_value is not null
+ALTER TABLE assembly ADD INDEX asm_overlap_end_idx (asm_seq_region_id, asm_end, asm_start);
+ALTER TABLE transcript ADD INDEX seq_region_current_start_idx (seq_region_id, is_current, seq_region_start, transcript_id, gene_id);
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_115_116_b.sql|Added indices to transcript and assembly');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -316,6 +316,8 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES
 # NOTE: Avoid line-breaks in values.
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_115_116_a.sql|schema_version');
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_115_116_b.sql|Added indices to transcript and assembly');
 
 
 /**

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -67,7 +67,8 @@ CREATE TABLE assembly (
 
   KEY cmp_seq_region_idx (cmp_seq_region_id),
   KEY asm_seq_region_idx (asm_seq_region_id, asm_start),
-  UNIQUE KEY all_idx (asm_seq_region_id, cmp_seq_region_id, asm_start, asm_end, cmp_start, cmp_end, ori)
+  UNIQUE KEY all_idx (asm_seq_region_id, cmp_seq_region_id, asm_start, asm_end, cmp_start, cmp_end, ori),
+  KEY asm_overlap_end_idx (asm_seq_region_id, asm_end, asm_start)
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
@@ -1051,7 +1052,8 @@ CREATE TABLE transcript (
   KEY xref_id_index (display_xref_id),
   KEY analysis_idx (analysis_id),
   UNIQUE KEY canonical_translation_idx (canonical_translation_id),
-  KEY stable_id_idx (stable_id, version)
+  KEY stable_id_idx (stable_id, version),
+  KEY `seq_region_current_start_idx` (`seq_region_id`,`is_current`,`seq_region_start`,`transcript_id`,`gene_id`)
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 


### PR DESCRIPTION
## Description

SQL Optimisations: index creation for speeding up queries.
For doing it in a quick-ish fashion, I introduced a nasty&dangerous thing, which is forcing the use of an index.
This is "necessary" because MySQL optimiser gets confused by other (similar) existing index, and does not want to use the last and better one.
To avoid excessive index manipulation at this stage I forced the use of the best index for the query.

This must be changed the sooner the better to avoid painful surprises down the road.

## Use case

Slow queries.

## Benefits

Faster queries.

## Possible Drawbacks

Pain because of direct/hardcoded index name.

## Testing

No test required changing, but test DBs had to be regenerated
Test suite could run successfully.