### PR TITLE
Removing MySQL hint

### DIFF
--- a/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
+++ b/modules/Bio/EnsEMBL/DBSQL/GeneAdaptor.pm
@@ -528,14 +528,12 @@ sub fetch_all_by_domain {
 
   throw("domain argument is required") unless ($domain);
 
-  my $index_hint = $self->dbc->driver eq 'mysql' ? ' FORCE INDEX (seq_region_current_start_idx)' : '';
-
   my $sth = $self->prepare(
   qq(
   SELECT    DISTINCT tr.gene_id
   FROM      interpro i,
             protein_feature pf,
-            transcript tr$index_hint,
+            transcript tr,
             translation tl,
             seq_region sr,
             coord_system cs


### PR DESCRIPTION
## Description

Removing MySQL optimiser hint, as found better (and more portable) way to optimise the query. 

## Use case

The query was performing poorly because of DB configuration and MyISAM not being "too smart" about using indices with joins.
The fix worked, but it was not portable and forcing index is never a good idea, especially in API context.

## Benefits

The SQL query is generic and code is simpler.

## Possible Drawbacks

None

## Testing

Test suite has run successfully.

