### PR TITLE
Fix placeholder generation for external_db_ids

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/DBEntryAdaptor.pm
@@ -2032,7 +2032,7 @@ SQL
     };
     return unless @external_db_ids;
 
-    my $external_db_placeholders = join ', ', '?' x @external_db_ids;
+    my $external_db_placeholders = join ', ', ('?') x @external_db_ids;
     $where_sql .= "x.external_db_id IN ($external_db_placeholders) AND ";
   }
 


### PR DESCRIPTION
## Description

'?' x @external_db_ids repeats the placeholder as string, creating invalid SQL queries like ... IN (???) ... when there are multiple external DB matches (instead of (?, ?, ?)). Repeating the placeholder in list context should fix it:

## Benefits

As described

## Possible Drawbacks

no

## Testing

no
